### PR TITLE
fix(schema): prevent prototype pollution in Zod validation (#39)

### DIFF
--- a/packages/schema/src/validation/dashboard.ts
+++ b/packages/schema/src/validation/dashboard.ts
@@ -2,6 +2,20 @@ import { z } from 'zod';
 import { VALID_CHILDREN } from '../types/dashboard';
 import type { LayoutComponentType } from '../types/dashboard';
 
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function safeRecord<V extends z.ZodTypeAny>(valueSchema: V) {
+  return z.record(z.string(), valueSchema).transform((obj) => {
+    const result: Record<string, z.output<V>> = Object.create(null);
+    for (const [key, value] of Object.entries(obj)) {
+      if (!DANGEROUS_KEYS.has(key)) {
+        result[key] = value;
+      }
+    }
+    return result;
+  });
+}
+
 // ─── Layout (flat normalized map) ────────────────────────────
 
 const breakpointOverrideSchema = z.object({
@@ -12,7 +26,16 @@ const breakpointOverrideSchema = z.object({
 });
 
 const layoutComponentTypeSchema = z.enum([
-  'root', 'grid', 'row', 'column', 'widget', 'tabs', 'tab', 'spacer', 'header', 'divider',
+  'root',
+  'grid',
+  'row',
+  'column',
+  'widget',
+  'tabs',
+  'tab',
+  'spacer',
+  'header',
+  'divider',
 ]);
 
 const layoutMetaSchema = z.object({
@@ -42,7 +65,9 @@ const layoutMapSchema = z.record(z.string(), layoutComponentSchema);
  * Validate nesting rules: check that every child type is valid for its parent type.
  * Returns an array of error messages (empty = valid).
  */
-export function validateNesting(layout: Record<string, { type: string; children: string[] }>): string[] {
+export function validateNesting(
+  layout: Record<string, { type: string; children: string[] }>,
+): string[] {
   const errors: string[] = [];
   for (const [id, component] of Object.entries(layout)) {
     const parentType = component.type as LayoutComponentType;
@@ -57,7 +82,7 @@ export function validateNesting(layout: Record<string, { type: string; children:
       const childType = child.type as LayoutComponentType;
       if (!allowedChildren.includes(childType)) {
         errors.push(
-          `Invalid nesting: "${childType}" cannot be a child of "${parentType}" (component "${id}" → "${childId}")`
+          `Invalid nesting: "${childType}" cannot be a child of "${parentType}" (component "${id}" → "${childId}")`,
         );
       }
     }
@@ -145,7 +170,7 @@ const interactionActionSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('external'),
     callbackKey: z.string().min(1),
-    payload: z.record(z.unknown()).optional(),
+    payload: safeRecord(z.unknown()).optional(),
   }),
   z.object({
     type: z.literal('drill'),
@@ -170,7 +195,7 @@ const widgetDefinitionSchema = z.object({
   id: z.string().min(1),
   type: z.string().min(1),
   title: z.string().optional(),
-  config: z.record(z.unknown()),
+  config: safeRecord(z.unknown()),
   dataBinding: dataBindingSchema.optional(),
   filters: z.array(filterRefSchema).optional(),
   interactions: z.array(interactionRefSchema).optional(),
@@ -190,19 +215,19 @@ const themeColorsSchema = z.object({
   danger: z.string().optional(),
   info: z.string().optional(),
   border: z.string().optional(),
-}).passthrough();
+});
 
 const themeTypographySchema = z.object({
   fontFamily: z.string().optional(),
   fontSize: z.string().optional(),
   headingFontFamily: z.string().optional(),
-}).passthrough();
+});
 
 const themeSpacingSchema = z.object({
   unit: z.number().optional(),
   widgetPadding: z.string().optional(),
   gridGap: z.string().optional(),
-}).passthrough();
+});
 
 const themeRefSchema = z.object({
   type: z.literal('ref'),
@@ -214,7 +239,7 @@ const inlineThemeSchema = z.object({
   colors: themeColorsSchema.optional(),
   typography: themeTypographySchema.optional(),
   spacing: themeSpacingSchema.optional(),
-  custom: z.record(z.unknown()).optional(),
+  custom: safeRecord(z.unknown()).optional(),
 });
 
 const themeSchema = z.discriminatedUnion('type', [themeRefSchema, inlineThemeSchema]);
@@ -253,7 +278,7 @@ const timeRangeSchema = z.object({
 
 const dashboardDefaultsSchema = z.object({
   activePage: z.string().optional(),
-  filterValues: z.record(z.unknown()).optional(),
+  filterValues: safeRecord(z.unknown()).optional(),
   timeRange: timeRangeSchema.optional(),
 });
 
@@ -262,7 +287,7 @@ const dashboardDefaultsSchema = z.object({
 const visibilityRuleSchema = z.object({
   targetId: z.string().min(1),
   targetType: z.enum(['page', 'widget', 'filter']),
-  condition: z.record(z.unknown()),
+  condition: safeRecord(z.unknown()),
 });
 
 // ─── Page ────────────────────────────────────────────────────

--- a/packages/schema/test/dashboard.test.ts
+++ b/packages/schema/test/dashboard.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import { dashboardDefinitionSchema, validateNesting } from '../src/validation';
+import {
+  dashboardDefinitionSchema,
+  widgetDefinitionSchema,
+  validateNesting,
+} from '../src/validation';
 import { serializeToJSON, parseFromJSON } from '../src/serializers';
 import type { DashboardDefinition } from '../src/types';
 
@@ -92,7 +96,7 @@ describe('layout nesting validation', () => {
 
   it('rejects widget as child of widget', () => {
     const layout = {
-      'root': { type: 'root', children: ['grid-1'] },
+      root: { type: 'root', children: ['grid-1'] },
       'grid-1': { type: 'grid', children: ['w-1'] },
       'w-1': { type: 'widget', children: ['w-2'] },
       'w-2': { type: 'widget', children: [] },
@@ -104,7 +108,7 @@ describe('layout nesting validation', () => {
 
   it('rejects row as child of root', () => {
     const layout = {
-      'root': { type: 'root', children: ['row-1'] },
+      root: { type: 'root', children: ['row-1'] },
       'row-1': { type: 'row', children: [] },
     };
     const errors = validateNesting(layout);
@@ -114,7 +118,7 @@ describe('layout nesting validation', () => {
 
   it('accepts tabs inside grid', () => {
     const layout = {
-      'root': { type: 'root', children: ['grid-1'] },
+      root: { type: 'root', children: ['grid-1'] },
       'grid-1': { type: 'grid', children: ['tabs-1'] },
       'tabs-1': { type: 'tabs', children: ['tab-1'] },
       'tab-1': { type: 'tab', children: ['row-1'] },
@@ -126,7 +130,7 @@ describe('layout nesting validation', () => {
 
   it('reports missing child references', () => {
     const layout = {
-      'root': { type: 'root', children: ['nonexistent'] },
+      root: { type: 'root', children: ['nonexistent'] },
     };
     const errors = validateNesting(layout);
     expect(errors.length).toBeGreaterThan(0);
@@ -186,17 +190,116 @@ describe('minimal valid dashboard', () => {
           title: 'Page 1',
           rootNodeId: 'root',
           layout: {
-            'root': { id: 'root', type: 'root', children: ['grid-1'], meta: {} },
-            'grid-1': { id: 'grid-1', type: 'grid', children: ['w-1'], parentId: 'root', meta: { columns: 12 } },
-            'w-1': { id: 'w-1', type: 'widget', children: [], parentId: 'grid-1', meta: { widgetRef: 'kpi-1', width: 4, height: 20 } },
+            root: { id: 'root', type: 'root', children: ['grid-1'], meta: {} },
+            'grid-1': {
+              id: 'grid-1',
+              type: 'grid',
+              children: ['w-1'],
+              parentId: 'root',
+              meta: { columns: 12 },
+            },
+            'w-1': {
+              id: 'w-1',
+              type: 'widget',
+              children: [],
+              parentId: 'grid-1',
+              meta: { widgetRef: 'kpi-1', width: 4, height: 20 },
+            },
           },
-          widgets: [
-            { id: 'kpi-1', type: 'kpi-card', config: {} },
-          ],
+          widgets: [{ id: 'kpi-1', type: 'kpi-card', config: {} }],
         },
       ],
     };
     const result = dashboardDefinitionSchema.safeParse(minimal);
     expect(result.success).toBe(true);
+  });
+});
+
+describe('prototype pollution prevention (#39)', () => {
+  it('strips __proto__ from widget config', () => {
+    const result = widgetDefinitionSchema.safeParse({
+      id: 'w1',
+      type: 'kpi-card',
+      config: { value: 42, __proto__: { polluted: true } },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect('__proto__' in result.data.config).toBe(false);
+      expect(result.data.config.value).toBe(42);
+    }
+  });
+
+  it('strips constructor and prototype keys from widget config', () => {
+    const result = widgetDefinitionSchema.safeParse({
+      id: 'w1',
+      type: 'kpi-card',
+      config: { ok: 1, constructor: 'bad', prototype: 'bad' },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect('constructor' in result.data.config).toBe(false);
+      expect('prototype' in result.data.config).toBe(false);
+      expect(result.data.config.ok).toBe(1);
+    }
+  });
+
+  it('strips dangerous keys from dashboard defaults filterValues', () => {
+    const minimal: DashboardDefinition = {
+      schemaVersion: '0.2.0',
+      id: 'test-proto',
+      title: 'Proto Test',
+      pages: [
+        {
+          id: 'page-1',
+          title: 'Page 1',
+          rootNodeId: 'root',
+          layout: {
+            root: { id: 'root', type: 'root', children: [], meta: {} },
+          },
+          widgets: [],
+        },
+      ],
+      defaults: {
+        filterValues: { safe: 'ok', __proto__: { polluted: true } } as Record<string, unknown>,
+      },
+    };
+    const result = dashboardDefinitionSchema.safeParse(minimal);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect('__proto__' in (result.data.defaults?.filterValues ?? {})).toBe(false);
+    }
+  });
+
+  it('theme no longer passes through unknown properties', () => {
+    const minimal: DashboardDefinition = {
+      schemaVersion: '0.2.0',
+      id: 'test-theme',
+      title: 'Theme Test',
+      pages: [
+        {
+          id: 'page-1',
+          title: 'Page 1',
+          rootNodeId: 'root',
+          layout: {
+            root: { id: 'root', type: 'root', children: [], meta: {} },
+          },
+          widgets: [],
+        },
+      ],
+      theme: {
+        type: 'inline',
+        colors: { primary: '#000', unknownExtraProp: 'should-be-stripped' } as Record<
+          string,
+          unknown
+        >,
+      } as DashboardDefinition['theme'],
+    };
+    const result = dashboardDefinitionSchema.safeParse(minimal);
+    expect(result.success).toBe(true);
+    if (result.success && result.data.theme?.type === 'inline') {
+      expect(
+        (result.data.theme.colors as Record<string, unknown>)?.unknownExtraProp,
+      ).toBeUndefined();
+    }
   });
 });


### PR DESCRIPTION
## Security Fix

Closes #39. Also verified #28 (XSS) and #27 (infinite recursion) are already fixed.

### Changes
- Add `safeRecord()` helper that strips `__proto__`, `constructor`, `prototype` keys
- Replace `z.record(z.unknown())` with `safeRecord(z.unknown())` in 5 schemas
- Remove `.passthrough()` from theme schemas
- Add 4 regression tests

### Packages affected
- `packages/schema/`