### PR TITLE
fix(runtime): error boundary messages and drill breadcrumb labels (#26, #29, #30, #31)

### DIFF
--- a/packages/runtime/src/interactions/DrillManager.tsx
+++ b/packages/runtime/src/interactions/DrillManager.tsx
@@ -3,14 +3,7 @@
  * Provides a React context so widgets and the interaction engine can
  * drill down into data, drill back up, or reset to the top level.
  */
-import {
-  createContext,
-  useContext,
-  useReducer,
-  useCallback,
-  useMemo,
-  type ReactNode,
-} from 'react';
+import { createContext, useContext, useReducer, useCallback, useMemo, type ReactNode } from 'react';
 
 // ─── Types ───────────────────────────────────────────────────
 
@@ -49,7 +42,9 @@ function drillReducer(state: DrillState, action: DrillAction): DrillState {
     case 'DRILL_DOWN': {
       const label =
         action.value != null && typeof action.value === 'object'
-          ? Object.values(action.value as Record<string, unknown>).join(' — ')
+          ? Object.entries(action.value as Record<string, unknown>)
+              .map(([k, v]) => `${k}: ${v}`)
+              .join(', ')
           : String(action.value);
       const newCrumb: DrillBreadcrumb = {
         label,
@@ -120,12 +115,9 @@ export interface DrillProviderProps {
 export function DrillProvider({ children }: DrillProviderProps) {
   const [drillState, dispatch] = useReducer(drillReducer, INITIAL_DRILL_STATE);
 
-  const drillDown = useCallback(
-    (sourceWidgetId: string, fieldRef: string, value: unknown) => {
-      dispatch({ type: 'DRILL_DOWN', sourceWidgetId, fieldRef, value });
-    },
-    [],
-  );
+  const drillDown = useCallback((sourceWidgetId: string, fieldRef: string, value: unknown) => {
+    dispatch({ type: 'DRILL_DOWN', sourceWidgetId, fieldRef, value });
+  }, []);
 
   const drillUp = useCallback(() => {
     dispatch({ type: 'DRILL_UP' });

--- a/packages/runtime/src/layout/LayoutRenderer.tsx
+++ b/packages/runtime/src/layout/LayoutRenderer.tsx
@@ -2,7 +2,15 @@
  * Layout renderer — walks the flat normalized layout map and renders components.
  * Starts from rootNodeId, recursively renders children.
  */
-import { type CSSProperties, type ReactNode, createElement, useState, Component, type ErrorInfo, type PropsWithChildren } from 'react';
+import {
+  type CSSProperties,
+  type ReactNode,
+  createElement,
+  useState,
+  Component,
+  type ErrorInfo,
+  type PropsWithChildren,
+} from 'react';
 import type {
   LayoutMap,
   LayoutComponent,
@@ -52,7 +60,18 @@ export function LayoutRenderer({
   return createElement(
     'div',
     { className: `ss-layout-root ${className ?? ''}`.trim(), 'data-ss-node': rootNodeId },
-    renderChildren(rootNode.children, layout, widgets, registry, theme, filters, activeFilterValues, onWidgetEvent, new Set([rootNodeId]), 0),
+    renderChildren(
+      rootNode.children,
+      layout,
+      widgets,
+      registry,
+      theme,
+      filters,
+      activeFilterValues,
+      onWidgetEvent,
+      new Set([rootNodeId]),
+      0,
+    ),
   );
 }
 
@@ -71,17 +90,38 @@ function renderChildren(
   depth: number,
 ): ReactNode[] {
   if (depth > MAX_LAYOUT_DEPTH) {
-    return [createElement('div', { key: 'depth-limit', className: 'ss-layout-error' }, 'Layout depth limit exceeded')];
+    return [
+      createElement(
+        'div',
+        { key: 'depth-limit', className: 'ss-layout-error' },
+        'Layout depth limit exceeded',
+      ),
+    ];
   }
   return childIds.map((childId) => {
     if (visited.has(childId)) {
-      return createElement('div', { key: childId, className: 'ss-layout-error' }, `Circular reference: ${childId}`);
+      return createElement(
+        'div',
+        { key: childId, className: 'ss-layout-error' },
+        `Circular reference: ${childId}`,
+      );
     }
     const node = layout[childId];
     if (!node) return null;
     const nextVisited = new Set(visited);
     nextVisited.add(childId);
-    return renderNode(node, layout, widgets, registry, theme, filters, activeFilterValues, onWidgetEvent, nextVisited, depth + 1);
+    return renderNode(
+      node,
+      layout,
+      widgets,
+      registry,
+      theme,
+      filters,
+      activeFilterValues,
+      onWidgetEvent,
+      nextVisited,
+      depth + 1,
+    );
   });
 }
 
@@ -101,7 +141,18 @@ function renderNode(
   if (!renderer) {
     return createElement('div', { key: node.id, className: 'ss-unknown' }, `Unknown: ${node.type}`);
   }
-  return renderer(node, layout, widgets, registry, theme, filters, activeFilterValues, onWidgetEvent, visited, depth);
+  return renderer(
+    node,
+    layout,
+    widgets,
+    registry,
+    theme,
+    filters,
+    activeFilterValues,
+    onWidgetEvent,
+    visited,
+    depth,
+  );
 }
 
 // ─── Component Type Renderers ────────────────────────────────
@@ -153,7 +204,18 @@ function renderGrid(
   return createElement(
     'div',
     { key: node.id, className: `ss-grid`, style, 'data-ss-node': node.id },
-    renderChildren(node.children, layout, widgets, registry, theme, filters, activeFilterValues, onWidgetEvent, visited, depth),
+    renderChildren(
+      node.children,
+      layout,
+      widgets,
+      registry,
+      theme,
+      filters,
+      activeFilterValues,
+      onWidgetEvent,
+      visited,
+      depth,
+    ),
   );
 }
 
@@ -178,7 +240,18 @@ function renderRow(
   return createElement(
     'div',
     { key: node.id, className: 'ss-row', style, 'data-ss-node': node.id },
-    renderChildren(node.children, layout, widgets, registry, theme, filters, activeFilterValues, onWidgetEvent, visited, depth),
+    renderChildren(
+      node.children,
+      layout,
+      widgets,
+      registry,
+      theme,
+      filters,
+      activeFilterValues,
+      onWidgetEvent,
+      visited,
+      depth,
+    ),
   );
 }
 
@@ -216,7 +289,18 @@ function renderColumn(
   return createElement(
     'div',
     { key: node.id, className: 'ss-column', style, 'data-ss-node': node.id },
-    renderChildren(node.children, layout, widgets, registry, theme, filters, activeFilterValues, onWidgetEvent, visited, depth),
+    renderChildren(
+      node.children,
+      layout,
+      widgets,
+      registry,
+      theme,
+      filters,
+      activeFilterValues,
+      onWidgetEvent,
+      visited,
+      depth,
+    ),
   );
 }
 
@@ -279,7 +363,9 @@ function renderWidget(
   return createElement(
     'div',
     { key: node.id, className: 'ss-widget', style, 'data-ss-node': node.id },
-    createElement(WidgetErrorBoundary, { widgetId: widgetDef.id, title: widgetDef.title },
+    createElement(
+      WidgetErrorBoundary,
+      { widgetId: widgetDef.id, title: widgetDef.title },
       createElement(Component, widgetProps),
     ),
   );
@@ -379,7 +465,15 @@ function TabsContainer({
     // Tab buttons
     createElement(
       'div',
-      { className: 'ss-tabs-header', style: { display: 'flex', gap: '4px', borderBottom: '1px solid #e0e0e0', marginBottom: '16px' } },
+      {
+        className: 'ss-tabs-header',
+        style: {
+          display: 'flex',
+          gap: '4px',
+          borderBottom: '1px solid #e0e0e0',
+          marginBottom: '16px',
+        },
+      },
       ...tabNodes.map((tab, i) =>
         createElement(
           'button',
@@ -390,7 +484,10 @@ function TabsContainer({
             style: {
               padding: '8px 16px',
               border: 'none',
-              borderBottom: i === activeTab ? '2px solid var(--ss-color-primary, #1677ff)' : '2px solid transparent',
+              borderBottom:
+                i === activeTab
+                  ? '2px solid var(--ss-color-primary, #1677ff)'
+                  : '2px solid transparent',
               background: 'transparent',
               cursor: 'pointer',
               fontWeight: i === activeTab ? 600 : 400,
@@ -405,7 +502,18 @@ function TabsContainer({
       ? createElement(
           'div',
           { className: 'ss-tab-content', 'data-ss-node': tabNodes[activeTab].id },
-          renderChildren(tabNodes[activeTab].children, layout, widgets, registry, theme, filters, activeFilterValues, onWidgetEvent, visited, depth),
+          renderChildren(
+            tabNodes[activeTab].children,
+            layout,
+            widgets,
+            registry,
+            theme,
+            filters,
+            activeFilterValues,
+            onWidgetEvent,
+            visited,
+            depth,
+          ),
         )
       : null,
   );
@@ -427,7 +535,18 @@ function renderTab(
   return createElement(
     'div',
     { key: node.id, className: 'ss-tab', 'data-ss-node': node.id },
-    renderChildren(node.children, layout, widgets, registry, theme, filters, activeFilterValues, onWidgetEvent, visited, depth),
+    renderChildren(
+      node.children,
+      layout,
+      widgets,
+      registry,
+      theme,
+      filters,
+      activeFilterValues,
+      onWidgetEvent,
+      visited,
+      depth,
+    ),
   );
 }
 
@@ -446,7 +565,12 @@ function renderSpacer(
   const style: CSSProperties = {
     height: node.meta.height ? `${node.meta.height}px` : '24px',
   };
-  return createElement('div', { key: node.id, className: 'ss-spacer', style, 'data-ss-node': node.id });
+  return createElement('div', {
+    key: node.id,
+    className: 'ss-spacer',
+    style,
+    'data-ss-node': node.id,
+  });
 }
 
 function renderHeader(
@@ -466,7 +590,11 @@ function renderHeader(
   const style: CSSProperties = {
     margin: 0,
   };
-  return createElement(tag, { key: node.id, className: 'ss-header', style, 'data-ss-node': node.id }, node.meta.text ?? '');
+  return createElement(
+    tag,
+    { key: node.id, className: 'ss-header', style, 'data-ss-node': node.id },
+    node.meta.text ?? '',
+  );
 }
 
 function renderDivider(
@@ -486,7 +614,12 @@ function renderDivider(
     borderTop: '1px solid #e0e0e0',
     margin: '8px 0',
   };
-  return createElement('hr', { key: node.id, className: 'ss-divider', style, 'data-ss-node': node.id });
+  return createElement('hr', {
+    key: node.id,
+    className: 'ss-divider',
+    style,
+    'data-ss-node': node.id,
+  });
 }
 
 // ─── dataBinding → config translation ────────────────────────
@@ -543,7 +676,10 @@ interface WidgetErrorBoundaryState {
   error?: Error;
 }
 
-class WidgetErrorBoundary extends Component<PropsWithChildren<WidgetErrorBoundaryProps>, WidgetErrorBoundaryState> {
+class WidgetErrorBoundary extends Component<
+  PropsWithChildren<WidgetErrorBoundaryProps>,
+  WidgetErrorBoundaryState
+> {
   constructor(props: WidgetErrorBoundaryProps) {
     super(props);
     this.state = { hasError: false };
@@ -573,7 +709,11 @@ class WidgetErrorBoundary extends Component<PropsWithChildren<WidgetErrorBoundar
           },
         },
         createElement('strong', null, this.props.title ?? this.props.widgetId),
-        createElement('div', { style: { marginTop: '4px' } }, 'This widget encountered an error and could not render.'),
+        createElement(
+          'div',
+          { style: { marginTop: '4px' } },
+          `Widget error: ${this.state.error?.message ?? 'Unknown error'}`,
+        ),
       );
     }
     return this.props.children;

--- a/packages/runtime/test/regression-bugs-17-31.test.tsx
+++ b/packages/runtime/test/regression-bugs-17-31.test.tsx
@@ -102,9 +102,27 @@ describe('LayoutRenderer — #26 error boundary isolates widget crashes', () => 
 
     const layout: LayoutMap = {
       root: { id: 'root', type: 'root', children: ['grid-1'], meta: {} },
-      'grid-1': { id: 'grid-1', type: 'grid', children: ['w-ok', 'w-crash'], parentId: 'root', meta: {} },
-      'w-ok': { id: 'w-ok', type: 'widget', children: [], parentId: 'grid-1', meta: { widgetRef: 'ok-1' } },
-      'w-crash': { id: 'w-crash', type: 'widget', children: [], parentId: 'grid-1', meta: { widgetRef: 'crash-1' } },
+      'grid-1': {
+        id: 'grid-1',
+        type: 'grid',
+        children: ['w-ok', 'w-crash'],
+        parentId: 'root',
+        meta: {},
+      },
+      'w-ok': {
+        id: 'w-ok',
+        type: 'widget',
+        children: [],
+        parentId: 'grid-1',
+        meta: { widgetRef: 'ok-1' },
+      },
+      'w-crash': {
+        id: 'w-crash',
+        type: 'widget',
+        children: [],
+        parentId: 'grid-1',
+        meta: { widgetRef: 'crash-1' },
+      },
     };
     const widgets: WidgetDefinition[] = [
       { id: 'ok-1', type: 'kpi-card', title: 'Healthy KPI', config: {} },
@@ -120,7 +138,7 @@ describe('LayoutRenderer — #26 error boundary isolates widget crashes', () => 
     expect(container.textContent).toContain('Healthy KPI');
     // The crashing widget should show error state, not crash the page
     expect(container.querySelector('.ss-widget-error')).toBeTruthy();
-    expect(container.textContent).toContain('could not render');
+    expect(container.textContent).toContain('Widget error: Widget render explosion');
 
     consoleSpy.mockRestore();
   });
@@ -133,7 +151,13 @@ describe('LayoutRenderer — #18 dataBinding → config translation', () => {
     const layout: LayoutMap = {
       root: { id: 'root', type: 'root', children: ['grid-1'], meta: {} },
       'grid-1': { id: 'grid-1', type: 'grid', children: ['w-1'], parentId: 'root', meta: {} },
-      'w-1': { id: 'w-1', type: 'widget', children: [], parentId: 'grid-1', meta: { widgetRef: 'chart-1' } },
+      'w-1': {
+        id: 'w-1',
+        type: 'widget',
+        children: [],
+        parentId: 'grid-1',
+        meta: { widgetRef: 'chart-1' },
+      },
     };
     const widgets: WidgetDefinition[] = [
       {
@@ -174,7 +198,13 @@ describe('LayoutRenderer — #18 dataBinding → config translation', () => {
     const layout: LayoutMap = {
       root: { id: 'root', type: 'root', children: ['grid-1'], meta: {} },
       'grid-1': { id: 'grid-1', type: 'grid', children: ['w-1'], parentId: 'root', meta: {} },
-      'w-1': { id: 'w-1', type: 'widget', children: [], parentId: 'grid-1', meta: { widgetRef: 'chart-1' } },
+      'w-1': {
+        id: 'w-1',
+        type: 'widget',
+        children: [],
+        parentId: 'grid-1',
+        meta: { widgetRef: 'chart-1' },
+      },
     };
     const widgets: WidgetDefinition[] = [
       {
@@ -185,9 +215,7 @@ describe('LayoutRenderer — #18 dataBinding → config translation', () => {
         config: { xField: 'date' },
         dataBinding: {
           datasetRef: 'sales',
-          fields: [
-            { role: 'x-axis', fieldRef: 'month' },
-          ],
+          fields: [{ role: 'x-axis', fieldRef: 'month' }],
         },
       },
     ];
@@ -215,11 +243,7 @@ function InteractionConsumer({
   return null;
 }
 
-function FilterStateReader({
-  onRead,
-}: {
-  onRead: (values: Record<string, unknown>) => void;
-}) {
+function FilterStateReader({ onRead }: { onRead: (values: Record<string, unknown>) => void }) {
   const { state } = useFilters();
   onRead(state.values);
   return null;
@@ -258,10 +282,24 @@ describe('InteractionEngine — #29 cross-filter toggle with object values', () 
     let ctx: ReturnType<typeof useInteractions> | null = null;
     let filterValues: Record<string, unknown> = {};
 
-    renderWithProviders(interactions, {}, createElement('div', null,
-      createElement(InteractionConsumer, { onReady: (c) => { ctx = c; } }),
-      createElement(FilterStateReader, { onRead: (v) => { filterValues = v; } }),
-    ));
+    renderWithProviders(
+      interactions,
+      {},
+      createElement(
+        'div',
+        null,
+        createElement(InteractionConsumer, {
+          onReady: (c) => {
+            ctx = c;
+          },
+        }),
+        createElement(FilterStateReader, {
+          onRead: (v) => {
+            filterValues = v;
+          },
+        }),
+      ),
+    );
 
     // First click: set filter with an object value
     act(() => {
@@ -297,10 +335,24 @@ describe('InteractionEngine — #29 cross-filter toggle with object values', () 
     let ctx: ReturnType<typeof useInteractions> | null = null;
     let filterValues: Record<string, unknown> = {};
 
-    renderWithProviders(interactions, {}, createElement('div', null,
-      createElement(InteractionConsumer, { onReady: (c) => { ctx = c; } }),
-      createElement(FilterStateReader, { onRead: (v) => { filterValues = v; } }),
-    ));
+    renderWithProviders(
+      interactions,
+      {},
+      createElement(
+        'div',
+        null,
+        createElement(InteractionConsumer, {
+          onReady: (c) => {
+            ctx = c;
+          },
+        }),
+        createElement(FilterStateReader, {
+          onRead: (v) => {
+            filterValues = v;
+          },
+        }),
+      ),
+    );
 
     act(() => {
       ctx!.handleWidgetEvent({
@@ -325,11 +377,7 @@ describe('InteractionEngine — #29 cross-filter toggle with object values', () 
 
 // ─── #31: DrillManager breadcrumb shows [object Object] ──────
 
-function DrillConsumer({
-  onReady,
-}: {
-  onReady: (ctx: DrillContextValue) => void;
-}) {
+function DrillConsumer({ onReady }: { onReady: (ctx: DrillContextValue) => void }) {
   const ctx = useDrill();
   onReady(ctx);
   return null;
@@ -340,8 +388,14 @@ describe('DrillManager — #31 breadcrumb label for object values', () => {
     let ctx: DrillContextValue | null = null;
 
     render(
-      createElement(DrillProvider, null,
-        createElement(DrillConsumer, { onReady: (c) => { ctx = c; } }),
+      createElement(
+        DrillProvider,
+        null,
+        createElement(DrillConsumer, {
+          onReady: (c) => {
+            ctx = c;
+          },
+        }),
       ),
     );
 
@@ -352,16 +406,22 @@ describe('DrillManager — #31 breadcrumb label for object values', () => {
     const label = ctx!.drillState.breadcrumb[0].label;
     // Before fix: would be "[object Object]"
     expect(label).not.toContain('[object Object]');
-    expect(label).toContain('NYC');
-    expect(label).toContain('NY');
+    expect(label).toContain('city: NYC');
+    expect(label).toContain('state: NY');
   });
 
   it('still handles simple string values correctly', () => {
     let ctx: DrillContextValue | null = null;
 
     render(
-      createElement(DrillProvider, null,
-        createElement(DrillConsumer, { onReady: (c) => { ctx = c; } }),
+      createElement(
+        DrillProvider,
+        null,
+        createElement(DrillConsumer, {
+          onReady: (c) => {
+            ctx = c;
+          },
+        }),
       ),
     );
 
@@ -376,8 +436,14 @@ describe('DrillManager — #31 breadcrumb label for object values', () => {
     let ctx: DrillContextValue | null = null;
 
     render(
-      createElement(DrillProvider, null,
-        createElement(DrillConsumer, { onReady: (c) => { ctx = c; } }),
+      createElement(
+        DrillProvider,
+        null,
+        createElement(DrillConsumer, {
+          onReady: (c) => {
+            ctx = c;
+          },
+        }),
       ),
     );
 


### PR DESCRIPTION
## Runtime Stability Fixes

Closes #26, #29, #30, #31.

### Changes
- **#26**: Error boundary fallback now shows actual error message
- **#31**: DrillManager formats object values as readable key-value pairs
- **#29** (cross-filter equality) and **#30** (table NaN) verified already fixed

### Packages affected
- `packages/runtime/`