### PR TITLE
feat(dev-app): backend probe flow for blank designer bootstrap (#52)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,25 @@
-npx lint-staged
+#!/bin/sh
+set -e
+
+if ! command -v node >/dev/null 2>&1; then
+	if [ -s "$HOME/.nvm/nvm.sh" ]; then
+		. "$HOME/.nvm/nvm.sh"
+		nvm use --silent default >/dev/null 2>&1 || nvm use --silent >/dev/null 2>&1 || true
+	fi
+
+	if ! command -v node >/dev/null 2>&1; then
+		for dir in /opt/homebrew/bin /usr/local/bin "$HOME"/.nvm/versions/node/*/bin; do
+			if [ -d "$dir" ]; then
+				PATH="$dir:$PATH"
+			fi
+		done
+		export PATH
+	fi
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+	echo "husky - pre-commit requires node in PATH" >&2
+	exit 127
+fi
+
+exec node node_modules/lint-staged/bin/lint-staged.js

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-  "snyk.advanced.autoSelectOrganization": true,
-  "snyk.advanced.organization": "e1d9a17c-9673-469b-a55f-0150092b5694"
+  "snyk.advanced.autoSelectOrganization": true
 }

--- a/README.md
+++ b/README.md
@@ -106,6 +106,72 @@ pnpm test:e2e
 pnpm typecheck
 ```
 
+## Getting Started with Your Data
+
+Supersubset needs two kinds of information before it can build charts against your backend:
+
+1. **Metadata**: datasets, fields, types, and semantic roles like dimension, measure, and time.
+2. **Query execution**: a backend endpoint that can answer logical chart-preview queries.
+
+The discovery endpoint is optional. You can onboard your data model in three ways:
+
+### 1. Discovery URL
+
+If your backend can expose normalized metadata directly, point Probe mode at a discovery URL or backend base URL and Supersubset will fetch datasets automatically.
+
+### 2. CLI-generated metadata snapshot
+
+If you already have Prisma, SQL catalog, dbt, or JSON metadata, generate a normalized snapshot with the CLI:
+
+```bash
+npx supersubset export-metadata \
+  --source-type prisma \
+  --source ./prisma/schema.prisma \
+  --out ./supersubset-metadata.json
+```
+
+The output is an envelope shaped like:
+
+```json
+{
+  "datasets": [
+    {
+      "id": "orders",
+      "label": "Orders",
+      "fields": [
+        { "id": "region", "label": "Region", "dataType": "string", "role": "dimension" },
+        {
+          "id": "revenue",
+          "label": "Revenue",
+          "dataType": "number",
+          "role": "measure",
+          "defaultAggregation": "sum"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 3. Paste metadata JSON into Probe mode
+
+For the fastest proof of concept, open the dev app, switch to `Probe`, choose `Paste metadata JSON`, and paste either:
+
+- a raw `NormalizedDataset[]`
+- or an object with a `datasets` array
+
+### Probe mode workflow
+
+1. Run the dev app: `pnpm dev`
+2. Open http://localhost:3000
+3. Switch to `Probe`
+4. Choose a metadata source: `Discovery URL` or `Paste metadata JSON`
+5. Optionally provide a separate query endpoint URL for live chart preview
+6. Add auth as either Bearer JWT or custom header
+7. Load metadata and start building charts
+
+If you provide metadata but no query endpoint, you can still design the dashboard and export JSON, but chart previews will fall back to sample data.
+
 ## Embedding in Your App
 
 ### Runtime Only

--- a/docs/api/metadata-and-cli.md
+++ b/docs/api/metadata-and-cli.md
@@ -12,9 +12,26 @@ Main exports:
 - `MetadataAdapter`
 - `LogicalQuery`, `QueryField`, `QueryFilter`, `QuerySort`, `QueryResult`
 - `QueryAdapter`
+- `PROBE_PROTOCOL_VERSION`, `PROBE_STANDARD_FILTER_OPERATORS`, `PROBE_STANDARD_AGGREGATIONS`
+- `ProbeCapabilities`, `ProbeDatasetsResponse`, `ProbeQueryRequest`, `ProbeQueryResponse`, `ProbeErrorResponse`
 - `inferFieldRole()`, `inferAggregation()`, `humanizeFieldName()`
 
 Use `MetadataAdapter` when normalizing source metadata into a backend-agnostic analytical model. Use `QueryAdapter` when the host wants to execute logical queries against its own backend or in-browser engine.
+
+### Probe contract
+
+The same package now defines the canonical host probe envelope used when a host exposes Supersubset-compatible discovery and query endpoints.
+
+Core pieces:
+
+- `PROBE_PROTOCOL_VERSION`: version string emitted by discovery and query endpoints
+- `ProbeCapabilities`: host-advertised support for operators, aggregations, source types, and limits
+- `ProbeDatasetsResponse`: discovery envelope with `protocolVersion`, `capabilities`, and `datasets`
+- `ProbeQueryRequest`: logical query payload sent to a host endpoint
+- `ProbeQueryResponse`: query result envelope with `protocolVersion`, `capabilities`, and result columns/rows
+- `ProbeErrorResponse`: error envelope for invalid queries or unavailable features
+
+This keeps the transport contract explicit instead of forcing each host app to re-declare a near-copy of the TypeScript types.
 
 ## @supersubset/query-client
 
@@ -61,7 +78,7 @@ Supersubset ships four metadata normalization packages today:
 - `@supersubset/adapter-prisma`: parses Prisma schema text via `PrismaAdapter`
 - `@supersubset/adapter-sql`: normalizes structured catalog objects via `SqlAdapter`
 - `@supersubset/adapter-json`: normalizes hand-authored JSON dataset definitions via `JsonAdapter`
-- `@supersubset/adapter-dbt`: normalizes dbt manifest objects via `DbtAdapter`
+- `@supersubset/adapter-dbt`: normalizes dbt manifest objects via `DbtAdapter`; dataset ids come from dbt manifest node ids so they stay stable across schemas and packages, and `meta.supersubset` can override dataset and field metadata such as labels, roles, aggregations, formats, and source types
 
 These packages normalize metadata only. They do not connect the runtime directly to a database.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,13 +56,44 @@ What to look for:
 - host-owned SQL execution via `sql.js`
 - filter state translated into host-side queries
 
+## Getting Started With Your Data
+
+Supersubset needs:
+
+1. metadata describing datasets and fields
+2. a query endpoint for live preview or runtime execution
+
+The metadata step does not require a live discovery endpoint. You can now onboard data in three ways:
+
+- use a discovery URL that returns normalized metadata
+- generate a metadata snapshot with `npx supersubset export-metadata`
+- paste metadata JSON directly into Probe mode in the dev app
+
+Example CLI export:
+
+```bash
+npx supersubset export-metadata \
+  --source-type json \
+  --source ./metadata.json \
+  --out ./supersubset-metadata.json
+```
+
+Then either:
+
+1. serve that JSON from a discovery endpoint later, or
+2. paste it directly into Probe mode and point previews at a query endpoint
+
 ## Minimal Runtime Host
 
 Use the runtime when the host app already owns routing, persistence, and data delivery.
 
 ```tsx
 import { useMemo } from 'react';
-import { SupersubsetRenderer, createWidgetRegistry, type NavigateRequest } from '@supersubset/runtime';
+import {
+  SupersubsetRenderer,
+  createWidgetRegistry,
+  type NavigateRequest,
+} from '@supersubset/runtime';
 import { registerAllCharts } from '@supersubset/charts-echarts';
 import { resolveTheme, themeToCssVariables } from '@supersubset/theme';
 

--- a/e2e/workflows/probe-metadata-paste.spec.ts
+++ b/e2e/workflows/probe-metadata-paste.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Probe metadata onboarding', () => {
+  test('opens the designer from pasted metadata JSON', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByTestId('mode-probe').click();
+    await page.getByTestId('probe-metadata-mode').selectOption('paste-json');
+    await page.getByTestId('probe-metadata-json-input').fill(
+      JSON.stringify({
+        datasets: [
+          {
+            id: 'orders',
+            label: 'Orders',
+            fields: [
+              { id: 'region', dataType: 'string' },
+              { id: 'revenue', dataType: 'number' },
+              { id: 'order_date', dataType: 'date' },
+            ],
+          },
+        ],
+      }),
+    );
+
+    await page.getByTestId('probe-connect-button').click();
+
+    await expect(page.getByTestId('probe-dataset-count')).toHaveText('1 dataset(s) discovered');
+    await expect(page.getByTestId('probe-preview-status')).toContainText('Preview: disabled');
+    await expect(page.getByText('Supersubset Probe Designer')).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "docs:screenshots": "npx playwright test --config packages/docs/playwright.config.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepare": "husky",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/adapter-dbt/src/index.ts
+++ b/packages/adapter-dbt/src/index.ts
@@ -5,6 +5,9 @@
  * into the analytical metadata model.
  */
 import type {
+  AggregationType,
+  DatasetSource,
+  FieldRole,
   MetadataAdapter,
   NormalizedDataset,
   NormalizedField,
@@ -33,6 +36,22 @@ export interface DbtNode {
 
 export interface DbtManifestSource {
   nodes: Record<string, DbtNode>;
+}
+
+interface DbtSupersubsetDatasetMeta {
+  label?: string;
+  description?: string;
+  sourceType?: DatasetSource['type'];
+}
+
+interface DbtSupersubsetFieldMeta {
+  label?: string;
+  description?: string;
+  dataType?: FieldDataType;
+  role?: FieldRole;
+  defaultAggregation?: AggregationType;
+  format?: string;
+  sourceExpression?: string;
 }
 
 // ─── SQL Type Mapping (reused from sql adapter logic) ────────
@@ -72,31 +91,146 @@ function validateSource(source: unknown): asserts source is DbtManifestSource {
 // ─── Normalization ───────────────────────────────────────────
 
 const PROCESSABLE_TYPES = new Set(['model', 'source']);
+const VALID_FIELD_DATA_TYPES: ReadonlySet<FieldDataType> = new Set([
+  'string',
+  'number',
+  'integer',
+  'date',
+  'datetime',
+  'boolean',
+  'json',
+  'unknown',
+]);
+const VALID_FIELD_ROLES: ReadonlySet<FieldRole> = new Set([
+  'dimension',
+  'measure',
+  'time',
+  'key',
+  'unknown',
+]);
+const VALID_AGGREGATIONS: ReadonlySet<AggregationType> = new Set([
+  'sum',
+  'avg',
+  'count',
+  'count_distinct',
+  'min',
+  'max',
+  'none',
+]);
+const VALID_SOURCE_TYPES: ReadonlySet<DatasetSource['type']> = new Set([
+  'table',
+  'view',
+  'model',
+  'query',
+  'file',
+]);
 
-function convertColumn(col: DbtColumn): NormalizedField {
-  const dataType = mapSqlType(col.data_type);
-  const role = inferFieldRole(col.name, dataType);
-  const defaultAggregation = inferAggregation(role, dataType);
+function getSupersubsetMeta(
+  meta: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  const candidate = meta?.supersubset;
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+    return undefined;
+  }
+  return candidate as Record<string, unknown>;
+}
 
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function readFieldDataType(value: unknown): FieldDataType | undefined {
+  return typeof value === 'string' && VALID_FIELD_DATA_TYPES.has(value as FieldDataType)
+    ? (value as FieldDataType)
+    : undefined;
+}
+
+function readFieldRole(value: unknown): FieldRole | undefined {
+  return typeof value === 'string' && VALID_FIELD_ROLES.has(value as FieldRole)
+    ? (value as FieldRole)
+    : undefined;
+}
+
+function readAggregation(value: unknown): AggregationType | undefined {
+  return typeof value === 'string' && VALID_AGGREGATIONS.has(value as AggregationType)
+    ? (value as AggregationType)
+    : undefined;
+}
+
+function readSourceType(value: unknown): DatasetSource['type'] | undefined {
+  return typeof value === 'string' && VALID_SOURCE_TYPES.has(value as DatasetSource['type'])
+    ? (value as DatasetSource['type'])
+    : undefined;
+}
+
+function getDatasetOverrides(node: DbtNode): DbtSupersubsetDatasetMeta {
+  const meta = getSupersubsetMeta(node.meta);
   return {
-    id: col.name,
-    label: humanizeFieldName(col.name),
-    dataType,
-    role,
-    ...(defaultAggregation !== undefined && { defaultAggregation }),
-    ...(col.description && { description: col.description }),
+    label: readString(meta?.label),
+    description: readString(meta?.description),
+    sourceType: readSourceType(meta?.sourceType),
   };
 }
 
+function getFieldOverrides(col: DbtColumn): DbtSupersubsetFieldMeta {
+  const meta = getSupersubsetMeta(col.meta);
+  return {
+    label: readString(meta?.label),
+    description: readString(meta?.description),
+    dataType: readFieldDataType(meta?.dataType),
+    role: readFieldRole(meta?.role),
+    defaultAggregation: readAggregation(meta?.defaultAggregation),
+    format: readString(meta?.format),
+    sourceExpression: readString(meta?.sourceExpression),
+  };
+}
+
+function convertColumn(col: DbtColumn): NormalizedField {
+  const overrides = getFieldOverrides(col);
+  const dataType = overrides.dataType ?? mapSqlType(col.data_type);
+  const role = overrides.role ?? inferFieldRole(col.name, dataType);
+  const defaultAggregation = overrides.defaultAggregation ?? inferAggregation(role, dataType);
+  const description = overrides.description ?? col.description;
+
+  return {
+    id: col.name,
+    label: overrides.label ?? humanizeFieldName(col.name),
+    dataType,
+    role,
+    ...(defaultAggregation !== undefined && { defaultAggregation }),
+    ...(overrides.format !== undefined && { format: overrides.format }),
+    ...(overrides.sourceExpression !== undefined && {
+      sourceExpression: overrides.sourceExpression,
+    }),
+    ...(description !== undefined && { description }),
+  };
+}
+
+function getDatasetId(nodeId: string): string {
+  // dbt manifest node keys are unique_ids; use them directly so dataset IDs
+  // remain stable across schemas/packages and do not collide on display names.
+  return nodeId;
+}
+
+function getDatasetSourceType(node: DbtNode): DatasetSource['type'] {
+  return node.resource_type === 'source' ? 'table' : 'model';
+}
+
 function convertNode(nodeId: string, node: DbtNode): NormalizedDataset {
+  const overrides = getDatasetOverrides(node);
   const columns = node.columns ?? {};
   const fields = Object.values(columns).map(convertColumn);
 
   return {
-    id: node.name.toLowerCase(),
-    label: node.name,
-    ...(node.description && { description: node.description }),
-    source: { type: 'model', ref: nodeId },
+    id: getDatasetId(nodeId),
+    label: overrides.label ?? node.name,
+    ...((overrides.description ?? node.description) !== undefined && {
+      description: overrides.description ?? node.description,
+    }),
+    source: {
+      type: overrides.sourceType ?? getDatasetSourceType(node),
+      ref: nodeId,
+    },
     fields,
   };
 }
@@ -119,7 +253,10 @@ export class DbtAdapter implements MetadataAdapter<DbtManifestSource> {
     return datasets;
   }
 
-  async getDataset(source: DbtManifestSource, datasetId: string): Promise<NormalizedDataset | undefined> {
+  async getDataset(
+    source: DbtManifestSource,
+    datasetId: string,
+  ): Promise<NormalizedDataset | undefined> {
     const datasets = await this.getDatasets(source);
     return datasets.find((d) => d.id === datasetId);
   }

--- a/packages/adapter-dbt/test/placeholder.test.ts
+++ b/packages/adapter-dbt/test/placeholder.test.ts
@@ -68,9 +68,9 @@ describe('DbtAdapter', () => {
       const datasets = await adapter.getDatasets(FIXTURE);
       expect(datasets).toHaveLength(3);
       const names = datasets.map((d) => d.id);
-      expect(names).toContain('users');
-      expect(names).toContain('orders');
-      expect(names).toContain('raw_events');
+      expect(names).toContain('model.project.users');
+      expect(names).toContain('model.project.orders');
+      expect(names).toContain('source.project.raw_events');
     });
 
     it('skips test and seed nodes', async () => {
@@ -82,19 +82,25 @@ describe('DbtAdapter', () => {
 
     it('preserves descriptions', async () => {
       const datasets = await adapter.getDatasets(FIXTURE);
-      const users = datasets.find((d) => d.id === 'users')!;
+      const users = datasets.find((d) => d.id === 'model.project.users')!;
       expect(users.description).toBe('All application users');
     });
 
     it('sets source ref to node id', async () => {
       const datasets = await adapter.getDatasets(FIXTURE);
-      const users = datasets.find((d) => d.id === 'users')!;
+      const users = datasets.find((d) => d.id === 'model.project.users')!;
       expect(users.source).toEqual({ type: 'model', ref: 'model.project.users' });
+    });
+
+    it('maps dbt sources to table source types', async () => {
+      const datasets = await adapter.getDatasets(FIXTURE);
+      const rawEvents = datasets.find((d) => d.id === 'source.project.raw_events')!;
+      expect(rawEvents.source).toEqual({ type: 'table', ref: 'source.project.raw_events' });
     });
 
     it('maps dbt column types correctly', async () => {
       const datasets = await adapter.getDatasets(FIXTURE);
-      const users = datasets.find((d) => d.id === 'users')!;
+      const users = datasets.find((d) => d.id === 'model.project.users')!;
 
       expect(users.fields.find((f) => f.id === 'id')?.dataType).toBe('integer');
       expect(users.fields.find((f) => f.id === 'email')?.dataType).toBe('string');
@@ -104,7 +110,7 @@ describe('DbtAdapter', () => {
 
     it('infers field roles', async () => {
       const datasets = await adapter.getDatasets(FIXTURE);
-      const orders = datasets.find((d) => d.id === 'orders')!;
+      const orders = datasets.find((d) => d.id === 'model.project.orders')!;
 
       expect(orders.fields.find((f) => f.id === 'id')?.role).toBe('key');
       expect(orders.fields.find((f) => f.id === 'total_amount')?.role).toBe('measure');
@@ -114,20 +120,20 @@ describe('DbtAdapter', () => {
 
     it('infers aggregation for measures', async () => {
       const datasets = await adapter.getDatasets(FIXTURE);
-      const orders = datasets.find((d) => d.id === 'orders')!;
+      const orders = datasets.find((d) => d.id === 'model.project.orders')!;
       expect(orders.fields.find((f) => f.id === 'total_amount')?.defaultAggregation).toBe('sum');
     });
 
     it('humanizes field names', async () => {
       const datasets = await adapter.getDatasets(FIXTURE);
-      const users = datasets.find((d) => d.id === 'users')!;
+      const users = datasets.find((d) => d.id === 'model.project.users')!;
       expect(users.fields.find((f) => f.id === 'created_at')?.label).toBe('Created At');
       expect(users.fields.find((f) => f.id === 'is_active')?.label).toBe('Is Active');
     });
 
     it('preserves column descriptions', async () => {
       const datasets = await adapter.getDatasets(FIXTURE);
-      const users = datasets.find((d) => d.id === 'users')!;
+      const users = datasets.find((d) => d.id === 'model.project.users')!;
       expect(users.fields.find((f) => f.id === 'id')?.description).toBe('Primary key');
     });
 
@@ -149,15 +155,144 @@ describe('DbtAdapter', () => {
 
     it('handles JSON column type', async () => {
       const datasets = await adapter.getDatasets(FIXTURE);
-      const events = datasets.find((d) => d.id === 'raw_events')!;
+      const events = datasets.find((d) => d.id === 'source.project.raw_events')!;
       expect(events.fields.find((f) => f.id === 'payload')?.dataType).toBe('json');
+    });
+
+    it('uses stable dbt node ids instead of display names', async () => {
+      const source: DbtManifestSource = {
+        nodes: {
+          'model.project.orders': {
+            resource_type: 'model',
+            name: 'orders',
+            description: 'Core orders',
+          },
+          'model.analytics.orders': {
+            resource_type: 'model',
+            name: 'orders',
+            description: 'Analytics orders',
+          },
+        },
+      };
+
+      const datasets = await adapter.getDatasets(source);
+
+      expect(datasets.map((dataset) => dataset.id)).toEqual([
+        'model.project.orders',
+        'model.analytics.orders',
+      ]);
+      expect(datasets.map((dataset) => dataset.label)).toEqual(['orders', 'orders']);
+    });
+
+    it('applies supersubset dataset and field overrides from dbt meta', async () => {
+      const source: DbtManifestSource = {
+        nodes: {
+          'model.project.override_demo': {
+            resource_type: 'model',
+            name: 'override_demo',
+            description: 'Original description',
+            meta: {
+              supersubset: {
+                label: 'Revenue Overrides',
+                description: 'Dataset description override',
+                sourceType: 'view',
+              },
+            },
+            columns: {
+              amount: {
+                name: 'amount',
+                data_type: 'INTEGER',
+                description: 'Original amount description',
+                meta: {
+                  supersubset: {
+                    label: 'Gross Revenue',
+                    description: 'Recognized revenue',
+                    dataType: 'number',
+                    role: 'measure',
+                    defaultAggregation: 'avg',
+                    format: '$0,0.00',
+                    sourceExpression: 'sum(raw.amount)',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const datasets = await adapter.getDatasets(source);
+      const dataset = datasets[0];
+      const amount = dataset.fields[0];
+
+      expect(dataset.label).toBe('Revenue Overrides');
+      expect(dataset.description).toBe('Dataset description override');
+      expect(dataset.source).toEqual({
+        type: 'view',
+        ref: 'model.project.override_demo',
+      });
+      expect(amount).toEqual(
+        expect.objectContaining({
+          label: 'Gross Revenue',
+          description: 'Recognized revenue',
+          dataType: 'number',
+          role: 'measure',
+          defaultAggregation: 'avg',
+          format: '$0,0.00',
+          sourceExpression: 'sum(raw.amount)',
+        }),
+      );
+    });
+
+    it('ignores invalid supersubset meta overrides', async () => {
+      const source: DbtManifestSource = {
+        nodes: {
+          'model.project.invalid_meta': {
+            resource_type: 'model',
+            name: 'invalid_meta',
+            meta: {
+              supersubset: {
+                sourceType: 'warehouse',
+              },
+            },
+            columns: {
+              order_date: {
+                name: 'order_date',
+                data_type: 'DATE',
+                meta: {
+                  supersubset: {
+                    dataType: 'currency',
+                    role: 'axis',
+                    defaultAggregation: 'median',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const datasets = await adapter.getDatasets(source);
+      const dataset = datasets[0];
+      const field = dataset.fields[0];
+
+      expect(dataset.source).toEqual({
+        type: 'model',
+        ref: 'model.project.invalid_meta',
+      });
+      expect(field).toEqual(
+        expect.objectContaining({
+          dataType: 'date',
+          role: 'time',
+        }),
+      );
+      expect(field.defaultAggregation).toBe('none');
     });
   });
 
   describe('getDataset', () => {
     it('returns a single dataset by id', async () => {
-      const ds = await adapter.getDataset(FIXTURE, 'users');
-      expect(ds?.id).toBe('users');
+      const ds = await adapter.getDataset(FIXTURE, 'model.project.users');
+      expect(ds?.id).toBe('model.project.users');
     });
 
     it('returns undefined for missing dataset', async () => {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,9 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
     "test": "vitest run",
@@ -23,6 +25,7 @@
     "@supersubset/adapter-dbt": "workspace:*"
   },
   "devDependencies": {
+    "@types/node": "^22.13.14",
     "tsup": "^8.0.0",
     "typescript": "^5.4.0",
     "vitest": "^1.6.0"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,162 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+import { exportMetadata, createExportMetadataEnvelope } from './export-metadata.js';
+import { importSchema } from './import-schema.js';
+import type { SupportedSourceType } from './metadata-source.js';
+
+export interface CliIO {
+  stdout: (text: string) => void;
+  stderr: (text: string) => void;
+  readText: (filePath: string) => Promise<string>;
+  writeText: (filePath: string, content: string) => Promise<void>;
+  resolvePath: (filePath: string) => string;
+}
+
+const defaultIO: CliIO = {
+  stdout: (text) => {
+    process.stdout.write(text.endsWith('\n') ? text : `${text}\n`);
+  },
+  stderr: (text) => {
+    process.stderr.write(text.endsWith('\n') ? text : `${text}\n`);
+  },
+  readText: (filePath) => readFile(filePath, 'utf8'),
+  writeText: async (filePath, content) => {
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, content, 'utf8');
+  },
+  resolvePath: (filePath) => resolve(process.cwd(), filePath),
+};
+
+function getHelpText(): string {
+  return [
+    'Supersubset CLI',
+    '',
+    'Commands:',
+    '  supersubset import-schema --source-type <prisma|sql|json|dbt> --source <path-or-string> [--title <title>] [--id <id>] [--out <file>]',
+    '  supersubset export-metadata --source-type <prisma|sql|json|dbt> --source <path-or-string> [--out <file>]',
+    '',
+    'Examples:',
+    '  supersubset export-metadata --source-type json --source ./metadata.json --out ./supersubset-metadata.json',
+    '  supersubset import-schema --source-type prisma --source ./schema.prisma --title "Orders" --out ./dashboard.json',
+  ].join('\n');
+}
+
+function parseArgs(argv: string[]): { command?: string; flags: Record<string, string> } {
+  const [command, ...rest] = argv;
+  const flags: Record<string, string> = {};
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index];
+    if (!token) {
+      continue;
+    }
+
+    if (token === '--help' || token === '-h') {
+      flags.help = 'true';
+      continue;
+    }
+
+    if (!token.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${token}`);
+    }
+
+    const value = rest[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for ${token}`);
+    }
+
+    flags[token.slice(2)] = value;
+    index += 1;
+  }
+
+  return { command, flags };
+}
+
+function readSourceType(value: string | undefined): SupportedSourceType {
+  if (value === 'prisma' || value === 'sql' || value === 'json' || value === 'dbt') {
+    return value;
+  }
+
+  throw new Error('Expected --source-type to be one of prisma, sql, json, or dbt');
+}
+
+async function loadSourceValue(sourceArg: string | undefined, io: CliIO): Promise<string> {
+  if (!sourceArg) {
+    throw new Error('Missing required flag: --source');
+  }
+
+  const resolvedPath = io.resolvePath(sourceArg);
+  try {
+    return await io.readText(resolvedPath);
+  } catch {
+    return sourceArg;
+  }
+}
+
+async function handleImportSchema(flags: Record<string, string>, io: CliIO): Promise<void> {
+  const sourceType = readSourceType(flags['source-type']);
+  const source = await loadSourceValue(flags.source, io);
+  const result = await importSchema({
+    sourceType,
+    source,
+    title: flags.title,
+    id: flags.id,
+  });
+  const output = JSON.stringify(result.dashboard, null, 2);
+
+  if (flags.out) {
+    await io.writeText(io.resolvePath(flags.out), output);
+    io.stdout(`Wrote dashboard JSON to ${flags.out}`);
+    return;
+  }
+
+  io.stdout(output);
+}
+
+async function handleExportMetadata(flags: Record<string, string>, io: CliIO): Promise<void> {
+  const sourceType = readSourceType(flags['source-type']);
+  const source = await loadSourceValue(flags.source, io);
+  const result = await exportMetadata({
+    sourceType,
+    source,
+  });
+  const output = JSON.stringify(createExportMetadataEnvelope(result.datasets), null, 2);
+
+  if (flags.out) {
+    await io.writeText(io.resolvePath(flags.out), output);
+    io.stdout(`Wrote metadata JSON to ${flags.out}`);
+    return;
+  }
+
+  io.stdout(output);
+}
+
+export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<number> {
+  try {
+    const { command, flags } = parseArgs(argv);
+
+    if (!command || flags.help) {
+      io.stdout(getHelpText());
+      return 0;
+    }
+
+    if (command === 'import-schema') {
+      await handleImportSchema(flags, io);
+      return 0;
+    }
+
+    if (command === 'export-metadata') {
+      await handleExportMetadata(flags, io);
+      return 0;
+    }
+
+    throw new Error(`Unknown command: ${command}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected CLI error';
+    io.stderr(message);
+    io.stderr('');
+    io.stderr(getHelpText());
+    return 1;
+  }
+}

--- a/packages/cli/src/export-metadata.ts
+++ b/packages/cli/src/export-metadata.ts
@@ -1,0 +1,38 @@
+import type { NormalizedDataset } from '@supersubset/data-model';
+
+import { getDatasetsFromSource, type MetadataSourceOptions } from './metadata-source.js';
+
+export type ExportMetadataOptions = MetadataSourceOptions;
+
+export interface ExportMetadataEnvelope {
+  datasets: NormalizedDataset[];
+}
+
+export interface ExportMetadataResult {
+  datasets: NormalizedDataset[];
+  stats: {
+    datasetsCount: number;
+    fieldsCount: number;
+  };
+}
+
+export async function exportMetadata(
+  options: ExportMetadataOptions,
+): Promise<ExportMetadataResult> {
+  const datasets = await getDatasetsFromSource(options);
+  const fieldsCount = datasets.reduce((sum, dataset) => sum + dataset.fields.length, 0);
+
+  return {
+    datasets,
+    stats: {
+      datasetsCount: datasets.length,
+      fieldsCount,
+    },
+  };
+}
+
+export function createExportMetadataEnvelope(
+  datasets: NormalizedDataset[],
+): ExportMetadataEnvelope {
+  return { datasets };
+}

--- a/packages/cli/src/import-schema.ts
+++ b/packages/cli/src/import-schema.ts
@@ -14,10 +14,7 @@ import type {
 import { CURRENT_SCHEMA_VERSION } from '@supersubset/schema';
 import type { NormalizedDataset, NormalizedField } from '@supersubset/data-model';
 import { humanizeFieldName } from '@supersubset/data-model';
-import { PrismaAdapter } from '@supersubset/adapter-prisma';
-import { SqlAdapter } from '@supersubset/adapter-sql';
-import { JsonAdapter } from '@supersubset/adapter-json';
-import { DbtAdapter } from '@supersubset/adapter-dbt';
+import { getDatasetsFromSource } from './metadata-source.js';
 
 // ─── Public Types ────────────────────────────────────────────
 
@@ -52,10 +49,6 @@ function slugify(text: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '');
-}
-
-function hasFieldWithRole(fields: NormalizedField[], role: string): boolean {
-  return fields.some((f) => f.role === role);
 }
 
 function getFieldsWithRole(fields: NormalizedField[], role: string): NormalizedField[] {
@@ -176,37 +169,8 @@ function generatePage(dataset: NormalizedDataset): PageDefinition {
 
 // ─── Main Import Function ────────────────────────────────────
 
-async function getDatasets(options: ImportSchemaOptions): Promise<NormalizedDataset[]> {
-  switch (options.sourceType) {
-    case 'prisma': {
-      const adapter = new PrismaAdapter();
-      return adapter.getDatasets(options.source as string);
-    }
-    case 'sql': {
-      const adapter = new SqlAdapter();
-      const source =
-        typeof options.source === 'string' ? JSON.parse(options.source) : options.source;
-      return adapter.getDatasets(source);
-    }
-    case 'json': {
-      const adapter = new JsonAdapter();
-      const source =
-        typeof options.source === 'string' ? JSON.parse(options.source) : options.source;
-      return adapter.getDatasets(source);
-    }
-    case 'dbt': {
-      const adapter = new DbtAdapter();
-      const source =
-        typeof options.source === 'string' ? JSON.parse(options.source) : options.source;
-      return adapter.getDatasets(source);
-    }
-    default:
-      throw new Error(`Unsupported source type: ${options.sourceType as string}`);
-  }
-}
-
 export async function importSchema(options: ImportSchemaOptions): Promise<ImportSchemaResult> {
-  const datasets = await getDatasets(options);
+  const datasets = await getDatasetsFromSource(options);
 
   const pages = datasets.map(generatePage);
   const totalWidgets = pages.reduce((sum, p) => sum + p.widgets.length, 0);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,1 +1,28 @@
-export { importSchema, type ImportSchemaOptions, type ImportSchemaResult } from './import-schema.js';
+#!/usr/bin/env node
+
+export {
+  importSchema,
+  type ImportSchemaOptions,
+  type ImportSchemaResult,
+} from './import-schema.js';
+export {
+  exportMetadata,
+  createExportMetadataEnvelope,
+  type ExportMetadataOptions,
+  type ExportMetadataResult,
+  type ExportMetadataEnvelope,
+} from './export-metadata.js';
+export { runCli, type CliIO } from './cli.js';
+
+import { fileURLToPath } from 'node:url';
+
+import { runCli } from './cli.js';
+
+const entryPath = process.argv[1];
+const currentFilePath = fileURLToPath(import.meta.url);
+
+if (entryPath && currentFilePath === entryPath) {
+  void runCli(process.argv.slice(2)).then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}

--- a/packages/cli/src/metadata-source.ts
+++ b/packages/cli/src/metadata-source.ts
@@ -1,0 +1,42 @@
+import type { NormalizedDataset } from '@supersubset/data-model';
+
+import { PrismaAdapter } from '@supersubset/adapter-prisma';
+import { SqlAdapter, type SqlCatalogSource } from '@supersubset/adapter-sql';
+import { JsonAdapter, type JsonAdapterSource } from '@supersubset/adapter-json';
+import { DbtAdapter, type DbtManifestSource } from '@supersubset/adapter-dbt';
+
+export type SupportedSourceType = 'prisma' | 'sql' | 'json' | 'dbt';
+
+export interface MetadataSourceOptions {
+  sourceType: SupportedSourceType;
+  source: string | object;
+}
+
+function parseStructuredSource<TExpected extends object>(source: string | object): TExpected {
+  return (typeof source === 'string' ? JSON.parse(source) : source) as TExpected;
+}
+
+export async function getDatasetsFromSource(
+  options: MetadataSourceOptions,
+): Promise<NormalizedDataset[]> {
+  switch (options.sourceType) {
+    case 'prisma': {
+      const adapter = new PrismaAdapter();
+      return adapter.getDatasets(options.source as string);
+    }
+    case 'sql': {
+      const adapter = new SqlAdapter();
+      return adapter.getDatasets(parseStructuredSource<SqlCatalogSource>(options.source));
+    }
+    case 'json': {
+      const adapter = new JsonAdapter();
+      return adapter.getDatasets(parseStructuredSource<JsonAdapterSource>(options.source));
+    }
+    case 'dbt': {
+      const adapter = new DbtAdapter();
+      return adapter.getDatasets(parseStructuredSource<DbtManifestSource>(options.source));
+    }
+    default:
+      throw new Error(`Unsupported source type: ${options.sourceType as string}`);
+  }
+}

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import { runCli, type CliIO } from '../src/cli.js';
+
+function createMockIo(initialFiles: Record<string, string> = {}): {
+  io: CliIO;
+  writes: Map<string, string>;
+  stdout: string[];
+  stderr: string[];
+} {
+  const files = new Map(Object.entries(initialFiles));
+  const writes = new Map<string, string>();
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  return {
+    io: {
+      stdout: (text) => {
+        stdout.push(text);
+      },
+      stderr: (text) => {
+        stderr.push(text);
+      },
+      readText: async (filePath) => {
+        const value = files.get(filePath);
+        if (value === undefined) {
+          throw new Error('ENOENT');
+        }
+        return value;
+      },
+      writeText: async (filePath, content) => {
+        writes.set(filePath, content);
+      },
+      resolvePath: (filePath) => `/cwd/${filePath.replace(/^\.\//, '')}`,
+    },
+    writes,
+    stdout,
+    stderr,
+  };
+}
+
+describe('runCli', () => {
+  it('writes exported metadata JSON to an output file', async () => {
+    const { io, writes, stdout } = createMockIo({
+      '/cwd/metadata.json': JSON.stringify([
+        {
+          id: 'orders',
+          label: 'Orders',
+          fields: [{ id: 'revenue', dataType: 'number' }],
+        },
+      ]),
+    });
+
+    const exitCode = await runCli(
+      [
+        'export-metadata',
+        '--source-type',
+        'json',
+        '--source',
+        './metadata.json',
+        '--out',
+        './normalized.json',
+      ],
+      io,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout[0]).toContain('Wrote metadata JSON');
+    expect(JSON.parse(writes.get('/cwd/normalized.json') ?? '{}')).toEqual({
+      datasets: [
+        {
+          id: 'orders',
+          label: 'Orders',
+          fields: [
+            {
+              id: 'revenue',
+              label: 'Revenue',
+              dataType: 'number',
+              role: 'measure',
+              defaultAggregation: 'sum',
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('prints help text for missing command', async () => {
+    const { io, stdout } = createMockIo();
+
+    const exitCode = await runCli([], io);
+
+    expect(exitCode).toBe(0);
+    expect(stdout.join('\n')).toContain('Supersubset CLI');
+    expect(stdout.join('\n')).toContain('export-metadata');
+  });
+
+  it('returns a non-zero exit code for unknown commands', async () => {
+    const { io, stderr } = createMockIo();
+
+    const exitCode = await runCli(['wat'], io);
+
+    expect(exitCode).toBe(1);
+    expect(stderr.join('\n')).toContain('Unknown command: wat');
+  });
+});

--- a/packages/cli/test/export-metadata.test.ts
+++ b/packages/cli/test/export-metadata.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { createExportMetadataEnvelope, exportMetadata } from '../src/export-metadata.js';
+
+const JSON_SOURCE = [
+  {
+    id: 'orders',
+    label: 'Orders',
+    fields: [
+      { id: 'order_id', dataType: 'integer' },
+      { id: 'region', dataType: 'string' },
+      { id: 'order_date', dataType: 'date' },
+      { id: 'revenue', dataType: 'number' },
+    ],
+  },
+];
+
+describe('exportMetadata', () => {
+  it('exports normalized datasets and summary stats', async () => {
+    const result = await exportMetadata({
+      sourceType: 'json',
+      source: JSON_SOURCE,
+    });
+
+    expect(result.stats.datasetsCount).toBe(1);
+    expect(result.stats.fieldsCount).toBe(4);
+    expect(result.datasets[0]?.fields[0]?.label).toBe('Order Id');
+    expect(result.datasets[0]?.fields[3]?.defaultAggregation).toBe('sum');
+  });
+
+  it('wraps exported datasets in an envelope object', async () => {
+    const result = await exportMetadata({
+      sourceType: 'json',
+      source: JSON_SOURCE,
+    });
+
+    expect(createExportMetadataEnvelope(result.datasets)).toEqual({
+      datasets: result.datasets,
+    });
+  });
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "types": ["node"],
     "declaration": true,
     "strict": true,
     "esModuleInterop": true,

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -41,7 +41,15 @@ export interface NormalizedField {
   description?: string;
 }
 
-export type FieldDataType = 'string' | 'number' | 'integer' | 'date' | 'datetime' | 'boolean' | 'json' | 'unknown';
+export type FieldDataType =
+  | 'string'
+  | 'number'
+  | 'integer'
+  | 'date'
+  | 'datetime'
+  | 'boolean'
+  | 'json'
+  | 'unknown';
 
 export type FieldRole = 'dimension' | 'measure' | 'time' | 'key' | 'unknown';
 
@@ -91,11 +99,18 @@ export interface QueryFilter {
 }
 
 export type QueryFilterOperator =
-  | 'eq' | 'neq'
-  | 'gt' | 'gte' | 'lt' | 'lte'
-  | 'in' | 'not_in'
-  | 'like' | 'not_like'
-  | 'is_null' | 'is_not_null'
+  | 'eq'
+  | 'neq'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  | 'in'
+  | 'not_in'
+  | 'like'
+  | 'not_like'
+  | 'is_null'
+  | 'is_not_null'
   | 'between';
 
 export interface QuerySort {
@@ -123,6 +138,121 @@ export interface QueryAdapter {
   readonly name: string;
   execute(query: LogicalQuery): Promise<QueryResult>;
   cancel?(queryId: string): Promise<void>;
+}
+
+// ─── Probe Contract ──────────────────────────────────────────
+
+/**
+ * Version identifier for the Supersubset host probe contract.
+ *
+ * Probe responses should include this so hosts and libraries can reject
+ * incompatible envelopes before attempting to interpret discovery or query
+ * payloads.
+ */
+export const PROBE_PROTOCOL_VERSION = 'v1' as const;
+
+/**
+ * Standard filter operators understood by the logical query contract.
+ * Individual hosts may support a subset and should advertise that subset via
+ * ProbeCapabilities.supportedFilterOperators.
+ */
+export const PROBE_STANDARD_FILTER_OPERATORS = [
+  'eq',
+  'neq',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'in',
+  'not_in',
+  'like',
+  'not_like',
+  'is_null',
+  'is_not_null',
+  'between',
+] as const satisfies readonly QueryFilterOperator[];
+
+/**
+ * Standard aggregations available to hosts implementing the probe contract.
+ * Hosts should advertise their exact support level via ProbeCapabilities.
+ */
+export const PROBE_STANDARD_AGGREGATIONS = [
+  'sum',
+  'avg',
+  'count',
+  'count_distinct',
+  'min',
+  'max',
+  'none',
+] as const satisfies readonly AggregationType[];
+
+/**
+ * Dataset source kinds that discovery endpoints may expose.
+ */
+export const PROBE_STANDARD_SOURCE_TYPES = [
+  'table',
+  'view',
+  'model',
+  'query',
+  'file',
+] as const satisfies readonly DatasetSource['type'][];
+
+/**
+ * Host-advertised capabilities for the probe contract.
+ *
+ * This avoids forcing consumers to guess which logical operators or
+ * aggregations a specific backend actually supports.
+ */
+export interface ProbeCapabilities {
+  supportedAggregations: AggregationType[];
+  supportedFilterOperators: QueryFilterOperator[];
+  supportedSourceTypes: DatasetSource['type'][];
+  supportsMetadataDiscovery: boolean;
+  supportsQueryExecution: boolean;
+  supportsCancellation?: boolean;
+  maxLimit?: number;
+}
+
+/**
+ * Discovery response envelope for metadata probe endpoints.
+ */
+export interface ProbeDatasetsResponse {
+  protocolVersion: typeof PROBE_PROTOCOL_VERSION;
+  capabilities: ProbeCapabilities;
+  datasets: NormalizedDataset[];
+}
+
+/**
+ * Logical query request shape for probe-backed query execution.
+ */
+export type ProbeQueryRequest = LogicalQuery;
+
+/**
+ * Query response envelope for probe-backed query execution.
+ */
+export interface ProbeQueryResponse extends QueryResult {
+  protocolVersion: typeof PROBE_PROTOCOL_VERSION;
+  capabilities: ProbeCapabilities;
+}
+
+export type ProbeErrorCode =
+  | 'INVALID_QUERY'
+  | 'UNSUPPORTED_FEATURE'
+  | 'UNAUTHORIZED'
+  | 'UNAVAILABLE'
+  | 'INTERNAL_ERROR';
+
+/**
+ * Error envelope for probe endpoints.
+ */
+export interface ProbeErrorResponse {
+  protocolVersion: typeof PROBE_PROTOCOL_VERSION;
+  error: {
+    code: ProbeErrorCode;
+    message: string;
+    details?: Record<string, unknown>;
+  };
+  capabilities?: ProbeCapabilities;
 }
 
 // ─── Field Heuristics ────────────────────────────────────────

--- a/packages/data-model/test/data-model.test.ts
+++ b/packages/data-model/test/data-model.test.ts
@@ -6,6 +6,15 @@ import type {
   QueryAdapter,
   LogicalQuery,
   QueryResult,
+  ProbeCapabilities,
+  ProbeDatasetsResponse,
+  ProbeQueryResponse,
+} from '../src';
+import {
+  PROBE_PROTOCOL_VERSION,
+  PROBE_STANDARD_AGGREGATIONS,
+  PROBE_STANDARD_FILTER_OPERATORS,
+  PROBE_STANDARD_SOURCE_TYPES,
 } from '../src';
 
 describe('NormalizedDataset type', () => {
@@ -15,7 +24,13 @@ describe('NormalizedDataset type', () => {
       label: 'Orders',
       fields: [
         { id: 'id', label: 'Order ID', dataType: 'integer', role: 'key' },
-        { id: 'total', label: 'Total', dataType: 'number', role: 'measure', defaultAggregation: 'sum' },
+        {
+          id: 'total',
+          label: 'Total',
+          dataType: 'number',
+          role: 'measure',
+          defaultAggregation: 'sum',
+        },
         { id: 'date', label: 'Order Date', dataType: 'date', role: 'time' },
         { id: 'status', label: 'Status', dataType: 'string', role: 'dimension' },
       ],
@@ -106,5 +121,63 @@ describe('QueryAdapter interface', () => {
     });
     expect(result.rows).toHaveLength(1);
     expect(result.columns[0].fieldId).toBe('status');
+  });
+});
+
+describe('probe contract', () => {
+  const capabilities: ProbeCapabilities = {
+    supportedAggregations: [...PROBE_STANDARD_AGGREGATIONS],
+    supportedFilterOperators: [...PROBE_STANDARD_FILTER_OPERATORS],
+    supportedSourceTypes: [...PROBE_STANDARD_SOURCE_TYPES],
+    supportsMetadataDiscovery: true,
+    supportsQueryExecution: true,
+    maxLimit: 5000,
+  };
+
+  it('exposes a stable protocol version', () => {
+    expect(PROBE_PROTOCOL_VERSION).toBe('v1');
+  });
+
+  it('can construct a datasets response envelope', () => {
+    const response: ProbeDatasetsResponse = {
+      protocolVersion: PROBE_PROTOCOL_VERSION,
+      capabilities,
+      datasets: [
+        {
+          id: 'orders',
+          label: 'Orders',
+          source: { type: 'table', ref: 'public.orders' },
+          fields: [
+            { id: 'region', label: 'Region', dataType: 'string', role: 'dimension' },
+            {
+              id: 'revenue',
+              label: 'Revenue',
+              dataType: 'number',
+              role: 'measure',
+              defaultAggregation: 'sum',
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(response.capabilities.supportedFilterOperators).toContain('between');
+    expect(response.datasets[0].source?.type).toBe('table');
+  });
+
+  it('can construct a query response envelope', () => {
+    const response: ProbeQueryResponse = {
+      protocolVersion: PROBE_PROTOCOL_VERSION,
+      capabilities,
+      columns: [
+        { fieldId: 'region', label: 'Region', dataType: 'string' },
+        { fieldId: 'revenue', label: 'Revenue', dataType: 'number' },
+      ],
+      rows: [{ region: 'North', revenue: 12_500 }],
+      totalRows: 1,
+    };
+
+    expect(response.capabilities.supportedAggregations).toContain('count_distinct');
+    expect(response.rows[0].region).toBe('North');
   });
 });

--- a/packages/designer/src/preview/ChartPreview.tsx
+++ b/packages/designer/src/preview/ChartPreview.tsx
@@ -567,66 +567,110 @@ function remapSampleData(
 // ─── Chart Preview Component ─────────────────────────────────
 
 /**
- * Extract a flat map of field roles → field ids from the widget config.
- * This tells the host app which columns are needed for the preview query.
+ * Extract a flat map of field roles → field ids **from user-bound puckProps only**.
+ *
+ * Critical: this MUST NOT pull in values from DEFAULT_CONFIGS, because those
+ * defaults are placeholder names from sample data (e.g. `comparisonField:
+ * 'comparison'`, `yFields: ['revenue', 'orders']`) that do not exist in the
+ * host's actual datasets. Including them makes the preview POST fields the
+ * backend doesn't recognize, which yields 400s and silent fallback to sample.
+ *
+ * When the user hasn't bound any field yet, this returns `{}` and the caller
+ * skips the fetch entirely — the chart then renders static sample data, which
+ * is the intended "placeholder" state until real bindings exist.
  */
-function extractFieldsFromConfig(
-  config: Record<string, unknown>,
+function extractFieldsFromUserProps(
+  puckProps: Record<string, unknown>,
 ): Record<string, string | string[] | undefined> {
-  const fields: Record<string, string | string[] | undefined> = {};
   const str = (v: unknown) => (typeof v === 'string' && v.length > 0 ? v : undefined);
-  const strArr = (v: unknown) =>
-    Array.isArray(v)
-      ? v.filter((s): s is string => typeof s === 'string' && s.length > 0)
-      : undefined;
+  const fields: Record<string, string | string[] | undefined> = {};
   const metricFieldIds = new Set<string>();
 
-  const addMetricField = (value: unknown) => {
-    const fieldId = str(value);
-    if (fieldId) {
-      metricFieldIds.add(fieldId);
-    }
-  };
+  const xAxisField = str(puckProps.xAxisField);
+  if (xAxisField) fields.xField = xAxisField;
 
-  const addMetricFields = (value: unknown) => {
-    for (const fieldId of strArr(value) ?? []) {
-      metricFieldIds.add(fieldId);
-    }
-  };
+  const yAxisField = str(puckProps.yAxisField);
+  if (yAxisField) {
+    fields.yFields = [yAxisField];
+    fields.yField = yAxisField;
+    metricFieldIds.add(yAxisField);
+  }
 
-  fields.xField = str(config.xField);
-  fields.yFields = strArr(config.yFields);
-  fields.yField = str(config.yField);
-  fields.nameField = str(config.nameField);
-  fields.valueField = str(config.valueField);
-  fields.categoryField = str(config.categoryField);
-  fields.sizeField = str(config.sizeField);
-  fields.sourceField = str(config.sourceField);
-  fields.targetField = str(config.targetField);
-  fields.seriesField = str(config.seriesField);
-  fields.colorGroupField = str(config.colorGroupField);
-  fields.barFields = strArr(config.barFields);
-  fields.lineFields = strArr(config.lineFields);
-  fields.comparisonField = str(config.comparisonField);
-  fields.aggregation = str(config.aggregation);
+  const nameField = str(puckProps.nameField);
+  if (nameField) fields.nameField = nameField;
 
-  addMetricField(config.yField);
-  addMetricFields(config.yFields);
-  addMetricField(config.valueField);
-  addMetricField(config.comparisonField);
-  addMetricField(config.sizeField);
-  addMetricFields(config.barFields);
-  addMetricFields(config.lineFields);
+  const valueField = str(puckProps.valueField);
+  if (valueField) {
+    fields.valueField = valueField;
+    metricFieldIds.add(valueField);
+  }
+
+  const categoryField = str(puckProps.categoryField);
+  if (categoryField) {
+    fields.categoryField = categoryField;
+    if (!fields.nameField) fields.nameField = categoryField;
+  }
+
+  const sizeField = str(puckProps.sizeField);
+  if (sizeField) {
+    fields.sizeField = sizeField;
+    metricFieldIds.add(sizeField);
+  }
+
+  const sourceField = str(puckProps.sourceField);
+  if (sourceField) fields.sourceField = sourceField;
+
+  const targetField = str(puckProps.targetField);
+  if (targetField) fields.targetField = targetField;
+
+  const seriesField = str(puckProps.seriesField);
+  if (seriesField) fields.seriesField = seriesField;
+
+  const colorGroupField = str(puckProps.colorGroupField);
+  if (colorGroupField) fields.colorGroupField = colorGroupField;
+
+  const barField = str(puckProps.barField);
+  if (barField) {
+    fields.barFields = [barField];
+    metricFieldIds.add(barField);
+  }
+
+  const lineField = str(puckProps.lineField);
+  if (lineField) {
+    fields.lineFields = [lineField];
+    metricFieldIds.add(lineField);
+  }
+
+  const comparisonField = str(puckProps.comparisonField);
+  if (comparisonField) {
+    fields.comparisonField = comparisonField;
+    metricFieldIds.add(comparisonField);
+  }
+
+  const parentField = str(puckProps.parentField);
+  if (parentField) fields.parentField = parentField;
+
+  const aggregation = str(puckProps.aggregation);
+  if (aggregation) fields.aggregation = aggregation;
 
   if (metricFieldIds.size > 0) {
     fields.metricFields = Array.from(metricFieldIds);
   }
 
-  // Remove undefined entries
-  for (const key of Object.keys(fields)) {
-    if (fields[key] === undefined) delete fields[key];
-  }
   return fields;
+}
+
+const NON_BINDING_KEYS = new Set(['aggregation', 'metricFields']);
+
+function hasUserBoundAnyField(fields: Record<string, string | string[] | undefined>): boolean {
+  for (const [key, value] of Object.entries(fields)) {
+    if (NON_BINDING_KEYS.has(key)) continue;
+    if (value === undefined) continue;
+    if (Array.isArray(value) ? value.length > 0 : value.length > 0) {
+      return true;
+    }
+  }
+  return false;
 }
 
 interface ChartPreviewProps {
@@ -645,15 +689,17 @@ export function ChartPreview({ widgetType, puckProps, fallbackIcon }: ChartPrevi
   const fetchPreviewData = usePreviewData();
   const config = useMemo(() => buildWidgetConfig(widgetType, puckProps), [widgetType, puckProps]);
 
-  // Build the data request from current field config
+  // Build the data request from the user's explicit bindings only.
+  // IMPORTANT: we read from `puckProps` (user input) not `config` (merged with
+  // sample-data defaults) so we never POST field names that don't exist in
+  // the host's dataset.
   const datasetRef = (puckProps.datasetRef as string) || '';
   const dataRequest = useMemo<PreviewDataRequest | null>(() => {
     if (!fetchPreviewData || !datasetRef) return null;
-    return {
-      datasetRef,
-      fields: extractFieldsFromConfig(config),
-    };
-  }, [fetchPreviewData, datasetRef, config]);
+    const userFields = extractFieldsFromUserProps(puckProps);
+    if (!hasUserBoundAnyField(userFields)) return null;
+    return { datasetRef, fields: userFields };
+  }, [fetchPreviewData, datasetRef, puckProps]);
 
   // Fetch real data from host when available
   const [hostData, setHostData] = useState<Record<string, unknown>[] | null>(null);

--- a/packages/designer/src/preview/ChartPreview.tsx
+++ b/packages/designer/src/preview/ChartPreview.tsx
@@ -41,15 +41,15 @@ const WIDGET_COMPONENTS: Record<string, ComponentType<WidgetProps>> = {
   'scatter-chart': ScatterChartWidget,
   'area-chart': AreaChartWidget,
   'combo-chart': ComboChartWidget,
-  'heatmap': HeatmapWidget,
+  heatmap: HeatmapWidget,
   'radar-chart': RadarChartWidget,
   'funnel-chart': FunnelChartWidget,
-  'treemap': TreemapWidget,
-  'sankey': SankeyWidget,
-  'waterfall': WaterfallWidget,
+  treemap: TreemapWidget,
+  sankey: SankeyWidget,
+  waterfall: WaterfallWidget,
   'box-plot': BoxPlotWidget,
-  'gauge': GaugeWidget,
-  'table': TableWidget,
+  gauge: GaugeWidget,
+  table: TableWidget,
   'kpi-card': KPICardWidget,
 };
 
@@ -63,17 +63,20 @@ const DEFAULT_CONFIGS: Record<string, Record<string, unknown>> = {
   'scatter-chart': { xField: 'x', yField: 'y', sizeField: 'size' },
   'area-chart': { xField: 'month', yFields: ['revenue', 'orders'], area: true, smooth: true },
   'combo-chart': { xField: 'month', barFields: ['bar'], lineFields: ['line'] },
-  'heatmap': { xField: 'x', yField: 'y', valueField: 'value' },
-  'radar-chart': { nameField: 'name', valueFields: ['Speed', 'Strength', 'Defense', 'Magic', 'Agility', 'Luck'] },
+  heatmap: { xField: 'x', yField: 'y', valueField: 'value' },
+  'radar-chart': {
+    nameField: 'name',
+    valueFields: ['Speed', 'Strength', 'Defense', 'Magic', 'Agility', 'Luck'],
+  },
   'funnel-chart': { nameField: 'stage', valueField: 'value' },
-  'treemap': { nameField: 'name', valueField: 'value', parentField: 'parent' },
-  'sankey': { sourceField: 'source', targetField: 'target', valueField: 'value' },
-  'waterfall': { categoryField: 'category', valueField: 'value' },
+  treemap: { nameField: 'name', valueField: 'value', parentField: 'parent' },
+  sankey: { sourceField: 'source', targetField: 'target', valueField: 'value' },
+  waterfall: { categoryField: 'category', valueField: 'value' },
   'box-plot': { categoryField: 'category' },
-  'gauge': { valueField: 'value', min: 0, max: 100 },
-  'table': {},
+  gauge: { valueField: 'value', min: 0, max: 100 },
+  table: {},
   'kpi-card': { valueField: 'value', comparisonField: 'comparison' },
-  'alerts': {
+  alerts: {
     titleField: 'alert_title',
     messageField: 'alert_message',
     severityField: 'severity',
@@ -109,7 +112,10 @@ const ALERT_LAYOUT_STYLES: Record<AlertLayout, React.CSSProperties> = {
   },
 };
 
-const ALERT_SEVERITY_STYLES: Record<AlertSeverity, { accent: string; background: string; border: string }> = {
+const ALERT_SEVERITY_STYLES: Record<
+  AlertSeverity,
+  { accent: string; background: string; border: string }
+> = {
   info: {
     accent: '#1d4ed8',
     background: '#eff6ff',
@@ -158,13 +164,15 @@ interface AlertsPreviewProps {
 
 function AlertsPreview({ title, data, config, fallbackIcon }: AlertsPreviewProps) {
   const titleField = typeof config.titleField === 'string' ? config.titleField : 'alert_title';
-  const messageField = typeof config.messageField === 'string' ? config.messageField : 'alert_message';
-  const severityField = typeof config.severityField === 'string' ? config.severityField : 'severity';
-  const timestampField = typeof config.timestampField === 'string' ? config.timestampField : 'detected_at';
+  const messageField =
+    typeof config.messageField === 'string' ? config.messageField : 'alert_message';
+  const severityField =
+    typeof config.severityField === 'string' ? config.severityField : 'severity';
+  const timestampField =
+    typeof config.timestampField === 'string' ? config.timestampField : 'detected_at';
   const layout = config.layout === 'wrap' || config.layout === 'inline' ? config.layout : 'stack';
-  const maxItems = typeof config.maxItems === 'number' && config.maxItems > 0
-    ? config.maxItems
-    : data.length;
+  const maxItems =
+    typeof config.maxItems === 'number' && config.maxItems > 0 ? config.maxItems : data.length;
   const emptyState = config.emptyState === 'hide' ? 'hide' : 'placeholder';
   const showTimestamp = config.showTimestamp !== false;
   const defaultSeverity = normalizeAlertSeverity(config.defaultSeverity, 'info');
@@ -188,7 +196,9 @@ function AlertsPreview({ title, data, config, fallbackIcon }: AlertsPreviewProps
         fontFamily: 'sans-serif',
       }}
     >
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
+      <div
+        style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}
+      >
         <strong style={{ color: '#0f172a', fontSize: 15 }}>{title}</strong>
         <span style={{ color: '#64748b', fontSize: 12 }}>
           {visibleAlerts.length}
@@ -238,10 +248,19 @@ function AlertsPreview({ title, data, config, fallbackIcon }: AlertsPreviewProps
                   gap: 8,
                 }}
               >
-                <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'flex-start' }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    gap: 12,
+                    alignItems: 'flex-start',
+                  }}
+                >
                   <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
                     <strong style={{ color: '#0f172a', fontSize: 14 }}>{alertTitle}</strong>
-                    <span style={{ color: '#334155', fontSize: 12, lineHeight: 1.45 }}>{alertMessage}</span>
+                    <span style={{ color: '#334155', fontSize: 12, lineHeight: 1.45 }}>
+                      {alertMessage}
+                    </span>
                   </div>
                   <span
                     style={{
@@ -278,7 +297,7 @@ function AlertsPreview({ title, data, config, fallbackIcon }: AlertsPreviewProps
  */
 function buildWidgetConfig(
   widgetType: string,
-  puckProps: Record<string, unknown>
+  puckProps: Record<string, unknown>,
 ): Record<string, unknown> {
   const defaults = DEFAULT_CONFIGS[widgetType] ?? {};
 
@@ -298,7 +317,7 @@ function buildWidgetConfig(
   }
 
   // Override defaults if user has set actual field references (non-empty strings)
-  const s = (v: unknown) => typeof v === 'string' && v.length > 0 ? v : undefined;
+  const s = (v: unknown) => (typeof v === 'string' && v.length > 0 ? v : undefined);
   if (s(puckProps.xAxisField)) config.xField = puckProps.xAxisField;
   if (s(puckProps.yAxisField)) {
     config.yFields = [puckProps.yAxisField as string];
@@ -312,6 +331,7 @@ function buildWidgetConfig(
   if (s(puckProps.valueField)) config.valueField = puckProps.valueField;
   if (s(puckProps.sizeField)) config.sizeField = puckProps.sizeField;
   if (s(puckProps.colorGroupField)) config.colorGroupField = puckProps.colorGroupField;
+  if (s(puckProps.aggregation)) config.aggregation = puckProps.aggregation;
   if (s(puckProps.nameField)) config.nameField = puckProps.nameField;
   if (s(puckProps.parentField)) config.parentField = puckProps.parentField;
   if (s(puckProps.sourceField)) config.sourceField = puckProps.sourceField;
@@ -324,7 +344,8 @@ function buildWidgetConfig(
   if (s(puckProps.severityField)) config.severityField = puckProps.severityField;
   if (s(puckProps.timestampField)) config.timestampField = puckProps.timestampField;
   if (s(puckProps.layout)) config.layout = puckProps.layout;
-  if (puckProps.maxItems != null && puckProps.maxItems !== '') config.maxItems = Number(puckProps.maxItems);
+  if (puckProps.maxItems != null && puckProps.maxItems !== '')
+    config.maxItems = Number(puckProps.maxItems);
   if (s(puckProps.emptyState)) config.emptyState = puckProps.emptyState;
   if (puckProps.showTimestamp === 'true') config.showTimestamp = true;
   else if (puckProps.showTimestamp === 'false') config.showTimestamp = false;
@@ -349,8 +370,10 @@ function buildWidgetConfig(
   if (s(puckProps.xAxisLabelRotate) && puckProps.xAxisLabelRotate !== '0') {
     config.xAxisLabelRotate = Number(puckProps.xAxisLabelRotate);
   }
-  if (puckProps.yAxisMin != null && puckProps.yAxisMin !== '') config.yAxisMin = Number(puckProps.yAxisMin);
-  if (puckProps.yAxisMax != null && puckProps.yAxisMax !== '') config.yAxisMax = Number(puckProps.yAxisMax);
+  if (puckProps.yAxisMin != null && puckProps.yAxisMin !== '')
+    config.yAxisMin = Number(puckProps.yAxisMin);
+  if (puckProps.yAxisMax != null && puckProps.yAxisMax !== '')
+    config.yAxisMax = Number(puckProps.yAxisMax);
   if (puckProps.logAxis === 'true') config.logAxis = true;
   else if (puckProps.logAxis === 'false') config.logAxis = false;
   if (puckProps.zoomable === 'true') config.zoomable = true;
@@ -360,7 +383,8 @@ function buildWidgetConfig(
   // Line / Area
   if (puckProps.showMarkers === 'true') config.showMarkers = true;
   else if (puckProps.showMarkers === 'false') config.showMarkers = false;
-  if (puckProps.markerSize != null && puckProps.markerSize !== '') config.markerSize = Number(puckProps.markerSize);
+  if (puckProps.markerSize != null && puckProps.markerSize !== '')
+    config.markerSize = Number(puckProps.markerSize);
   if (s(puckProps.step)) config.step = puckProps.step;
   if (puckProps.connectNulls === 'true') config.connectNulls = true;
   else if (puckProps.connectNulls === 'false') config.connectNulls = false;
@@ -368,24 +392,36 @@ function buildWidgetConfig(
   // Bar
   if (s(puckProps.barWidth)) config.barWidth = puckProps.barWidth;
   if (s(puckProps.barGap)) config.barGap = puckProps.barGap;
-  if (puckProps.borderRadius != null && puckProps.borderRadius !== '' && Number(puckProps.borderRadius) > 0) config.borderRadius = Number(puckProps.borderRadius);
-  if (puckProps.barMinHeight != null && Number(puckProps.barMinHeight) > 0) config.barMinHeight = Number(puckProps.barMinHeight);
+  if (
+    puckProps.borderRadius != null &&
+    puckProps.borderRadius !== '' &&
+    Number(puckProps.borderRadius) > 0
+  )
+    config.borderRadius = Number(puckProps.borderRadius);
+  if (puckProps.barMinHeight != null && Number(puckProps.barMinHeight) > 0)
+    config.barMinHeight = Number(puckProps.barMinHeight);
   // Pie
-  if (puckProps.innerRadius != null && puckProps.innerRadius !== '') config.innerRadius = Number(puckProps.innerRadius);
-  if (puckProps.outerRadius != null && puckProps.outerRadius !== '') config.outerRadius = Number(puckProps.outerRadius);
+  if (puckProps.innerRadius != null && puckProps.innerRadius !== '')
+    config.innerRadius = Number(puckProps.innerRadius);
+  if (puckProps.outerRadius != null && puckProps.outerRadius !== '')
+    config.outerRadius = Number(puckProps.outerRadius);
   if (s(puckProps.labelPosition)) config.labelPosition = puckProps.labelPosition;
-  if (puckProps.padAngle != null && Number(puckProps.padAngle) > 0) config.padAngle = Number(puckProps.padAngle);
+  if (puckProps.padAngle != null && Number(puckProps.padAngle) > 0)
+    config.padAngle = Number(puckProps.padAngle);
   if (puckProps.variant === 'donut') config.donut = true;
   else if (puckProps.variant === 'pie') config.donut = false;
   if (puckProps.variant === 'rose') config.roseType = 'radius';
   // Scatter
-  if (puckProps.symbolSize != null && puckProps.symbolSize !== '') config.symbolSize = Number(puckProps.symbolSize);
+  if (puckProps.symbolSize != null && puckProps.symbolSize !== '')
+    config.symbolSize = Number(puckProps.symbolSize);
   if (s(puckProps.opacity)) config.opacity = Number(puckProps.opacity);
   // Combo
   if (puckProps.lineSmooth === 'false') config.lineSmooth = false;
-  if (puckProps.barBorderRadius != null && Number(puckProps.barBorderRadius) > 0) config.barBorderRadius = Number(puckProps.barBorderRadius);
+  if (puckProps.barBorderRadius != null && Number(puckProps.barBorderRadius) > 0)
+    config.barBorderRadius = Number(puckProps.barBorderRadius);
   // Heatmap
-  if (puckProps.cellBorderWidth != null && puckProps.cellBorderWidth !== '') config.cellBorderWidth = Number(puckProps.cellBorderWidth);
+  if (puckProps.cellBorderWidth != null && puckProps.cellBorderWidth !== '')
+    config.cellBorderWidth = Number(puckProps.cellBorderWidth);
   if (s(puckProps.cellBorderColor)) config.cellBorderColor = puckProps.cellBorderColor;
   // Radar
   if (s(puckProps.shape)) config.shape = puckProps.shape;
@@ -397,11 +433,15 @@ function buildWidgetConfig(
   // Treemap
   if (puckProps.showUpperLabel === 'true') config.showUpperLabel = true;
   else if (puckProps.showUpperLabel === 'false') config.showUpperLabel = false;
-  if (puckProps.maxDepth != null && Number(puckProps.maxDepth) > 0) config.maxDepth = Number(puckProps.maxDepth);
-  if (puckProps.borderWidth != null && Number(puckProps.borderWidth) > 0) config.borderWidth = Number(puckProps.borderWidth);
+  if (puckProps.maxDepth != null && Number(puckProps.maxDepth) > 0)
+    config.maxDepth = Number(puckProps.maxDepth);
+  if (puckProps.borderWidth != null && Number(puckProps.borderWidth) > 0)
+    config.borderWidth = Number(puckProps.borderWidth);
   // Sankey
-  if (puckProps.nodeWidth != null && puckProps.nodeWidth !== '') config.nodeWidth = Number(puckProps.nodeWidth);
-  if (puckProps.nodeGap != null && puckProps.nodeGap !== '') config.nodeGap = Number(puckProps.nodeGap);
+  if (puckProps.nodeWidth != null && puckProps.nodeWidth !== '')
+    config.nodeWidth = Number(puckProps.nodeWidth);
+  if (puckProps.nodeGap != null && puckProps.nodeGap !== '')
+    config.nodeGap = Number(puckProps.nodeGap);
   if (s(puckProps.orient)) config.orient = puckProps.orient;
   // Waterfall
   if (s(puckProps.totalLabel)) config.totalLabel = puckProps.totalLabel;
@@ -411,11 +451,14 @@ function buildWidgetConfig(
   // BoxPlot
   if (s(puckProps.boxWidth)) config.boxWidth = puckProps.boxWidth;
   // Gauge
-  if (puckProps.startAngle != null && puckProps.startAngle !== '') config.startAngle = Number(puckProps.startAngle);
-  if (puckProps.endAngle != null && puckProps.endAngle !== '') config.endAngle = Number(puckProps.endAngle);
+  if (puckProps.startAngle != null && puckProps.startAngle !== '')
+    config.startAngle = Number(puckProps.startAngle);
+  if (puckProps.endAngle != null && puckProps.endAngle !== '')
+    config.endAngle = Number(puckProps.endAngle);
   if (puckProps.roundCap === 'true') config.roundCap = true;
   else if (puckProps.roundCap === 'false') config.roundCap = false;
-  if (puckProps.splitCount != null && puckProps.splitCount !== '') config.splitCount = Number(puckProps.splitCount);
+  if (puckProps.splitCount != null && puckProps.splitCount !== '')
+    config.splitCount = Number(puckProps.splitCount);
   if (puckProps.progressMode === 'true') config.progressMode = true;
   else if (puckProps.progressMode === 'false') config.progressMode = false;
   // Table
@@ -449,14 +492,19 @@ function buildWidgetConfig(
  */
 function buildFieldRemap(
   widgetType: string,
-  config: Record<string, unknown>
+  config: Record<string, unknown>,
 ): Record<string, string> {
   const defaults = DEFAULT_CONFIGS[widgetType] ?? {};
   const remap: Record<string, string> = {};
 
   const addRemap = (configKey: string, defaultKey: string | undefined) => {
     const userVal = config[configKey];
-    if (typeof userVal === 'string' && userVal.length > 0 && typeof defaultKey === 'string' && defaultKey !== userVal) {
+    if (
+      typeof userVal === 'string' &&
+      userVal.length > 0 &&
+      typeof defaultKey === 'string' &&
+      defaultKey !== userVal
+    ) {
       remap[defaultKey] = userVal;
     }
   };
@@ -501,7 +549,7 @@ function buildFieldRemap(
  */
 function remapSampleData(
   data: Record<string, unknown>[],
-  fieldRemap: Record<string, string>
+  fieldRemap: Record<string, string>,
 ): Record<string, unknown>[] {
   const entries = Object.entries(fieldRemap);
   if (entries.length === 0) return data;
@@ -523,11 +571,28 @@ function remapSampleData(
  * This tells the host app which columns are needed for the preview query.
  */
 function extractFieldsFromConfig(
-  config: Record<string, unknown>
+  config: Record<string, unknown>,
 ): Record<string, string | string[] | undefined> {
   const fields: Record<string, string | string[] | undefined> = {};
-  const str = (v: unknown) => typeof v === 'string' && v.length > 0 ? v : undefined;
-  const strArr = (v: unknown) => Array.isArray(v) ? v.filter((s): s is string => typeof s === 'string' && s.length > 0) : undefined;
+  const str = (v: unknown) => (typeof v === 'string' && v.length > 0 ? v : undefined);
+  const strArr = (v: unknown) =>
+    Array.isArray(v)
+      ? v.filter((s): s is string => typeof s === 'string' && s.length > 0)
+      : undefined;
+  const metricFieldIds = new Set<string>();
+
+  const addMetricField = (value: unknown) => {
+    const fieldId = str(value);
+    if (fieldId) {
+      metricFieldIds.add(fieldId);
+    }
+  };
+
+  const addMetricFields = (value: unknown) => {
+    for (const fieldId of strArr(value) ?? []) {
+      metricFieldIds.add(fieldId);
+    }
+  };
 
   fields.xField = str(config.xField);
   fields.yFields = strArr(config.yFields);
@@ -543,6 +608,19 @@ function extractFieldsFromConfig(
   fields.barFields = strArr(config.barFields);
   fields.lineFields = strArr(config.lineFields);
   fields.comparisonField = str(config.comparisonField);
+  fields.aggregation = str(config.aggregation);
+
+  addMetricField(config.yField);
+  addMetricFields(config.yFields);
+  addMetricField(config.valueField);
+  addMetricField(config.comparisonField);
+  addMetricField(config.sizeField);
+  addMetricFields(config.barFields);
+  addMetricFields(config.lineFields);
+
+  if (metricFieldIds.size > 0) {
+    fields.metricFields = Array.from(metricFieldIds);
+  }
 
   // Remove undefined entries
   for (const key of Object.keys(fields)) {
@@ -565,10 +643,7 @@ export function ChartPreview({ widgetType, puckProps, fallbackIcon }: ChartPrevi
   const Component = WIDGET_COMPONENTS[widgetType];
   const sampleData = useMemo(() => getSampleData(widgetType), [widgetType]);
   const fetchPreviewData = usePreviewData();
-  const config = useMemo(
-    () => buildWidgetConfig(widgetType, puckProps),
-    [widgetType, puckProps]
-  );
+  const config = useMemo(() => buildWidgetConfig(widgetType, puckProps), [widgetType, puckProps]);
 
   // Build the data request from current field config
   const datasetRef = (puckProps.datasetRef as string) || '';
@@ -590,24 +665,28 @@ export function ChartPreview({ widgetType, puckProps, fallbackIcon }: ChartPrevi
     let cancelled = false;
     const result = fetchPreviewData(dataRequest);
     if (result instanceof Promise) {
-      result.then((rows) => {
-        if (!cancelled) setHostData(rows);
-      }).catch(() => {
-        if (!cancelled) setHostData(null);
-      });
+      result
+        .then((rows) => {
+          if (!cancelled) setHostData(rows);
+        })
+        .catch(() => {
+          if (!cancelled) setHostData(null);
+        });
     } else {
       setHostData(result);
     }
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [dataRequest, fetchPreviewData]);
 
   // Use host data when available, otherwise fall back to remapped sample data
   const fieldRemap = useMemo(() => buildFieldRemap(widgetType, config), [widgetType, config]);
   const fallbackData = useMemo(
-    () => sampleData ? remapSampleData(sampleData.data, fieldRemap) : [],
-    [sampleData, fieldRemap]
+    () => (sampleData ? remapSampleData(sampleData.data, fieldRemap) : []),
+    [sampleData, fieldRemap],
   );
-  const previewData = (hostData && hostData.length > 0) ? hostData : fallbackData;
+  const previewData = hostData && hostData.length > 0 ? hostData : fallbackData;
 
   const displayTitle = (puckProps.title as string) || widgetType;
 
@@ -642,7 +721,7 @@ export function ChartPreview({ widgetType, puckProps, fallbackIcon }: ChartPrevi
       },
       React.createElement('span', { style: { fontSize: 32 } }, fallbackIcon),
       React.createElement('span', { style: { fontWeight: 600, fontSize: 14 } }, displayTitle),
-      React.createElement('span', { style: { fontSize: 12, color: '#999' } }, widgetType)
+      React.createElement('span', { style: { fontSize: 12, color: '#999' } }, widgetType),
     );
   }
 
@@ -677,11 +756,15 @@ export function ChartPreview({ widgetType, puckProps, fallbackIcon }: ChartPrevi
           'div',
           { style: { padding: 16, color: '#999', textAlign: 'center' as const } },
           React.createElement('span', { style: { fontSize: 24 } }, fallbackIcon),
-          React.createElement('div', { style: { fontSize: 12, marginTop: 4 } }, 'Preview unavailable')
+          React.createElement(
+            'div',
+            { style: { fontSize: 12, marginTop: 4 } },
+            'Preview unavailable',
+          ),
         ),
       },
-      React.createElement(Component, widgetProps)
-    )
+      React.createElement(Component, widgetProps),
+    ),
   );
 }
 

--- a/packages/designer/test/preview-data-provider.test.tsx
+++ b/packages/designer/test/preview-data-provider.test.tsx
@@ -14,26 +14,42 @@ import { render, act } from '@testing-library/react';
 const mockChartWidget = vi.fn((props: Record<string, unknown>) =>
   React.createElement('div', {
     'data-testid': `chart-${props.widgetType}`,
-  })
+  }),
 );
 
 vi.mock('@supersubset/charts-echarts', () => ({
-  LineChartWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'line-chart' }),
-  BarChartWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'bar-chart' }),
-  PieChartWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'pie-chart' }),
-  ScatterChartWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'scatter-chart' }),
-  AreaChartWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'area-chart' }),
-  ComboChartWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'combo-chart' }),
-  HeatmapWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'heatmap' }),
-  RadarChartWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'radar-chart' }),
-  FunnelChartWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'funnel-chart' }),
-  TreemapWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'treemap' }),
-  SankeyWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'sankey' }),
-  WaterfallWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'waterfall' }),
-  BoxPlotWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'box-plot' }),
-  GaugeWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'gauge' }),
-  TableWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'table' }),
-  KPICardWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'kpi-card' }),
+  LineChartWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'line-chart' }),
+  BarChartWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'bar-chart' }),
+  PieChartWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'pie-chart' }),
+  ScatterChartWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'scatter-chart' }),
+  AreaChartWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'area-chart' }),
+  ComboChartWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'combo-chart' }),
+  HeatmapWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'heatmap' }),
+  RadarChartWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'radar-chart' }),
+  FunnelChartWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'funnel-chart' }),
+  TreemapWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'treemap' }),
+  SankeyWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'sankey' }),
+  WaterfallWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'waterfall' }),
+  BoxPlotWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'box-plot' }),
+  GaugeWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'gauge' }),
+  TableWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'table' }),
+  KPICardWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'kpi-card' }),
 }));
 
 vi.mock('@supersubset/runtime', () => ({}));
@@ -47,7 +63,7 @@ import { PreviewDataProvider, type PreviewDataRequest } from '../src/context/Pre
 const DATABASE_ROWS = [
   { month: 'Jan', revenue: 8500, orders: 42, units: 120, category: 'Apparel' },
   { month: 'Feb', revenue: 9200, orders: 48, units: 135, category: 'Footwear' },
-  { month: 'Mar', revenue: 7800, orders: 38, units: 98,  category: 'Accessories' },
+  { month: 'Mar', revenue: 7800, orders: 38, units: 98, category: 'Accessories' },
   { month: 'Apr', revenue: 11000, orders: 55, units: 160, category: 'Apparel' },
   { month: 'May', revenue: 10500, orders: 52, units: 145, category: 'Footwear' },
   { month: 'Jun', revenue: 12300, orders: 61, units: 178, category: 'Accessories' },
@@ -84,7 +100,7 @@ function mockFetchPreviewData(request: PreviewDataRequest): Record<string, unkno
 function renderWithProvider(
   widgetType: string,
   puckProps: Record<string, unknown>,
-  fetcher: (req: PreviewDataRequest) => Record<string, unknown>[]
+  fetcher: (req: PreviewDataRequest) => Record<string, unknown>[],
 ) {
   mockChartWidget.mockClear();
   const fetchSpy = vi.fn(fetcher);
@@ -99,8 +115,8 @@ function renderWithProvider(
           widgetType,
           puckProps: { title: 'Test', datasetRef: 'test-orders', ...puckProps },
           fallbackIcon: '📊',
-        })
-      )
+        }),
+      ),
     );
   });
 
@@ -118,7 +134,7 @@ function renderWithoutProvider(widgetType: string, puckProps: Record<string, unk
       widgetType,
       puckProps: { title: 'Test', ...puckProps },
       fallbackIcon: '📊',
-    })
+    }),
   );
   const lastCall = mockChartWidget.mock.calls[mockChartWidget.mock.calls.length - 1];
   return lastCall?.[0]?.data as Record<string, unknown>[];
@@ -129,23 +145,34 @@ function renderWithoutProvider(widgetType: string, puckProps: Record<string, unk
 describe('ChartPreview — real data from host', () => {
   describe('data provider integration', () => {
     it('calls fetchPreviewData with the correct dataset ref and fields', () => {
-      const { fetchSpy } = renderWithProvider('line-chart', {
-        xAxisField: 'month',
-        yAxisField: 'revenue',
-      }, mockFetchPreviewData);
+      const { fetchSpy } = renderWithProvider(
+        'line-chart',
+        {
+          xAxisField: 'month',
+          yAxisField: 'revenue',
+          aggregation: 'avg',
+        },
+        mockFetchPreviewData,
+      );
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
       const request = fetchSpy.mock.calls[0][0] as PreviewDataRequest;
       expect(request.datasetRef).toBe('test-orders');
       expect(request.fields.xField).toBe('month');
       expect(request.fields.yFields).toEqual(['revenue']);
+      expect(request.fields.metricFields).toEqual(['revenue']);
+      expect(request.fields.aggregation).toBe('avg');
     });
 
     it('passes host data to chart widget instead of sample data', () => {
-      const { widgetData } = renderWithProvider('line-chart', {
-        xAxisField: 'month',
-        yAxisField: 'revenue',
-      }, mockFetchPreviewData);
+      const { widgetData } = renderWithProvider(
+        'line-chart',
+        {
+          xAxisField: 'month',
+          yAxisField: 'revenue',
+        },
+        mockFetchPreviewData,
+      );
 
       // Host returns our DATABASE_ROWS projected to month + revenue
       expect(widgetData).toBeDefined();
@@ -182,8 +209,8 @@ describe('ChartPreview — real data from host', () => {
               widgetType: 'line-chart',
               puckProps: { title: 'Test', xAxisField: 'month', yAxisField: 'revenue' },
               fallbackIcon: '📊',
-            })
-          )
+            }),
+          ),
         );
       });
 
@@ -201,19 +228,27 @@ describe('ChartPreview — real data from host', () => {
   describe('line chart — changing Y axis shows different data', () => {
     it('revenue data values differ from units data values', () => {
       // Step 1: Render with yAxisField = revenue
-      const { widgetData: revenueData } = renderWithProvider('line-chart', {
-        xAxisField: 'month',
-        yAxisField: 'revenue',
-      }, mockFetchPreviewData);
+      const { widgetData: revenueData } = renderWithProvider(
+        'line-chart',
+        {
+          xAxisField: 'month',
+          yAxisField: 'revenue',
+        },
+        mockFetchPreviewData,
+      );
 
       const revenueValues = revenueData!.map((r) => r.revenue);
       expect(revenueValues).toEqual([8500, 9200, 7800, 11000, 10500, 12300]);
 
       // Step 2: Render with yAxisField = units
-      const { widgetData: unitsData } = renderWithProvider('line-chart', {
-        xAxisField: 'month',
-        yAxisField: 'units',
-      }, mockFetchPreviewData);
+      const { widgetData: unitsData } = renderWithProvider(
+        'line-chart',
+        {
+          xAxisField: 'month',
+          yAxisField: 'units',
+        },
+        mockFetchPreviewData,
+      );
 
       const unitsValues = unitsData!.map((r) => r.units);
       expect(unitsValues).toEqual([120, 135, 98, 160, 145, 178]);
@@ -223,18 +258,26 @@ describe('ChartPreview — real data from host', () => {
     });
 
     it('the data rows contain the correct field key for the selected Y axis', () => {
-      const { widgetData: revenueData, widgetConfig: revenueConfig } = renderWithProvider('line-chart', {
-        xAxisField: 'month',
-        yAxisField: 'revenue',
-      }, mockFetchPreviewData);
+      const { widgetData: revenueData, widgetConfig: revenueConfig } = renderWithProvider(
+        'line-chart',
+        {
+          xAxisField: 'month',
+          yAxisField: 'revenue',
+        },
+        mockFetchPreviewData,
+      );
 
       expect(revenueConfig!.yFields).toEqual(['revenue']);
       expect(revenueData![0]).toHaveProperty('revenue');
 
-      const { widgetData: unitsData, widgetConfig: unitsConfig } = renderWithProvider('line-chart', {
-        xAxisField: 'month',
-        yAxisField: 'units',
-      }, mockFetchPreviewData);
+      const { widgetData: unitsData, widgetConfig: unitsConfig } = renderWithProvider(
+        'line-chart',
+        {
+          xAxisField: 'month',
+          yAxisField: 'units',
+        },
+        mockFetchPreviewData,
+      );
 
       expect(unitsConfig!.yFields).toEqual(['units']);
       expect(unitsData![0]).toHaveProperty('units');
@@ -243,23 +286,38 @@ describe('ChartPreview — real data from host', () => {
 
   describe('line chart — changing X axis shows different data', () => {
     it('changing xAxisField from month to category returns category data', () => {
-      const { widgetData: monthData, widgetConfig: monthConfig } = renderWithProvider('line-chart', {
-        xAxisField: 'month',
-        yAxisField: 'revenue',
-      }, mockFetchPreviewData);
+      const { widgetData: monthData, widgetConfig: monthConfig } = renderWithProvider(
+        'line-chart',
+        {
+          xAxisField: 'month',
+          yAxisField: 'revenue',
+        },
+        mockFetchPreviewData,
+      );
 
       expect(monthConfig!.xField).toBe('month');
       const months = monthData!.map((r) => r.month);
       expect(months).toEqual(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun']);
 
-      const { widgetData: catData, widgetConfig: catConfig } = renderWithProvider('line-chart', {
-        xAxisField: 'category',
-        yAxisField: 'revenue',
-      }, mockFetchPreviewData);
+      const { widgetData: catData, widgetConfig: catConfig } = renderWithProvider(
+        'line-chart',
+        {
+          xAxisField: 'category',
+          yAxisField: 'revenue',
+        },
+        mockFetchPreviewData,
+      );
 
       expect(catConfig!.xField).toBe('category');
       const categories = catData!.map((r) => r.category);
-      expect(categories).toEqual(['Apparel', 'Footwear', 'Accessories', 'Apparel', 'Footwear', 'Accessories']);
+      expect(categories).toEqual([
+        'Apparel',
+        'Footwear',
+        'Accessories',
+        'Apparel',
+        'Footwear',
+        'Accessories',
+      ]);
 
       // Months and categories must be different
       expect(months).not.toEqual(categories);
@@ -268,10 +326,14 @@ describe('ChartPreview — real data from host', () => {
 
   describe('field request correctness', () => {
     it('requests the right fields for a bar chart', () => {
-      const { fetchSpy } = renderWithProvider('bar-chart', {
-        xAxisField: 'category',
-        yAxisField: 'revenue',
-      }, mockFetchPreviewData);
+      const { fetchSpy } = renderWithProvider(
+        'bar-chart',
+        {
+          xAxisField: 'category',
+          yAxisField: 'revenue',
+        },
+        mockFetchPreviewData,
+      );
 
       const request = fetchSpy.mock.calls[0][0] as PreviewDataRequest;
       expect(request.fields.xField).toBe('category');
@@ -279,11 +341,15 @@ describe('ChartPreview — real data from host', () => {
     });
 
     it('includes seriesField when specified', () => {
-      const { fetchSpy } = renderWithProvider('line-chart', {
-        xAxisField: 'month',
-        yAxisField: 'revenue',
-        seriesField: 'category',
-      }, mockFetchPreviewData);
+      const { fetchSpy } = renderWithProvider(
+        'line-chart',
+        {
+          xAxisField: 'month',
+          yAxisField: 'revenue',
+          seriesField: 'category',
+        },
+        mockFetchPreviewData,
+      );
 
       const request = fetchSpy.mock.calls[0][0] as PreviewDataRequest;
       expect(request.fields.seriesField).toBe('category');

--- a/packages/designer/test/preview-data-provider.test.tsx
+++ b/packages/designer/test/preview-data-provider.test.tsx
@@ -355,4 +355,100 @@ describe('ChartPreview — real data from host', () => {
       expect(request.fields.seriesField).toBe('category');
     });
   });
+
+  describe('no sample-data field leaks (regression)', () => {
+    // Historical bug: DEFAULT_CONFIGS assigns sample-data placeholder names
+    // (e.g. KPI card's `comparisonField: 'comparison'`, line chart's
+    // `yFields: ['revenue','orders']`). When these leaked into the preview
+    // fetch, the backend 400'd on unknown fields and the chart silently
+    // fell back to sample data. The fix: extract only puckProps, never defaults.
+
+    it('KPI card does NOT leak `comparison` when user has not bound comparisonField', () => {
+      const { fetchSpy } = renderWithProvider(
+        'kpi-card',
+        {
+          valueField: 'read_count',
+          aggregation: 'sum',
+        },
+        mockFetchPreviewData,
+      );
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const request = fetchSpy.mock.calls[0][0] as PreviewDataRequest;
+      expect(request.fields.valueField).toBe('read_count');
+      // The sample-data placeholder must NOT be in the fetch payload.
+      expect(request.fields.comparisonField).toBeUndefined();
+      expect(request.fields.metricFields).toEqual(['read_count']);
+    });
+
+    it('line chart does NOT leak sample `xField=month` / `yFields=[revenue,orders]` when user has not bound them', () => {
+      // User has set ONLY the dataset, no X/Y fields yet.
+      // In this state, there should be NO fetch — the chart should fall back
+      // to sample data as a placeholder.
+      mockChartWidget.mockClear();
+      const fetchSpy = vi.fn(mockFetchPreviewData);
+
+      act(() => {
+        render(
+          React.createElement(
+            PreviewDataProvider,
+            { fetchPreviewData: fetchSpy },
+            React.createElement(ChartPreview, {
+              widgetType: 'line-chart',
+              puckProps: { title: 'Test', datasetRef: 'test-orders' },
+              fallbackIcon: '📊',
+            }),
+          ),
+        );
+      });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('KPI card skips fetch when neither valueField nor any other binding is set', () => {
+      mockChartWidget.mockClear();
+      const fetchSpy = vi.fn(mockFetchPreviewData);
+
+      act(() => {
+        render(
+          React.createElement(
+            PreviewDataProvider,
+            { fetchPreviewData: fetchSpy },
+            React.createElement(ChartPreview, {
+              widgetType: 'kpi-card',
+              puckProps: { title: 'Test', datasetRef: 'test-orders', aggregation: 'sum' },
+              fallbackIcon: '📊',
+            }),
+          ),
+        );
+      });
+
+      // `aggregation` alone is not a field binding; it must not trigger a fetch.
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('bar chart with user-bound x and y fields does NOT carry extra sample-data fields', () => {
+      const { fetchSpy } = renderWithProvider(
+        'bar-chart',
+        {
+          xAxisField: 'sent_date',
+          yAxisField: 'read_count',
+          aggregation: 'count',
+        },
+        mockFetchPreviewData,
+      );
+
+      const request = fetchSpy.mock.calls[0][0] as PreviewDataRequest;
+      expect(request.fields.xField).toBe('sent_date');
+      expect(request.fields.yFields).toEqual(['read_count']);
+      // The default-config leak used to include extras like `nameField`
+      // or `valueField`; none should be present now.
+      expect(request.fields.nameField).toBeUndefined();
+      expect(request.fields.valueField).toBeUndefined();
+      expect(request.fields.comparisonField).toBeUndefined();
+      expect(request.fields.sizeField).toBeUndefined();
+      expect(request.fields.barFields).toBeUndefined();
+      expect(request.fields.lineFields).toBeUndefined();
+    });
+  });
 });

--- a/packages/dev-app/src/main.tsx
+++ b/packages/dev-app/src/main.tsx
@@ -45,6 +45,7 @@ import {
   boxplotData,
 } from './demo-dashboard';
 import { dashboardSwitchingDemo, pageNavigationDemoDashboard } from './navigation-demo';
+import { ProbeWorkspace } from './probe/ProbeWorkspace';
 
 /**
  * Data-injecting widget wrapper — in a real app, the runtime would
@@ -100,7 +101,7 @@ const FILTER_OPTIONS = {
 type ViewerScenario = 'live' | 'pages' | 'dashboards';
 
 function App() {
-  const [mode, setMode] = useState<'viewer' | 'designer' | 'preview'>('viewer');
+  const [mode, setMode] = useState<'viewer' | 'designer' | 'preview' | 'probe'>('viewer');
   const [viewerScenario, setViewerScenario] = useState<ViewerScenario>('live');
   const [activeDashboardId, setActiveDashboardId] = useState(
     dashboardSwitchingDemo.initialDashboardId,
@@ -473,6 +474,20 @@ function App() {
         >
           👁 Preview
         </button>
+        <button
+          onClick={() => setMode('probe')}
+          style={{
+            padding: '6px 14px',
+            borderRadius: 4,
+            border: 'none',
+            cursor: 'pointer',
+            background: mode === 'probe' ? '#3b82f6' : '#333',
+            color: '#fff',
+            fontWeight: mode === 'probe' ? 700 : 400,
+          }}
+        >
+          🔌 Probe
+        </button>
         {savedDashboard && (
           <span style={{ marginLeft: 'auto', fontSize: 12, color: '#aaa' }}>
             Last saved: {savedDashboard.title} ({savedDashboard.pages[0]?.widgets?.length ?? 0}{' '}
@@ -481,7 +496,9 @@ function App() {
         )}
       </div>
 
-      {mode === 'designer' ? (
+      {mode === 'probe' ? (
+        <ProbeWorkspace />
+      ) : mode === 'designer' ? (
         <div style={{ display: 'flex', height: 'calc(100vh - 44px)' }}>
           <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
             <div

--- a/packages/dev-app/src/main.tsx
+++ b/packages/dev-app/src/main.tsx
@@ -475,6 +475,7 @@ function App() {
           👁 Preview
         </button>
         <button
+          data-testid="mode-probe"
           onClick={() => setMode('probe')}
           style={{
             padding: '6px 14px',

--- a/packages/dev-app/src/probe/ProbeWorkspace.tsx
+++ b/packages/dev-app/src/probe/ProbeWorkspace.tsx
@@ -14,8 +14,10 @@ import type { NormalizedDataset } from '@supersubset/data-model';
 
 import {
   clearProbeSession,
+  createDefaultLoginConfig,
   loadProbeSession,
   normalizeBaseUrl,
+  performProbeLogin,
   saveProbeSession,
   toAuthHeader,
   type ProbeAuthMode,
@@ -24,6 +26,40 @@ import {
 import { toProbeErrorMessage } from './errors';
 import { HttpMetadataAdapter, HttpQueryAdapter } from './http-adapters';
 import { buildPreviewQuery, deriveQueryEndpointInput, parseProbeMetadataJson } from './metadata';
+
+interface PreviewStatus {
+  kind: 'idle' | 'loading' | 'success' | 'empty' | 'error';
+  url?: string;
+  datasetRef?: string;
+  rowCount?: number;
+  errorMessage?: string;
+  timestamp?: number;
+  requestBody?: string;
+  fieldBindings?: string;
+}
+
+type ConnectStageStatus = 'pending' | 'success' | 'error';
+
+interface ConnectStage {
+  id: string;
+  label: string;
+  status: ConnectStageStatus;
+  detail?: string;
+}
+
+function summarizeFieldBindings(fields: Record<string, string | string[] | undefined>): string {
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(fields)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      if (value.length === 0) continue;
+      parts.push(`${key}=[${value.join(', ')}]`);
+    } else if (value.length > 0) {
+      parts.push(`${key}=${value}`);
+    }
+  }
+  return parts.join(' · ');
+}
 
 function createBlankDashboardDefinition(): DashboardDefinition {
   return {
@@ -75,8 +111,14 @@ export function ProbeWorkspace(): ReactElement {
   const jwtInputId = 'probe-jwt-token';
   const customHeaderNameId = 'probe-custom-header-name';
   const customHeaderValueId = 'probe-custom-header-value';
+  const loginUrlInputId = 'probe-login-url';
+  const loginEmailInputId = 'probe-login-email';
+  const loginPasswordInputId = 'probe-login-password';
+  const loginMutationInputId = 'probe-login-mutation';
+  const loginTokenPathInputId = 'probe-login-token-path';
 
   const session = loadProbeSession();
+  const loginDefaults = createDefaultLoginConfig();
 
   const [metadataSourceMode, setMetadataSourceMode] = useState<ProbeMetadataSourceMode>(
     session?.metadataSourceMode ?? 'discovery-url',
@@ -88,11 +130,27 @@ export function ProbeWorkspace(): ReactElement {
   const [jwtInput, setJwtInput] = useState(session?.jwt ?? '');
   const [customHeaderName, setCustomHeaderName] = useState(session?.customHeaderName ?? '');
   const [customHeaderValue, setCustomHeaderValue] = useState(session?.customHeaderValue ?? '');
+  const [loginUrlInput, setLoginUrlInput] = useState(session?.loginUrl ?? loginDefaults.loginUrl);
+  const [loginEmailInput, setLoginEmailInput] = useState(
+    session?.loginEmail ?? loginDefaults.loginEmail,
+  );
+  const [loginPasswordInput, setLoginPasswordInput] = useState(
+    session?.loginPassword ?? loginDefaults.loginPassword,
+  );
+  const [loginMutationInput, setLoginMutationInput] = useState(
+    session?.loginMutation ?? loginDefaults.loginMutation,
+  );
+  const [loginTokenPathInput, setLoginTokenPathInput] = useState(
+    session?.loginTokenPath ?? loginDefaults.loginTokenPath,
+  );
+  const [loginToken, setLoginToken] = useState<string>('');
   const [rememberSession, setRememberSession] = useState(Boolean(session));
   const [datasets, setDatasets] = useState<NormalizedDataset[]>([]);
   const [probeError, setProbeError] = useState<string>('');
   const [isConnecting, setIsConnecting] = useState(false);
+  const [connectStages, setConnectStages] = useState<ConnectStage[]>([]);
   const [showCode, setShowCode] = useState(false);
+  const [previewStatus, setPreviewStatus] = useState<PreviewStatus>({ kind: 'idle' });
   const isConnected = datasets.length > 0;
 
   const undoRedo = useUndoRedo(createBlankDashboardDefinition(), { debounceMs: 500 });
@@ -101,8 +159,8 @@ export function ProbeWorkspace(): ReactElement {
   const currentDashboard = undoRedo.current;
 
   const authHeader = useMemo(
-    () => toAuthHeader(authMode, jwtInput, customHeaderName, customHeaderValue),
-    [authMode, jwtInput, customHeaderName, customHeaderValue],
+    () => toAuthHeader(authMode, jwtInput, customHeaderName, customHeaderValue, loginToken),
+    [authMode, jwtInput, customHeaderName, customHeaderValue, loginToken],
   );
 
   const effectiveQueryEndpoint = useMemo(() => {
@@ -125,16 +183,53 @@ export function ProbeWorkspace(): ReactElement {
 
     const queryAdapter = new HttpQueryAdapter(effectiveQueryEndpoint, { authHeader });
     return async (request) => {
+      const bindings = summarizeFieldBindings(request.fields);
       const query = buildPreviewQuery(datasets, request.datasetRef, request.fields);
       if (!query) {
+        setPreviewStatus({
+          kind: 'idle',
+          url: queryAdapter.resolvedUrl,
+          datasetRef: request.datasetRef,
+          fieldBindings: bindings,
+          timestamp: Date.now(),
+        });
         return [];
       }
 
+      const requestBody = JSON.stringify(query, null, 2);
+
+      setPreviewStatus({
+        kind: 'loading',
+        url: queryAdapter.resolvedUrl,
+        datasetRef: request.datasetRef,
+        fieldBindings: bindings,
+        requestBody,
+        timestamp: Date.now(),
+      });
+
       try {
         const result = await queryAdapter.execute(query);
+        setPreviewStatus({
+          kind: result.rows.length === 0 ? 'empty' : 'success',
+          url: queryAdapter.resolvedUrl,
+          datasetRef: request.datasetRef,
+          rowCount: result.rows.length,
+          fieldBindings: bindings,
+          requestBody,
+          timestamp: Date.now(),
+        });
         return result.rows;
       } catch (error) {
         console.warn('[Supersubset Probe] Preview query failed', error);
+        setPreviewStatus({
+          kind: 'error',
+          url: queryAdapter.resolvedUrl,
+          datasetRef: request.datasetRef,
+          errorMessage: toProbeErrorMessage(error),
+          fieldBindings: bindings,
+          requestBody,
+          timestamp: Date.now(),
+        });
         return [];
       }
     };
@@ -164,40 +259,147 @@ export function ProbeWorkspace(): ReactElement {
       return;
     }
 
+    const sessionPayload = {
+      metadataSourceMode,
+      discoveryUrl: normalizedDiscoveryUrl,
+      metadataJson: metadataJsonInput,
+      queryUrl: normalizedQueryUrl,
+      authMode,
+      jwt: jwtInput,
+      customHeaderName,
+      customHeaderValue,
+      loginUrl: loginUrlInput.trim(),
+      loginMutation: loginMutationInput,
+      loginEmail: loginEmailInput,
+      loginPassword: loginPasswordInput,
+      loginTokenPath: loginTokenPathInput,
+    };
+
+    const stages: ConnectStage[] = [];
+    const pushStage = (stage: ConnectStage): ConnectStage => {
+      stages.push(stage);
+      setConnectStages([...stages]);
+      return stage;
+    };
+    const updateStage = (id: string, patch: Partial<ConnectStage>): void => {
+      const index = stages.findIndex((entry) => entry.id === id);
+      if (index === -1) return;
+      stages[index] = { ...stages[index], ...patch } as ConnectStage;
+      setConnectStages([...stages]);
+    };
+
     setIsConnecting(true);
     setProbeError('');
+    setConnectStages([]);
 
     try {
-      const nextDatasets =
-        metadataSourceMode === 'discovery-url'
-          ? await new HttpMetadataAdapter({ authHeader }).getDatasets(normalizedDiscoveryUrl)
-          : await parseProbeMetadataJson(metadataJsonInput);
+      let effectiveAuthHeader = authHeader;
+
+      if (authMode === 'login') {
+        pushStage({
+          id: 'login',
+          label: `Login: POST ${loginUrlInput.trim() || '(no URL)'}`,
+          status: 'pending',
+          detail: `User: ${loginEmailInput || '(empty)'}`,
+        });
+        console.info('[Supersubset Probe] Attempting login', {
+          url: loginUrlInput.trim(),
+          email: loginEmailInput,
+          tokenPath: loginTokenPathInput,
+        });
+
+        try {
+          const { token } = await performProbeLogin({
+            loginUrl: loginUrlInput,
+            loginMutation: loginMutationInput,
+            loginEmail: loginEmailInput,
+            loginPassword: loginPasswordInput,
+            loginTokenPath: loginTokenPathInput,
+          });
+          setLoginToken(token);
+          effectiveAuthHeader = toAuthHeader(
+            'login',
+            jwtInput,
+            customHeaderName,
+            customHeaderValue,
+            token,
+          );
+          const tokenPreview = `${token.slice(0, 12)}…${token.slice(-6)} (${token.length} chars)`;
+          updateStage('login', {
+            status: 'success',
+            detail: `Token captured: ${tokenPreview}`,
+          });
+          console.info('[Supersubset Probe] Login succeeded', { tokenPreview });
+        } catch (loginError) {
+          const message = toProbeErrorMessage(loginError);
+          updateStage('login', { status: 'error', detail: message });
+          console.warn('[Supersubset Probe] Login failed', loginError);
+          throw loginError;
+        }
+      }
+
+      if (metadataSourceMode === 'discovery-url') {
+        pushStage({
+          id: 'metadata',
+          label: `Metadata: GET ${normalizedDiscoveryUrl}`,
+          status: 'pending',
+        });
+        console.info('[Supersubset Probe] Fetching metadata', {
+          url: normalizedDiscoveryUrl,
+          authHeader: effectiveAuthHeader?.name,
+        });
+      } else {
+        pushStage({
+          id: 'metadata',
+          label: 'Metadata: parsing pasted JSON',
+          status: 'pending',
+        });
+      }
+
+      let nextDatasets;
+      try {
+        nextDatasets =
+          metadataSourceMode === 'discovery-url'
+            ? await new HttpMetadataAdapter({ authHeader: effectiveAuthHeader }).getDatasets(
+                normalizedDiscoveryUrl,
+              )
+            : await parseProbeMetadataJson(metadataJsonInput);
+      } catch (metadataError) {
+        const message = toProbeErrorMessage(metadataError);
+        updateStage('metadata', { status: 'error', detail: message });
+        console.warn('[Supersubset Probe] Metadata fetch failed', metadataError);
+        throw metadataError;
+      }
 
       if (nextDatasets.length === 0) {
-        throw new Error('Metadata loaded successfully, but no datasets were discovered.');
+        const emptyMessage = 'Metadata loaded successfully, but no datasets were discovered.';
+        updateStage('metadata', { status: 'error', detail: emptyMessage });
+        console.warn('[Supersubset Probe]', emptyMessage);
+        throw new Error(emptyMessage);
       }
+
+      updateStage('metadata', {
+        status: 'success',
+        detail: `${nextDatasets.length} dataset(s) discovered`,
+      });
+      console.info('[Supersubset Probe] Metadata loaded', {
+        datasetCount: nextDatasets.length,
+        datasetIds: nextDatasets.map((dataset) => dataset.id),
+      });
 
       setDatasets(nextDatasets);
       undoRedo.reset(createBlankDashboardDefinition());
 
-      if (rememberSession) {
-        saveProbeSession({
-          metadataSourceMode,
-          discoveryUrl: normalizedDiscoveryUrl,
-          metadataJson: metadataJsonInput,
-          queryUrl: normalizedQueryUrl,
-          authMode,
-          jwt: jwtInput,
-          customHeaderName,
-          customHeaderValue,
-        });
-      } else {
+      if (!rememberSession) {
         clearProbeSession();
       }
     } catch (error) {
       setDatasets([]);
       setProbeError(toProbeErrorMessage(error));
     } finally {
+      if (rememberSession) {
+        saveProbeSession(sessionPayload);
+      }
       setIsConnecting(false);
     }
   }
@@ -223,6 +425,8 @@ export function ProbeWorkspace(): ReactElement {
   function handleDisconnect(): void {
     setDatasets([]);
     setProbeError('');
+    setLoginToken('');
+    setConnectStages([]);
   }
 
   const metadataSourceSummary =
@@ -307,12 +511,19 @@ export function ProbeWorkspace(): ReactElement {
                 style={{
                   width: '100%',
                   padding: '10px 12px',
-                  marginBottom: 14,
+                  marginBottom: 8,
                   borderRadius: 8,
                   border: '1px solid #cbd5e1',
                   fontSize: 14,
                 }}
               />
+              <p style={{ margin: '0 0 14px', color: '#64748b', fontSize: 12, lineHeight: 1.5 }}>
+                Metadata is loaded from <code>GET {'{base}/supersubset/datasets'}</code> unless the
+                URL already ends with <code>/supersubset/datasets</code>. Prefer an API-segment base
+                (for example Tripmatch: <code>http://localhost:PORT/api/analytics</code>) so an
+                empty query field below can reuse the same base for{' '}
+                <code>POST {'{base}/supersubset/query'}</code>.
+              </p>
             </>
           ) : (
             <>
@@ -390,9 +601,10 @@ export function ProbeWorkspace(): ReactElement {
           >
             <option value="bearer">Bearer JWT</option>
             <option value="custom">Custom header</option>
+            <option value="login">Login with email + password</option>
           </select>
 
-          {authMode === 'bearer' ? (
+          {authMode === 'bearer' && (
             <>
               <label
                 htmlFor={jwtInputId}
@@ -400,6 +612,10 @@ export function ProbeWorkspace(): ReactElement {
               >
                 JWT token (optional)
               </label>
+              <p style={{ margin: '0 0 8px', color: '#64748b', fontSize: 12, lineHeight: 1.5 }}>
+                Paste the raw JWT only — <code>Bearer</code> is added for you. A leading{' '}
+                <code>Bearer</code> prefix is stripped if you paste it anyway.
+              </p>
               <textarea
                 id={jwtInputId}
                 data-testid="probe-jwt-input"
@@ -418,7 +634,9 @@ export function ProbeWorkspace(): ReactElement {
                 }}
               />
             </>
-          ) : (
+          )}
+
+          {authMode === 'custom' && (
             <>
               <div
                 style={{
@@ -481,6 +699,172 @@ export function ProbeWorkspace(): ReactElement {
             </>
           )}
 
+          {authMode === 'login' && (
+            <>
+              <p style={{ margin: '0 0 12px', color: '#64748b', fontSize: 12, lineHeight: 1.5 }}>
+                The probe will POST a GraphQL mutation to the login URL with{' '}
+                <code>{'{ query, variables: { email, password } }'}</code> and then use the returned
+                token as <code>Authorization: Bearer &lt;token&gt;</code> for discovery and preview
+                requests. Defaults match the tripmatch / bi-data-mart GraphQL schema.
+              </p>
+
+              <label
+                htmlFor={loginUrlInputId}
+                style={{ display: 'block', marginBottom: 6, fontWeight: 600, color: '#0f172a' }}
+              >
+                Login URL
+              </label>
+              <input
+                id={loginUrlInputId}
+                data-testid="probe-login-url"
+                value={loginUrlInput}
+                onChange={(event) => setLoginUrlInput(event.target.value)}
+                placeholder="http://localhost:3009/graphql"
+                style={{
+                  width: '100%',
+                  padding: '10px 12px',
+                  marginBottom: 10,
+                  borderRadius: 8,
+                  border: '1px solid #cbd5e1',
+                  fontSize: 14,
+                }}
+              />
+
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: '1fr 1fr',
+                  gap: 10,
+                  marginBottom: 10,
+                }}
+              >
+                <div>
+                  <label
+                    htmlFor={loginEmailInputId}
+                    style={{
+                      display: 'block',
+                      marginBottom: 6,
+                      fontWeight: 600,
+                      color: '#0f172a',
+                    }}
+                  >
+                    Email / user ID
+                  </label>
+                  <input
+                    id={loginEmailInputId}
+                    data-testid="probe-login-email"
+                    value={loginEmailInput}
+                    onChange={(event) => setLoginEmailInput(event.target.value)}
+                    placeholder="dev@example.com"
+                    autoComplete="username"
+                    style={{
+                      width: '100%',
+                      padding: '10px 12px',
+                      borderRadius: 8,
+                      border: '1px solid #cbd5e1',
+                      fontSize: 14,
+                    }}
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor={loginPasswordInputId}
+                    style={{
+                      display: 'block',
+                      marginBottom: 6,
+                      fontWeight: 600,
+                      color: '#0f172a',
+                    }}
+                  >
+                    Password
+                  </label>
+                  <input
+                    id={loginPasswordInputId}
+                    data-testid="probe-login-password"
+                    type="password"
+                    value={loginPasswordInput}
+                    onChange={(event) => setLoginPasswordInput(event.target.value)}
+                    placeholder="dev password"
+                    autoComplete="current-password"
+                    style={{
+                      width: '100%',
+                      padding: '10px 12px',
+                      borderRadius: 8,
+                      border: '1px solid #cbd5e1',
+                      fontSize: 14,
+                    }}
+                  />
+                </div>
+              </div>
+
+              <details style={{ marginBottom: 10 }}>
+                <summary
+                  style={{
+                    cursor: 'pointer',
+                    color: '#334155',
+                    fontSize: 13,
+                    fontWeight: 600,
+                    marginBottom: 8,
+                  }}
+                >
+                  Advanced: login mutation and token path
+                </summary>
+                <label
+                  htmlFor={loginMutationInputId}
+                  style={{
+                    display: 'block',
+                    marginTop: 10,
+                    marginBottom: 6,
+                    fontWeight: 600,
+                    color: '#0f172a',
+                  }}
+                >
+                  Login mutation
+                </label>
+                <p style={{ margin: '0 0 6px', color: '#64748b', fontSize: 12, lineHeight: 1.5 }}>
+                  Must accept <code>$email</code> and <code>$password</code> variables.
+                </p>
+                <textarea
+                  id={loginMutationInputId}
+                  data-testid="probe-login-mutation"
+                  value={loginMutationInput}
+                  onChange={(event) => setLoginMutationInput(event.target.value)}
+                  rows={6}
+                  style={{
+                    width: '100%',
+                    padding: '10px 12px',
+                    marginBottom: 10,
+                    borderRadius: 8,
+                    border: '1px solid #cbd5e1',
+                    fontSize: 13,
+                    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                  }}
+                />
+                <label
+                  htmlFor={loginTokenPathInputId}
+                  style={{ display: 'block', marginBottom: 6, fontWeight: 600, color: '#0f172a' }}
+                >
+                  Token path in response
+                </label>
+                <input
+                  id={loginTokenPathInputId}
+                  data-testid="probe-login-token-path"
+                  value={loginTokenPathInput}
+                  onChange={(event) => setLoginTokenPathInput(event.target.value)}
+                  placeholder="data.login.accessToken"
+                  style={{
+                    width: '100%',
+                    padding: '10px 12px',
+                    borderRadius: 8,
+                    border: '1px solid #cbd5e1',
+                    fontSize: 13,
+                    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                  }}
+                />
+              </details>
+            </>
+          )}
+
           <label
             style={{
               display: 'flex',
@@ -498,6 +882,8 @@ export function ProbeWorkspace(): ReactElement {
             />
             Remember settings in sessionStorage for this browser session
           </label>
+
+          <ConnectStageList stages={connectStages} />
 
           {probeError && (
             <div
@@ -620,6 +1006,8 @@ export function ProbeWorkspace(): ReactElement {
             </button>
           </div>
 
+          <PreviewStatusBanner status={previewStatus} fallbackUrl={effectiveQueryEndpoint} />
+
           <div style={{ display: 'flex', height: 'calc(100vh - 140px)' }}>
             <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
               <div
@@ -671,6 +1059,235 @@ export function ProbeWorkspace(): ReactElement {
           </div>
         </section>
       )}
+    </div>
+  );
+}
+
+const CONNECT_STAGE_STYLES: Record<
+  ConnectStageStatus,
+  { icon: string; color: string; border: string; background: string }
+> = {
+  pending: {
+    icon: '…',
+    color: '#1d4ed8',
+    border: '#bfdbfe',
+    background: '#eff6ff',
+  },
+  success: {
+    icon: '✓',
+    color: '#14532d',
+    border: '#86efac',
+    background: '#dcfce7',
+  },
+  error: {
+    icon: '✕',
+    color: '#991b1b',
+    border: '#fecaca',
+    background: '#fef2f2',
+  },
+};
+
+function ConnectStageList({ stages }: { stages: ConnectStage[] }): ReactElement | null {
+  if (stages.length === 0) return null;
+
+  return (
+    <div
+      data-testid="probe-connect-log"
+      style={{
+        marginBottom: 14,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+      }}
+    >
+      {stages.map((stage) => {
+        const style = CONNECT_STAGE_STYLES[stage.status];
+        return (
+          <div
+            key={stage.id}
+            data-testid={`probe-connect-stage-${stage.id}`}
+            data-status={stage.status}
+            style={{
+              borderRadius: 8,
+              border: `1px solid ${style.border}`,
+              background: style.background,
+              color: style.color,
+              padding: '8px 12px',
+              fontSize: 13,
+              lineHeight: 1.5,
+              display: 'flex',
+              gap: 10,
+              alignItems: 'flex-start',
+            }}
+          >
+            <span
+              aria-hidden
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 20,
+                height: 20,
+                borderRadius: '50%',
+                background: 'rgba(255,255,255,0.6)',
+                fontWeight: 700,
+                fontSize: 13,
+                flexShrink: 0,
+              }}
+            >
+              {style.icon}
+            </span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontWeight: 600 }}>{stage.label}</div>
+              {stage.detail ? (
+                <div
+                  style={{
+                    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                    fontSize: 12,
+                    wordBreak: 'break-word',
+                  }}
+                >
+                  {stage.detail}
+                </div>
+              ) : null}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const PREVIEW_STATUS_STYLES: Record<
+  PreviewStatus['kind'],
+  { background: string; border: string; color: string; label: string }
+> = {
+  idle: {
+    background: '#f1f5f9',
+    border: '#cbd5e1',
+    color: '#475569',
+    label: 'Idle',
+  },
+  loading: {
+    background: '#eff6ff',
+    border: '#bfdbfe',
+    color: '#1d4ed8',
+    label: 'Loading…',
+  },
+  success: {
+    background: '#dcfce7',
+    border: '#86efac',
+    color: '#14532d',
+    label: 'Live data',
+  },
+  empty: {
+    background: '#fef3c7',
+    border: '#fde68a',
+    color: '#92400e',
+    label: 'Empty result (falling back to sample data)',
+  },
+  error: {
+    background: '#fef2f2',
+    border: '#fecaca',
+    color: '#991b1b',
+    label: 'Failed (falling back to sample data)',
+  },
+};
+
+function PreviewStatusBanner({
+  status,
+  fallbackUrl,
+}: {
+  status: PreviewStatus;
+  fallbackUrl: string;
+}): ReactElement | null {
+  if (status.kind === 'idle' && !status.url) {
+    return null;
+  }
+
+  const style = PREVIEW_STATUS_STYLES[status.kind];
+  const url = status.url ?? fallbackUrl;
+
+  return (
+    <div
+      data-testid="probe-preview-query-status"
+      style={{
+        marginBottom: 12,
+        borderRadius: 8,
+        border: `1px solid ${style.border}`,
+        background: style.background,
+        color: style.color,
+        padding: '8px 12px',
+        fontSize: 12,
+        lineHeight: 1.5,
+        display: 'flex',
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        gap: 10,
+      }}
+    >
+      <span style={{ fontWeight: 700 }}>Last preview query: {style.label}</span>
+      {status.datasetRef ? (
+        <code style={{ background: 'rgba(0,0,0,0.05)', padding: '1px 6px', borderRadius: 4 }}>
+          {status.datasetRef}
+        </code>
+      ) : null}
+      {typeof status.rowCount === 'number' ? (
+        <span>
+          {status.rowCount} row{status.rowCount === 1 ? '' : 's'}
+        </span>
+      ) : null}
+      {url ? (
+        <span style={{ opacity: 0.85 }}>
+          POST <code>{url}</code>
+        </span>
+      ) : null}
+      {status.fieldBindings ? (
+        <span style={{ flexBasis: '100%', fontSize: 11, opacity: 0.9 }}>
+          Bindings: <code>{status.fieldBindings}</code>
+        </span>
+      ) : null}
+      {status.errorMessage ? (
+        <span style={{ flexBasis: '100%', fontFamily: 'ui-monospace, Menlo, monospace' }}>
+          {status.errorMessage}
+        </span>
+      ) : null}
+      {status.requestBody ? (
+        <details
+          style={{
+            flexBasis: '100%',
+            marginTop: 4,
+            fontFamily: 'ui-monospace, Menlo, monospace',
+            fontSize: 11,
+          }}
+        >
+          <summary
+            style={{
+              cursor: 'pointer',
+              userSelect: 'none',
+              fontFamily: 'sans-serif',
+              fontSize: 12,
+              fontWeight: 600,
+            }}
+          >
+            Request body (click to expand)
+          </summary>
+          <pre
+            style={{
+              margin: '6px 0 0',
+              padding: 10,
+              background: 'rgba(15, 23, 42, 0.05)',
+              borderRadius: 6,
+              overflow: 'auto',
+              maxHeight: 220,
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+            }}
+          >
+            {status.requestBody}
+          </pre>
+        </details>
+      ) : null}
     </div>
   );
 }

--- a/packages/dev-app/src/probe/ProbeWorkspace.tsx
+++ b/packages/dev-app/src/probe/ProbeWorkspace.tsx
@@ -64,6 +64,12 @@ function triggerJsonDownload(filename: string, content: string): void {
 }
 
 export function ProbeWorkspace(): ReactElement {
+  const urlInputId = 'probe-backend-url';
+  const authModeId = 'probe-auth-mode-select';
+  const jwtInputId = 'probe-jwt-token';
+  const customHeaderNameId = 'probe-custom-header-name';
+  const customHeaderValueId = 'probe-custom-header-value';
+
   const session = loadProbeSession();
 
   const [authMode, setAuthMode] = useState<ProbeAuthMode>(session?.authMode ?? 'bearer');
@@ -77,13 +83,12 @@ export function ProbeWorkspace(): ReactElement {
   const [probeError, setProbeError] = useState<string>('');
   const [isConnecting, setIsConnecting] = useState(false);
   const [showCode, setShowCode] = useState(false);
+  const isConnected = datasets.length > 0 && probeUrl.length > 0;
 
   const undoRedo = useUndoRedo(createBlankDashboardDefinition(), { debounceMs: 500 });
-  useUndoRedoKeyboard(undoRedo.undo, undoRedo.redo, true);
+  useUndoRedoKeyboard(undoRedo.undo, undoRedo.redo, isConnected);
 
   const currentDashboard = undoRedo.current;
-
-  const isConnected = datasets.length > 0 && probeUrl.length > 0;
 
   const authHeader = useMemo(
     () => toAuthHeader(authMode, jwtInput, customHeaderName, customHeaderValue),
@@ -189,10 +194,14 @@ export function ProbeWorkspace(): ReactElement {
             Point Supersubset at a compatible backend, scan datasets, and open a blank designer.
           </p>
 
-          <label style={{ display: 'block', marginBottom: 6, fontWeight: 600, color: '#0f172a' }}>
+          <label
+            htmlFor={urlInputId}
+            style={{ display: 'block', marginBottom: 6, fontWeight: 600, color: '#0f172a' }}
+          >
             Backend URL
           </label>
           <input
+            id={urlInputId}
             data-testid="probe-url-input"
             value={baseUrlInput}
             onChange={(event) => setBaseUrlInput(event.target.value)}
@@ -207,10 +216,14 @@ export function ProbeWorkspace(): ReactElement {
             }}
           />
 
-          <label style={{ display: 'block', marginBottom: 6, fontWeight: 600, color: '#0f172a' }}>
+          <label
+            htmlFor={authModeId}
+            style={{ display: 'block', marginBottom: 6, fontWeight: 600, color: '#0f172a' }}
+          >
             Auth mode
           </label>
           <select
+            id={authModeId}
             data-testid="probe-auth-mode"
             value={authMode}
             onChange={(event) => setAuthMode(event.target.value as ProbeAuthMode)}
@@ -230,11 +243,13 @@ export function ProbeWorkspace(): ReactElement {
           {authMode === 'bearer' ? (
             <>
               <label
+                htmlFor={jwtInputId}
                 style={{ display: 'block', marginBottom: 6, fontWeight: 600, color: '#0f172a' }}
               >
                 JWT token (optional)
               </label>
               <textarea
+                id={jwtInputId}
                 data-testid="probe-jwt-input"
                 value={jwtInput}
                 onChange={(event) => setJwtInput(event.target.value)}
@@ -252,36 +267,66 @@ export function ProbeWorkspace(): ReactElement {
               />
             </>
           ) : (
-            <div
-              style={{ display: 'grid', gridTemplateColumns: '1fr 2fr', gap: 10, marginBottom: 14 }}
-            >
-              <input
-                data-testid="probe-header-name"
-                value={customHeaderName}
-                onChange={(event) => setCustomHeaderName(event.target.value)}
-                placeholder="X-API-Key"
+            <>
+              <div
                 style={{
-                  width: '100%',
-                  padding: '10px 12px',
-                  borderRadius: 8,
-                  border: '1px solid #cbd5e1',
-                  fontSize: 14,
+                  display: 'grid',
+                  gridTemplateColumns: '1fr 2fr',
+                  gap: 10,
+                  marginBottom: 6,
                 }}
-              />
-              <input
-                data-testid="probe-header-value"
-                value={customHeaderValue}
-                onChange={(event) => setCustomHeaderValue(event.target.value)}
-                placeholder="my-dev-key"
+              >
+                <label
+                  htmlFor={customHeaderNameId}
+                  style={{ display: 'block', fontWeight: 600, color: '#0f172a' }}
+                >
+                  Header name
+                </label>
+                <label
+                  htmlFor={customHeaderValueId}
+                  style={{ display: 'block', fontWeight: 600, color: '#0f172a' }}
+                >
+                  Header value
+                </label>
+              </div>
+              <div
                 style={{
-                  width: '100%',
-                  padding: '10px 12px',
-                  borderRadius: 8,
-                  border: '1px solid #cbd5e1',
-                  fontSize: 14,
+                  display: 'grid',
+                  gridTemplateColumns: '1fr 2fr',
+                  gap: 10,
+                  marginBottom: 14,
                 }}
-              />
-            </div>
+              >
+                <input
+                  id={customHeaderNameId}
+                  data-testid="probe-header-name"
+                  value={customHeaderName}
+                  onChange={(event) => setCustomHeaderName(event.target.value)}
+                  placeholder="X-API-Key"
+                  style={{
+                    width: '100%',
+                    padding: '10px 12px',
+                    borderRadius: 8,
+                    border: '1px solid #cbd5e1',
+                    fontSize: 14,
+                  }}
+                />
+                <input
+                  id={customHeaderValueId}
+                  data-testid="probe-header-value"
+                  value={customHeaderValue}
+                  onChange={(event) => setCustomHeaderValue(event.target.value)}
+                  placeholder="my-dev-key"
+                  style={{
+                    width: '100%',
+                    padding: '10px 12px',
+                    borderRadius: 8,
+                    border: '1px solid #cbd5e1',
+                    fontSize: 14,
+                  }}
+                />
+              </div>
+            </>
           )}
 
           <label

--- a/packages/dev-app/src/probe/ProbeWorkspace.tsx
+++ b/packages/dev-app/src/probe/ProbeWorkspace.tsx
@@ -4,6 +4,7 @@ import {
   SupersubsetDesigner,
   ImportExportPanel,
   CodeViewPanel,
+  type FetchPreviewData,
   useUndoRedo,
   UndoRedoToolbar,
   useUndoRedoKeyboard,
@@ -18,9 +19,11 @@ import {
   saveProbeSession,
   toAuthHeader,
   type ProbeAuthMode,
+  type ProbeMetadataSourceMode,
 } from './auth';
 import { toProbeErrorMessage } from './errors';
-import { HttpMetadataAdapter } from './http-adapters';
+import { HttpMetadataAdapter, HttpQueryAdapter } from './http-adapters';
+import { buildPreviewQuery, deriveQueryEndpointInput, parseProbeMetadataJson } from './metadata';
 
 function createBlankDashboardDefinition(): DashboardDefinition {
   return {
@@ -64,7 +67,10 @@ function triggerJsonDownload(filename: string, content: string): void {
 }
 
 export function ProbeWorkspace(): ReactElement {
-  const urlInputId = 'probe-backend-url';
+  const metadataModeId = 'probe-metadata-mode';
+  const discoveryUrlInputId = 'probe-discovery-url';
+  const metadataJsonInputId = 'probe-metadata-json';
+  const queryUrlInputId = 'probe-query-url';
   const authModeId = 'probe-auth-mode-select';
   const jwtInputId = 'probe-jwt-token';
   const customHeaderNameId = 'probe-custom-header-name';
@@ -72,18 +78,22 @@ export function ProbeWorkspace(): ReactElement {
 
   const session = loadProbeSession();
 
+  const [metadataSourceMode, setMetadataSourceMode] = useState<ProbeMetadataSourceMode>(
+    session?.metadataSourceMode ?? 'discovery-url',
+  );
   const [authMode, setAuthMode] = useState<ProbeAuthMode>(session?.authMode ?? 'bearer');
-  const [baseUrlInput, setBaseUrlInput] = useState(session?.baseUrl ?? '');
+  const [discoveryUrlInput, setDiscoveryUrlInput] = useState(session?.discoveryUrl ?? '');
+  const [metadataJsonInput, setMetadataJsonInput] = useState(session?.metadataJson ?? '');
+  const [queryUrlInput, setQueryUrlInput] = useState(session?.queryUrl ?? '');
   const [jwtInput, setJwtInput] = useState(session?.jwt ?? '');
   const [customHeaderName, setCustomHeaderName] = useState(session?.customHeaderName ?? '');
   const [customHeaderValue, setCustomHeaderValue] = useState(session?.customHeaderValue ?? '');
   const [rememberSession, setRememberSession] = useState(Boolean(session));
   const [datasets, setDatasets] = useState<NormalizedDataset[]>([]);
-  const [probeUrl, setProbeUrl] = useState<string>('');
   const [probeError, setProbeError] = useState<string>('');
   const [isConnecting, setIsConnecting] = useState(false);
   const [showCode, setShowCode] = useState(false);
-  const isConnected = datasets.length > 0 && probeUrl.length > 0;
+  const isConnected = datasets.length > 0;
 
   const undoRedo = useUndoRedo(createBlankDashboardDefinition(), { debounceMs: 500 });
   useUndoRedoKeyboard(undoRedo.undo, undoRedo.redo, isConnected);
@@ -95,10 +105,62 @@ export function ProbeWorkspace(): ReactElement {
     [authMode, jwtInput, customHeaderName, customHeaderValue],
   );
 
+  const effectiveQueryEndpoint = useMemo(() => {
+    const normalizedQueryUrl = normalizeBaseUrl(queryUrlInput);
+    if (normalizedQueryUrl) {
+      return normalizedQueryUrl;
+    }
+
+    if (metadataSourceMode === 'discovery-url') {
+      return deriveQueryEndpointInput(discoveryUrlInput);
+    }
+
+    return '';
+  }, [discoveryUrlInput, metadataSourceMode, queryUrlInput]);
+
+  const fetchPreviewData = useMemo<FetchPreviewData | undefined>(() => {
+    if (!isConnected || !effectiveQueryEndpoint) {
+      return undefined;
+    }
+
+    const queryAdapter = new HttpQueryAdapter(effectiveQueryEndpoint, { authHeader });
+    return async (request) => {
+      const query = buildPreviewQuery(datasets, request.datasetRef, request.fields);
+      if (!query) {
+        return [];
+      }
+
+      try {
+        const result = await queryAdapter.execute(query);
+        return result.rows;
+      } catch (error) {
+        console.warn('[Supersubset Probe] Preview query failed', error);
+        return [];
+      }
+    };
+  }, [authHeader, datasets, effectiveQueryEndpoint, isConnected]);
+
   async function handleProbeConnect(): Promise<void> {
-    const normalizedUrl = normalizeBaseUrl(baseUrlInput);
-    if (!normalizedUrl.startsWith('http://') && !normalizedUrl.startsWith('https://')) {
-      setProbeError('Enter a full backend URL starting with http:// or https://');
+    const normalizedDiscoveryUrl = normalizeBaseUrl(discoveryUrlInput);
+    const normalizedQueryUrl = normalizeBaseUrl(queryUrlInput);
+
+    if (
+      metadataSourceMode === 'discovery-url' &&
+      !normalizedDiscoveryUrl.startsWith('http://') &&
+      !normalizedDiscoveryUrl.startsWith('https://')
+    ) {
+      setProbeError(
+        'Enter a full discovery URL or backend base URL starting with http:// or https://',
+      );
+      return;
+    }
+
+    if (
+      normalizedQueryUrl.length > 0 &&
+      !normalizedQueryUrl.startsWith('http://') &&
+      !normalizedQueryUrl.startsWith('https://')
+    ) {
+      setProbeError('Enter a full query URL or backend base URL starting with http:// or https://');
       return;
     }
 
@@ -106,20 +168,24 @@ export function ProbeWorkspace(): ReactElement {
     setProbeError('');
 
     try {
-      const metadataAdapter = new HttpMetadataAdapter({ authHeader });
-      const nextDatasets = await metadataAdapter.getDatasets(normalizedUrl);
+      const nextDatasets =
+        metadataSourceMode === 'discovery-url'
+          ? await new HttpMetadataAdapter({ authHeader }).getDatasets(normalizedDiscoveryUrl)
+          : await parseProbeMetadataJson(metadataJsonInput);
 
       if (nextDatasets.length === 0) {
-        throw new Error('Backend responded, but no datasets were discovered.');
+        throw new Error('Metadata loaded successfully, but no datasets were discovered.');
       }
 
-      setProbeUrl(normalizedUrl);
       setDatasets(nextDatasets);
       undoRedo.reset(createBlankDashboardDefinition());
 
       if (rememberSession) {
         saveProbeSession({
-          baseUrl: normalizedUrl,
+          metadataSourceMode,
+          discoveryUrl: normalizedDiscoveryUrl,
+          metadataJson: metadataJsonInput,
+          queryUrl: normalizedQueryUrl,
           authMode,
           jwt: jwtInput,
           customHeaderName,
@@ -130,7 +196,6 @@ export function ProbeWorkspace(): ReactElement {
       }
     } catch (error) {
       setDatasets([]);
-      setProbeUrl('');
       setProbeError(toProbeErrorMessage(error));
     } finally {
       setIsConnecting(false);
@@ -157,9 +222,13 @@ export function ProbeWorkspace(): ReactElement {
 
   function handleDisconnect(): void {
     setDatasets([]);
-    setProbeUrl('');
     setProbeError('');
   }
+
+  const metadataSourceSummary =
+    metadataSourceMode === 'discovery-url'
+      ? normalizeBaseUrl(discoveryUrlInput)
+      : 'Pasted metadata JSON';
 
   return (
     <div style={{ maxWidth: 1320, margin: '0 auto', padding: '20px 24px' }}>
@@ -191,21 +260,23 @@ export function ProbeWorkspace(): ReactElement {
         >
           <h2 style={{ marginTop: 0, marginBottom: 10, color: '#0f172a' }}>Backend Probe</h2>
           <p style={{ margin: '0 0 18px', color: '#475569' }}>
-            Point Supersubset at a compatible backend, scan datasets, and open a blank designer.
+            Load metadata from a discovery endpoint or pasted JSON, then optionally use a live query
+            endpoint for preview data while building charts.
           </p>
 
           <label
-            htmlFor={urlInputId}
+            htmlFor={metadataModeId}
             style={{ display: 'block', marginBottom: 6, fontWeight: 600, color: '#0f172a' }}
           >
-            Backend URL
+            Metadata source
           </label>
-          <input
-            id={urlInputId}
-            data-testid="probe-url-input"
-            value={baseUrlInput}
-            onChange={(event) => setBaseUrlInput(event.target.value)}
-            placeholder="https://api.example.com"
+          <select
+            id={metadataModeId}
+            data-testid="probe-metadata-mode"
+            value={metadataSourceMode}
+            onChange={(event) =>
+              setMetadataSourceMode(event.target.value as ProbeMetadataSourceMode)
+            }
             style={{
               width: '100%',
               padding: '10px 12px',
@@ -214,7 +285,88 @@ export function ProbeWorkspace(): ReactElement {
               border: '1px solid #cbd5e1',
               fontSize: 14,
             }}
+          >
+            <option value="discovery-url">Discovery URL</option>
+            <option value="paste-json">Paste metadata JSON</option>
+          </select>
+
+          {metadataSourceMode === 'discovery-url' ? (
+            <>
+              <label
+                htmlFor={discoveryUrlInputId}
+                style={{ display: 'block', marginBottom: 6, fontWeight: 600, color: '#0f172a' }}
+              >
+                Discovery URL or backend base URL
+              </label>
+              <input
+                id={discoveryUrlInputId}
+                data-testid="probe-url-input"
+                value={discoveryUrlInput}
+                onChange={(event) => setDiscoveryUrlInput(event.target.value)}
+                placeholder="https://api.example.com"
+                style={{
+                  width: '100%',
+                  padding: '10px 12px',
+                  marginBottom: 14,
+                  borderRadius: 8,
+                  border: '1px solid #cbd5e1',
+                  fontSize: 14,
+                }}
+              />
+            </>
+          ) : (
+            <>
+              <label
+                htmlFor={metadataJsonInputId}
+                style={{ display: 'block', marginBottom: 6, fontWeight: 600, color: '#0f172a' }}
+              >
+                Metadata JSON
+              </label>
+              <textarea
+                id={metadataJsonInputId}
+                data-testid="probe-metadata-json-input"
+                value={metadataJsonInput}
+                onChange={(event) => setMetadataJsonInput(event.target.value)}
+                placeholder='{"datasets":[{"id":"orders","label":"Orders","fields":[...]}]}'
+                rows={8}
+                style={{
+                  width: '100%',
+                  padding: '10px 12px',
+                  marginBottom: 14,
+                  borderRadius: 8,
+                  border: '1px solid #cbd5e1',
+                  fontSize: 13,
+                  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                }}
+              />
+            </>
+          )}
+
+          <label
+            htmlFor={queryUrlInputId}
+            style={{ display: 'block', marginBottom: 6, fontWeight: 600, color: '#0f172a' }}
+          >
+            Query endpoint URL or backend base URL (optional)
+          </label>
+          <input
+            id={queryUrlInputId}
+            data-testid="probe-query-url-input"
+            value={queryUrlInput}
+            onChange={(event) => setQueryUrlInput(event.target.value)}
+            placeholder="https://api.example.com"
+            style={{
+              width: '100%',
+              padding: '10px 12px',
+              marginBottom: 8,
+              borderRadius: 8,
+              border: '1px solid #cbd5e1',
+              fontSize: 14,
+            }}
           />
+          <p style={{ margin: '0 0 14px', color: '#64748b', fontSize: 12, lineHeight: 1.5 }}>
+            Leave this blank to reuse the discovery URL for live preview when possible. When using
+            pasted metadata, you can still provide a query endpoint for chart preview data.
+          </p>
 
           <label
             htmlFor={authModeId}
@@ -380,7 +532,7 @@ export function ProbeWorkspace(): ReactElement {
               fontWeight: 700,
             }}
           >
-            {isConnecting ? 'Connecting...' : 'Scan backend and open designer'}
+            {isConnecting ? 'Connecting...' : 'Load metadata and open designer'}
           </button>
         </section>
       ) : (
@@ -395,6 +547,7 @@ export function ProbeWorkspace(): ReactElement {
             }}
           >
             <span
+              data-testid="probe-metadata-source-summary"
               style={{
                 borderRadius: 999,
                 background: '#dcfce7',
@@ -404,10 +557,25 @@ export function ProbeWorkspace(): ReactElement {
                 fontWeight: 700,
               }}
             >
-              Connected: {probeUrl}
+              Metadata: {metadataSourceSummary}
             </span>
-            <span style={{ color: '#334155', fontSize: 13 }}>
+            <span data-testid="probe-dataset-count" style={{ color: '#334155', fontSize: 13 }}>
               {datasets.length} dataset(s) discovered
+            </span>
+            <span
+              data-testid="probe-preview-status"
+              style={{
+                borderRadius: 999,
+                background: fetchPreviewData ? '#dbeafe' : '#fef3c7',
+                color: fetchPreviewData ? '#1d4ed8' : '#92400e',
+                padding: '4px 10px',
+                fontSize: 12,
+                fontWeight: 700,
+              }}
+            >
+              {fetchPreviewData
+                ? `Preview: ${effectiveQueryEndpoint}`
+                : 'Preview: disabled (metadata only)'}
             </span>
             <button
               onClick={() => setShowCode((value) => !value)}
@@ -468,6 +636,7 @@ export function ProbeWorkspace(): ReactElement {
                   headerTitle="Supersubset Probe Designer"
                   height="100%"
                   datasets={datasets}
+                  fetchPreviewData={fetchPreviewData}
                   headerActions={
                     <div
                       style={{

--- a/packages/dev-app/src/probe/ProbeWorkspace.tsx
+++ b/packages/dev-app/src/probe/ProbeWorkspace.tsx
@@ -1,0 +1,462 @@
+import { useMemo, useState, type ReactElement } from 'react';
+
+import {
+  SupersubsetDesigner,
+  ImportExportPanel,
+  CodeViewPanel,
+  useUndoRedo,
+  UndoRedoToolbar,
+  useUndoRedoKeyboard,
+} from '@supersubset/designer';
+import type { DashboardDefinition } from '@supersubset/schema';
+import type { NormalizedDataset } from '@supersubset/data-model';
+
+import {
+  clearProbeSession,
+  loadProbeSession,
+  normalizeBaseUrl,
+  saveProbeSession,
+  toAuthHeader,
+  type ProbeAuthMode,
+} from './auth';
+import { toProbeErrorMessage } from './errors';
+import { HttpMetadataAdapter } from './http-adapters';
+
+function createBlankDashboardDefinition(): DashboardDefinition {
+  return {
+    schemaVersion: '0.2.0',
+    id: `probe-${Date.now()}`,
+    title: 'Backend Probe Dashboard',
+    pages: [
+      {
+        id: 'page-1',
+        title: 'Page 1',
+        rootNodeId: 'root',
+        layout: {
+          root: { id: 'root', type: 'root', children: ['grid-main'], meta: {} },
+          'grid-main': {
+            id: 'grid-main',
+            type: 'grid',
+            children: [],
+            parentId: 'root',
+            meta: { columns: 12 },
+          },
+        },
+        widgets: [],
+      },
+    ],
+    defaults: {
+      activePage: 'page-1',
+    },
+  };
+}
+
+function triggerJsonDownload(filename: string, content: string): void {
+  const blob = new Blob([content], { type: 'application/json;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+export function ProbeWorkspace(): ReactElement {
+  const session = loadProbeSession();
+
+  const [authMode, setAuthMode] = useState<ProbeAuthMode>(session?.authMode ?? 'bearer');
+  const [baseUrlInput, setBaseUrlInput] = useState(session?.baseUrl ?? '');
+  const [jwtInput, setJwtInput] = useState(session?.jwt ?? '');
+  const [customHeaderName, setCustomHeaderName] = useState(session?.customHeaderName ?? '');
+  const [customHeaderValue, setCustomHeaderValue] = useState(session?.customHeaderValue ?? '');
+  const [rememberSession, setRememberSession] = useState(Boolean(session));
+  const [datasets, setDatasets] = useState<NormalizedDataset[]>([]);
+  const [probeUrl, setProbeUrl] = useState<string>('');
+  const [probeError, setProbeError] = useState<string>('');
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [showCode, setShowCode] = useState(false);
+
+  const undoRedo = useUndoRedo(createBlankDashboardDefinition(), { debounceMs: 500 });
+  useUndoRedoKeyboard(undoRedo.undo, undoRedo.redo, true);
+
+  const currentDashboard = undoRedo.current;
+
+  const isConnected = datasets.length > 0 && probeUrl.length > 0;
+
+  const authHeader = useMemo(
+    () => toAuthHeader(authMode, jwtInput, customHeaderName, customHeaderValue),
+    [authMode, jwtInput, customHeaderName, customHeaderValue],
+  );
+
+  async function handleProbeConnect(): Promise<void> {
+    const normalizedUrl = normalizeBaseUrl(baseUrlInput);
+    if (!normalizedUrl.startsWith('http://') && !normalizedUrl.startsWith('https://')) {
+      setProbeError('Enter a full backend URL starting with http:// or https://');
+      return;
+    }
+
+    setIsConnecting(true);
+    setProbeError('');
+
+    try {
+      const metadataAdapter = new HttpMetadataAdapter({ authHeader });
+      const nextDatasets = await metadataAdapter.getDatasets(normalizedUrl);
+
+      if (nextDatasets.length === 0) {
+        throw new Error('Backend responded, but no datasets were discovered.');
+      }
+
+      setProbeUrl(normalizedUrl);
+      setDatasets(nextDatasets);
+      undoRedo.reset(createBlankDashboardDefinition());
+
+      if (rememberSession) {
+        saveProbeSession({
+          baseUrl: normalizedUrl,
+          authMode,
+          jwt: jwtInput,
+          customHeaderName,
+          customHeaderValue,
+        });
+      } else {
+        clearProbeSession();
+      }
+    } catch (error) {
+      setDatasets([]);
+      setProbeUrl('');
+      setProbeError(toProbeErrorMessage(error));
+    } finally {
+      setIsConnecting(false);
+    }
+  }
+
+  async function handleExportJson(): Promise<void> {
+    const serialized = JSON.stringify(currentDashboard, null, 2);
+
+    try {
+      await navigator.clipboard.writeText(serialized);
+    } catch {
+      // Clipboard is best-effort. Download still works.
+    }
+
+    const safeTitle =
+      currentDashboard.title
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '') || 'probe-dashboard';
+
+    triggerJsonDownload(`${safeTitle}.json`, serialized);
+  }
+
+  function handleDisconnect(): void {
+    setDatasets([]);
+    setProbeUrl('');
+    setProbeError('');
+  }
+
+  return (
+    <div style={{ maxWidth: 1320, margin: '0 auto', padding: '20px 24px' }}>
+      <div
+        style={{
+          marginBottom: 16,
+          padding: '12px 14px',
+          borderRadius: 10,
+          border: '1px solid #fde68a',
+          background: '#fffbeb',
+          color: '#78350f',
+          fontSize: 13,
+          lineHeight: 1.5,
+        }}
+      >
+        DEV TOOL: Use development credentials only. This screen is designed for local/backend
+        compatibility testing, not production authentication flows.
+      </div>
+
+      {!isConnected ? (
+        <section
+          style={{
+            border: '1px solid #d6dee8',
+            borderRadius: 14,
+            padding: 20,
+            background: '#fff',
+            boxShadow: '0 12px 32px rgba(15, 23, 42, 0.07)',
+          }}
+        >
+          <h2 style={{ marginTop: 0, marginBottom: 10, color: '#0f172a' }}>Backend Probe</h2>
+          <p style={{ margin: '0 0 18px', color: '#475569' }}>
+            Point Supersubset at a compatible backend, scan datasets, and open a blank designer.
+          </p>
+
+          <label style={{ display: 'block', marginBottom: 6, fontWeight: 600, color: '#0f172a' }}>
+            Backend URL
+          </label>
+          <input
+            data-testid="probe-url-input"
+            value={baseUrlInput}
+            onChange={(event) => setBaseUrlInput(event.target.value)}
+            placeholder="https://api.example.com"
+            style={{
+              width: '100%',
+              padding: '10px 12px',
+              marginBottom: 14,
+              borderRadius: 8,
+              border: '1px solid #cbd5e1',
+              fontSize: 14,
+            }}
+          />
+
+          <label style={{ display: 'block', marginBottom: 6, fontWeight: 600, color: '#0f172a' }}>
+            Auth mode
+          </label>
+          <select
+            data-testid="probe-auth-mode"
+            value={authMode}
+            onChange={(event) => setAuthMode(event.target.value as ProbeAuthMode)}
+            style={{
+              width: '100%',
+              padding: '10px 12px',
+              marginBottom: 14,
+              borderRadius: 8,
+              border: '1px solid #cbd5e1',
+              fontSize: 14,
+            }}
+          >
+            <option value="bearer">Bearer JWT</option>
+            <option value="custom">Custom header</option>
+          </select>
+
+          {authMode === 'bearer' ? (
+            <>
+              <label
+                style={{ display: 'block', marginBottom: 6, fontWeight: 600, color: '#0f172a' }}
+              >
+                JWT token (optional)
+              </label>
+              <textarea
+                data-testid="probe-jwt-input"
+                value={jwtInput}
+                onChange={(event) => setJwtInput(event.target.value)}
+                placeholder="eyJhbGciOi..."
+                rows={4}
+                style={{
+                  width: '100%',
+                  padding: '10px 12px',
+                  marginBottom: 14,
+                  borderRadius: 8,
+                  border: '1px solid #cbd5e1',
+                  fontSize: 13,
+                  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                }}
+              />
+            </>
+          ) : (
+            <div
+              style={{ display: 'grid', gridTemplateColumns: '1fr 2fr', gap: 10, marginBottom: 14 }}
+            >
+              <input
+                data-testid="probe-header-name"
+                value={customHeaderName}
+                onChange={(event) => setCustomHeaderName(event.target.value)}
+                placeholder="X-API-Key"
+                style={{
+                  width: '100%',
+                  padding: '10px 12px',
+                  borderRadius: 8,
+                  border: '1px solid #cbd5e1',
+                  fontSize: 14,
+                }}
+              />
+              <input
+                data-testid="probe-header-value"
+                value={customHeaderValue}
+                onChange={(event) => setCustomHeaderValue(event.target.value)}
+                placeholder="my-dev-key"
+                style={{
+                  width: '100%',
+                  padding: '10px 12px',
+                  borderRadius: 8,
+                  border: '1px solid #cbd5e1',
+                  fontSize: 14,
+                }}
+              />
+            </div>
+          )}
+
+          <label
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              marginBottom: 14,
+              color: '#334155',
+              fontSize: 14,
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={rememberSession}
+              onChange={(event) => setRememberSession(event.target.checked)}
+            />
+            Remember settings in sessionStorage for this browser session
+          </label>
+
+          {probeError && (
+            <div
+              data-testid="probe-error"
+              style={{
+                marginBottom: 14,
+                borderRadius: 8,
+                border: '1px solid #fecaca',
+                background: '#fef2f2',
+                color: '#991b1b',
+                padding: '10px 12px',
+                fontSize: 13,
+              }}
+            >
+              {probeError}
+            </div>
+          )}
+
+          <button
+            data-testid="probe-connect-button"
+            onClick={() => {
+              void handleProbeConnect();
+            }}
+            disabled={isConnecting}
+            style={{
+              padding: '10px 14px',
+              borderRadius: 8,
+              border: 'none',
+              cursor: isConnecting ? 'wait' : 'pointer',
+              background: '#1d4ed8',
+              color: '#fff',
+              fontWeight: 700,
+            }}
+          >
+            {isConnecting ? 'Connecting...' : 'Scan backend and open designer'}
+          </button>
+        </section>
+      ) : (
+        <section>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+              marginBottom: 12,
+              flexWrap: 'wrap',
+            }}
+          >
+            <span
+              style={{
+                borderRadius: 999,
+                background: '#dcfce7',
+                color: '#14532d',
+                padding: '4px 10px',
+                fontSize: 12,
+                fontWeight: 700,
+              }}
+            >
+              Connected: {probeUrl}
+            </span>
+            <span style={{ color: '#334155', fontSize: 13 }}>
+              {datasets.length} dataset(s) discovered
+            </span>
+            <button
+              onClick={() => setShowCode((value) => !value)}
+              style={{
+                padding: '5px 10px',
+                borderRadius: 6,
+                border: '1px solid #cbd5e1',
+                cursor: 'pointer',
+                background: showCode ? '#e2e8f0' : '#fff',
+              }}
+            >
+              {'</>'} Code
+            </button>
+            <button
+              onClick={() => {
+                void handleExportJson();
+              }}
+              style={{
+                padding: '6px 10px',
+                borderRadius: 6,
+                border: '1px solid #1d4ed8',
+                color: '#1d4ed8',
+                background: '#eff6ff',
+                cursor: 'pointer',
+                fontWeight: 700,
+              }}
+            >
+              Export JSON
+            </button>
+            <button
+              onClick={handleDisconnect}
+              style={{
+                padding: '6px 10px',
+                borderRadius: 6,
+                border: '1px solid #fca5a5',
+                color: '#b91c1c',
+                background: '#fef2f2',
+                cursor: 'pointer',
+              }}
+            >
+              Reconnect
+            </button>
+          </div>
+
+          <div style={{ display: 'flex', height: 'calc(100vh - 140px)' }}>
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+              <div
+                style={{
+                  flex: showCode ? '1 1 64%' : '1 1 100%',
+                  overflow: 'hidden',
+                  minHeight: 0,
+                }}
+              >
+                <SupersubsetDesigner
+                  value={currentDashboard}
+                  onChange={undoRedo.push}
+                  onPublish={undoRedo.push}
+                  headerTitle="Supersubset Probe Designer"
+                  height="100%"
+                  datasets={datasets}
+                  headerActions={
+                    <div
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 6,
+                        flexWrap: 'nowrap',
+                        overflowX: 'auto',
+                        overflowY: 'hidden',
+                        minWidth: 0,
+                      }}
+                    >
+                      <UndoRedoToolbar
+                        canUndo={undoRedo.canUndo}
+                        canRedo={undoRedo.canRedo}
+                        onUndo={undoRedo.undo}
+                        onRedo={undoRedo.redo}
+                        undoCount={undoRedo.undoCount}
+                        redoCount={undoRedo.redoCount}
+                      />
+                      <ImportExportPanel dashboard={currentDashboard} onImport={undoRedo.reset} />
+                    </div>
+                  }
+                />
+              </div>
+              {showCode && (
+                <div style={{ flex: '0 0 280px', borderTop: '2px solid #e2e8f0' }}>
+                  <CodeViewPanel dashboard={currentDashboard} height="280px" />
+                </div>
+              )}
+            </div>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/packages/dev-app/src/probe/auth.test.ts
+++ b/packages/dev-app/src/probe/auth.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearProbeSession,
+  loadProbeSession,
+  normalizeBaseUrl,
+  saveProbeSession,
+  toAuthHeader,
+} from './auth';
+
+describe('probe auth helpers', () => {
+  let memoryStore: Map<string, string>;
+
+  beforeEach(() => {
+    memoryStore = new Map<string, string>();
+    vi.stubGlobal('window', {
+      sessionStorage: {
+        getItem: (key: string) => memoryStore.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          memoryStore.set(key, value);
+        },
+        removeItem: (key: string) => {
+          memoryStore.delete(key);
+        },
+        clear: () => {
+          memoryStore.clear();
+        },
+      },
+    });
+
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('normalizes base URL by trimming whitespace and trailing slash', () => {
+    expect(normalizeBaseUrl('  https://api.example.com///  ')).toBe('https://api.example.com');
+  });
+
+  it('builds bearer auth header', () => {
+    expect(toAuthHeader('bearer', 'token123', '', '')).toEqual({
+      name: 'Authorization',
+      value: 'Bearer token123',
+    });
+  });
+
+  it('persists and restores session config', () => {
+    saveProbeSession({
+      baseUrl: 'https://api.example.com',
+      authMode: 'custom',
+      jwt: '',
+      customHeaderName: 'X-Token',
+      customHeaderValue: 'abc',
+    });
+
+    expect(loadProbeSession()).toEqual({
+      baseUrl: 'https://api.example.com',
+      authMode: 'custom',
+      jwt: '',
+      customHeaderName: 'X-Token',
+      customHeaderValue: 'abc',
+    });
+  });
+
+  it('clears session config', () => {
+    saveProbeSession({
+      baseUrl: 'https://api.example.com',
+      authMode: 'bearer',
+      jwt: 'jwt',
+      customHeaderName: '',
+      customHeaderValue: '',
+    });
+
+    clearProbeSession();
+    expect(loadProbeSession()).toBeNull();
+  });
+
+  it('returns null for malformed session payload', () => {
+    window.sessionStorage.setItem('supersubset.dev.probe.session', 'invalid-json');
+
+    expect(loadProbeSession()).toBeNull();
+  });
+
+  it('returns undefined when credentials are not provided', () => {
+    expect(toAuthHeader('bearer', '', '', '')).toBeUndefined();
+    expect(toAuthHeader('custom', '', 'X-Test', '')).toBeUndefined();
+  });
+
+  it('is resilient if sessionStorage is unavailable', () => {
+    const getItem = vi.spyOn(window.sessionStorage, 'getItem').mockImplementation(() => {
+      throw new Error('disabled');
+    });
+
+    expect(loadProbeSession()).toBeNull();
+
+    getItem.mockRestore();
+  });
+});

--- a/packages/dev-app/src/probe/auth.test.ts
+++ b/packages/dev-app/src/probe/auth.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  DEFAULT_LOGIN_MUTATION,
+  DEFAULT_LOGIN_TOKEN_PATH,
   clearProbeSession,
+  createDefaultLoginConfig,
+  extractByPath,
   loadProbeSession,
   normalizeBaseUrl,
+  performProbeLogin,
   saveProbeSession,
+  stripLeadingBearerPrefix,
   toAuthHeader,
 } from './auth';
 
@@ -46,6 +52,26 @@ describe('probe auth helpers', () => {
     });
   });
 
+  it('strips pasted Bearer prefix so the header is not doubled', () => {
+    expect(stripLeadingBearerPrefix('  Bearer eyJhbG.test  ')).toBe('eyJhbG.test');
+    expect(stripLeadingBearerPrefix('bearer abc')).toBe('abc');
+    expect(toAuthHeader('bearer', 'Bearer eyJhbG', '', '')).toEqual({
+      name: 'Authorization',
+      value: 'Bearer eyJhbG',
+    });
+  });
+
+  it('uses loginToken as bearer when in login auth mode', () => {
+    expect(toAuthHeader('login', '', '', '', 'jwt-from-login')).toEqual({
+      name: 'Authorization',
+      value: 'Bearer jwt-from-login',
+    });
+  });
+
+  it('returns undefined in login mode without a loginToken', () => {
+    expect(toAuthHeader('login', '', '', '')).toBeUndefined();
+  });
+
   it('persists and restores session config', () => {
     saveProbeSession({
       metadataSourceMode: 'discovery-url',
@@ -56,6 +82,7 @@ describe('probe auth helpers', () => {
       jwt: '',
       customHeaderName: 'X-Token',
       customHeaderValue: 'abc',
+      ...createDefaultLoginConfig(),
     });
 
     expect(loadProbeSession()).toEqual({
@@ -67,7 +94,37 @@ describe('probe auth helpers', () => {
       jwt: '',
       customHeaderName: 'X-Token',
       customHeaderValue: 'abc',
+      loginUrl: '',
+      loginMutation: DEFAULT_LOGIN_MUTATION,
+      loginEmail: '',
+      loginPassword: '',
+      loginTokenPath: DEFAULT_LOGIN_TOKEN_PATH,
     });
+  });
+
+  it('persists and restores login mode credentials', () => {
+    saveProbeSession({
+      metadataSourceMode: 'discovery-url',
+      discoveryUrl: 'https://api.example.com',
+      metadataJson: '',
+      queryUrl: '',
+      authMode: 'login',
+      jwt: '',
+      customHeaderName: '',
+      customHeaderValue: '',
+      loginUrl: 'https://api.example.com/graphql',
+      loginMutation: DEFAULT_LOGIN_MUTATION,
+      loginEmail: 'dev@example.com',
+      loginPassword: 'shh',
+      loginTokenPath: 'data.login.accessToken',
+    });
+
+    const restored = loadProbeSession();
+    expect(restored?.authMode).toBe('login');
+    expect(restored?.loginUrl).toBe('https://api.example.com/graphql');
+    expect(restored?.loginEmail).toBe('dev@example.com');
+    expect(restored?.loginPassword).toBe('shh');
+    expect(restored?.loginTokenPath).toBe('data.login.accessToken');
   });
 
   it('clears session config', () => {
@@ -80,6 +137,7 @@ describe('probe auth helpers', () => {
       jwt: 'jwt',
       customHeaderName: '',
       customHeaderValue: '',
+      ...createDefaultLoginConfig(),
     });
 
     clearProbeSession();
@@ -111,6 +169,11 @@ describe('probe auth helpers', () => {
       jwt: 'jwt',
       customHeaderName: '',
       customHeaderValue: '',
+      loginUrl: '',
+      loginMutation: DEFAULT_LOGIN_MUTATION,
+      loginEmail: '',
+      loginPassword: '',
+      loginTokenPath: DEFAULT_LOGIN_TOKEN_PATH,
     });
   });
 
@@ -127,5 +190,138 @@ describe('probe auth helpers', () => {
     expect(loadProbeSession()).toBeNull();
 
     getItem.mockRestore();
+  });
+});
+
+describe('extractByPath', () => {
+  it('walks a dotted path on nested objects', () => {
+    expect(
+      extractByPath({ data: { login: { accessToken: 'tok' } } }, 'data.login.accessToken'),
+    ).toBe('tok');
+  });
+
+  it('returns undefined when any segment is missing', () => {
+    expect(extractByPath({ data: {} }, 'data.login.accessToken')).toBeUndefined();
+    expect(extractByPath(null, 'data.x')).toBeUndefined();
+  });
+
+  it('ignores leading/trailing dots and whitespace in path parts', () => {
+    expect(extractByPath({ a: { b: 1 } }, ' a . b ')).toBe(1);
+  });
+});
+
+describe('performProbeLogin', () => {
+  it('posts a GraphQL login mutation with variables and returns the extracted token', async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: { login: { accessToken: 'jwt-abc' } } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+
+    const result = await performProbeLogin(
+      {
+        ...createDefaultLoginConfig(),
+        loginUrl: 'https://api.example.com/graphql',
+        loginEmail: 'dev@example.com',
+        loginPassword: 'secret',
+      },
+      { fetcher },
+    );
+
+    expect(result.token).toBe('jwt-abc');
+
+    const [url, init] = fetcher.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://api.example.com/graphql');
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/json');
+    const body = JSON.parse(String(init.body));
+    expect(body.query).toContain('mutation login');
+    expect(body.variables).toEqual({ email: 'dev@example.com', password: 'secret' });
+  });
+
+  it('throws a descriptive error when the response contains GraphQL errors', async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ errors: [{ message: 'Invalid credentials' }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+
+    await expect(
+      performProbeLogin(
+        {
+          ...createDefaultLoginConfig(),
+          loginUrl: 'https://api.example.com/graphql',
+          loginEmail: 'dev@example.com',
+          loginPassword: 'wrong',
+        },
+        { fetcher },
+      ),
+    ).rejects.toThrow(/Invalid credentials/);
+  });
+
+  it('throws when the token path cannot be resolved', async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: { login: {} } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+
+    await expect(
+      performProbeLogin(
+        {
+          ...createDefaultLoginConfig(),
+          loginUrl: 'https://api.example.com/graphql',
+          loginEmail: 'dev@example.com',
+          loginPassword: 'secret',
+        },
+        { fetcher },
+      ),
+    ).rejects.toThrow(/no token was found/);
+  });
+
+  it('rejects when email or password is missing', async () => {
+    const fetcher = vi.fn();
+    await expect(
+      performProbeLogin(
+        {
+          ...createDefaultLoginConfig(),
+          loginUrl: 'https://api.example.com/graphql',
+          loginEmail: '',
+          loginPassword: '',
+        },
+        { fetcher: fetcher as unknown as typeof fetch },
+      ),
+    ).rejects.toThrow(/required/);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('surfaces HTTP errors with status code', async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ errors: [{ message: 'Boom' }] }), {
+          status: 500,
+          statusText: 'Internal Server Error',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+
+    await expect(
+      performProbeLogin(
+        {
+          ...createDefaultLoginConfig(),
+          loginUrl: 'https://api.example.com/graphql',
+          loginEmail: 'dev@example.com',
+          loginPassword: 'secret',
+        },
+        { fetcher },
+      ),
+    ).rejects.toThrow(/500.*Boom/);
   });
 });

--- a/packages/dev-app/src/probe/auth.test.ts
+++ b/packages/dev-app/src/probe/auth.test.ts
@@ -48,7 +48,10 @@ describe('probe auth helpers', () => {
 
   it('persists and restores session config', () => {
     saveProbeSession({
-      baseUrl: 'https://api.example.com',
+      metadataSourceMode: 'discovery-url',
+      discoveryUrl: 'https://api.example.com/supersubset/datasets',
+      metadataJson: '',
+      queryUrl: 'https://api.example.com/supersubset/query',
       authMode: 'custom',
       jwt: '',
       customHeaderName: 'X-Token',
@@ -56,7 +59,10 @@ describe('probe auth helpers', () => {
     });
 
     expect(loadProbeSession()).toEqual({
-      baseUrl: 'https://api.example.com',
+      metadataSourceMode: 'discovery-url',
+      discoveryUrl: 'https://api.example.com/supersubset/datasets',
+      metadataJson: '',
+      queryUrl: 'https://api.example.com/supersubset/query',
       authMode: 'custom',
       jwt: '',
       customHeaderName: 'X-Token',
@@ -66,7 +72,10 @@ describe('probe auth helpers', () => {
 
   it('clears session config', () => {
     saveProbeSession({
-      baseUrl: 'https://api.example.com',
+      metadataSourceMode: 'paste-json',
+      discoveryUrl: '',
+      metadataJson: '{"datasets":[]}',
+      queryUrl: '',
       authMode: 'bearer',
       jwt: 'jwt',
       customHeaderName: '',
@@ -81,6 +90,28 @@ describe('probe auth helpers', () => {
     window.sessionStorage.setItem('supersubset.dev.probe.session', 'invalid-json');
 
     expect(loadProbeSession()).toBeNull();
+  });
+
+  it('supports legacy session payloads that stored a single baseUrl', () => {
+    window.sessionStorage.setItem(
+      'supersubset.dev.probe.session',
+      JSON.stringify({
+        baseUrl: 'https://api.example.com',
+        authMode: 'bearer',
+        jwt: 'jwt',
+      }),
+    );
+
+    expect(loadProbeSession()).toEqual({
+      metadataSourceMode: 'discovery-url',
+      discoveryUrl: 'https://api.example.com',
+      metadataJson: '',
+      queryUrl: 'https://api.example.com',
+      authMode: 'bearer',
+      jwt: 'jwt',
+      customHeaderName: '',
+      customHeaderValue: '',
+    });
   });
 
   it('returns undefined when credentials are not provided', () => {

--- a/packages/dev-app/src/probe/auth.ts
+++ b/packages/dev-app/src/probe/auth.ts
@@ -1,0 +1,96 @@
+export interface AuthHeader {
+  name: string;
+  value: string;
+}
+
+export type ProbeAuthMode = 'bearer' | 'custom';
+
+export interface ProbeSessionConfig {
+  baseUrl: string;
+  authMode: ProbeAuthMode;
+  jwt: string;
+  customHeaderName: string;
+  customHeaderValue: string;
+}
+
+const SESSION_STORAGE_KEY = 'supersubset.dev.probe.session';
+
+export function normalizeBaseUrl(input: string): string {
+  return input.trim().replace(/\/+$/, '');
+}
+
+export function toAuthHeader(
+  authMode: ProbeAuthMode,
+  jwt: string,
+  customHeaderName: string,
+  customHeaderValue: string,
+): AuthHeader | undefined {
+  if (authMode === 'bearer') {
+    const token = jwt.trim();
+    if (!token) return undefined;
+    return { name: 'Authorization', value: `Bearer ${token}` };
+  }
+
+  const name = customHeaderName.trim();
+  const value = customHeaderValue.trim();
+  if (!name || !value) return undefined;
+  return { name, value };
+}
+
+export function saveProbeSession(config: ProbeSessionConfig): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(config));
+  } catch {
+    // Ignore storage write errors in restricted browser environments.
+  }
+}
+
+export function loadProbeSession(): ProbeSessionConfig | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  let raw: string | null;
+  try {
+    raw = window.sessionStorage.getItem(SESSION_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as ProbeSessionConfig;
+    if (!parsed?.baseUrl || !parsed?.authMode) {
+      return null;
+    }
+
+    return {
+      baseUrl: parsed.baseUrl,
+      authMode: parsed.authMode,
+      jwt: parsed.jwt ?? '',
+      customHeaderName: parsed.customHeaderName ?? '',
+      customHeaderValue: parsed.customHeaderValue ?? '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function clearProbeSession(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.sessionStorage.removeItem(SESSION_STORAGE_KEY);
+  } catch {
+    // Ignore storage clear errors in restricted browser environments.
+  }
+}

--- a/packages/dev-app/src/probe/auth.ts
+++ b/packages/dev-app/src/probe/auth.ts
@@ -4,9 +4,13 @@ export interface AuthHeader {
 }
 
 export type ProbeAuthMode = 'bearer' | 'custom';
+export type ProbeMetadataSourceMode = 'discovery-url' | 'paste-json';
 
 export interface ProbeSessionConfig {
-  baseUrl: string;
+  metadataSourceMode: ProbeMetadataSourceMode;
+  discoveryUrl: string;
+  metadataJson: string;
+  queryUrl: string;
   authMode: ProbeAuthMode;
   jwt: string;
   customHeaderName: string;
@@ -66,13 +70,20 @@ export function loadProbeSession(): ProbeSessionConfig | null {
   }
 
   try {
-    const parsed = JSON.parse(raw) as ProbeSessionConfig;
-    if (!parsed?.baseUrl || !parsed?.authMode) {
+    const parsed = JSON.parse(raw) as Partial<ProbeSessionConfig> & { baseUrl?: string };
+    if (!parsed?.authMode) {
       return null;
     }
 
+    const legacyBaseUrl = typeof parsed.baseUrl === 'string' ? parsed.baseUrl : '';
+    const metadataSourceMode: ProbeMetadataSourceMode =
+      parsed.metadataSourceMode === 'paste-json' ? 'paste-json' : 'discovery-url';
+
     return {
-      baseUrl: parsed.baseUrl,
+      metadataSourceMode,
+      discoveryUrl: parsed.discoveryUrl ?? legacyBaseUrl,
+      metadataJson: parsed.metadataJson ?? '',
+      queryUrl: parsed.queryUrl ?? legacyBaseUrl,
       authMode: parsed.authMode,
       jwt: parsed.jwt ?? '',
       customHeaderName: parsed.customHeaderName ?? '',

--- a/packages/dev-app/src/probe/auth.ts
+++ b/packages/dev-app/src/probe/auth.ts
@@ -3,10 +3,18 @@ export interface AuthHeader {
   value: string;
 }
 
-export type ProbeAuthMode = 'bearer' | 'custom';
+export type ProbeAuthMode = 'bearer' | 'custom' | 'login';
 export type ProbeMetadataSourceMode = 'discovery-url' | 'paste-json';
 
-export interface ProbeSessionConfig {
+export interface ProbeLoginConfig {
+  loginUrl: string;
+  loginMutation: string;
+  loginEmail: string;
+  loginPassword: string;
+  loginTokenPath: string;
+}
+
+export interface ProbeSessionConfig extends ProbeLoginConfig {
   metadataSourceMode: ProbeMetadataSourceMode;
   discoveryUrl: string;
   metadataJson: string;
@@ -19,8 +27,42 @@ export interface ProbeSessionConfig {
 
 const SESSION_STORAGE_KEY = 'supersubset.dev.probe.session';
 
+/**
+ * Default login mutation targets the tripmatch/bi-data-mart GraphQL server
+ * (`mutation login($email, $password) { login(data: { ... }) { accessToken } }`).
+ * Users can edit the mutation text to match other GraphQL backends.
+ */
+export const DEFAULT_LOGIN_MUTATION = `mutation login($email: String!, $password: String!) {
+  login(data: { email: $email, password: $password }) {
+    accessToken
+  }
+}`;
+
+export const DEFAULT_LOGIN_TOKEN_PATH = 'data.login.accessToken';
+
+export function createDefaultLoginConfig(): ProbeLoginConfig {
+  return {
+    loginUrl: '',
+    loginMutation: DEFAULT_LOGIN_MUTATION,
+    loginEmail: '',
+    loginPassword: '',
+    loginTokenPath: DEFAULT_LOGIN_TOKEN_PATH,
+  };
+}
+
 export function normalizeBaseUrl(input: string): string {
   return input.trim().replace(/\/+$/, '');
+}
+
+/**
+ * JWT field already gets `Bearer ` prepended in bearer mode. Strip a pasted prefix
+ * so we never send `Authorization: Bearer Bearer <token>`.
+ */
+export function stripLeadingBearerPrefix(input: string): string {
+  return input
+    .trim()
+    .replace(/^bearer\s+/i, '')
+    .trim();
 }
 
 export function toAuthHeader(
@@ -28,9 +70,16 @@ export function toAuthHeader(
   jwt: string,
   customHeaderName: string,
   customHeaderValue: string,
+  loginToken?: string,
 ): AuthHeader | undefined {
   if (authMode === 'bearer') {
-    const token = jwt.trim();
+    const token = stripLeadingBearerPrefix(jwt);
+    if (!token) return undefined;
+    return { name: 'Authorization', value: `Bearer ${token}` };
+  }
+
+  if (authMode === 'login') {
+    const token = stripLeadingBearerPrefix(loginToken ?? '');
     if (!token) return undefined;
     return { name: 'Authorization', value: `Bearer ${token}` };
   }
@@ -39,6 +88,120 @@ export function toAuthHeader(
   const value = customHeaderValue.trim();
   if (!name || !value) return undefined;
   return { name, value };
+}
+
+/**
+ * Walk a dotted path (e.g. `data.login.accessToken`) on an object tree.
+ * Returns `undefined` if any segment is missing or not traversable.
+ */
+export function extractByPath(value: unknown, path: string): unknown {
+  const parts = path
+    .split('.')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  let current: unknown = value;
+  for (const part of parts) {
+    if (current == null || typeof current !== 'object') {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+function summarizeGraphqlErrors(errors: unknown): string | undefined {
+  if (!Array.isArray(errors) || errors.length === 0) return undefined;
+  const messages = errors
+    .map((err) => {
+      if (err && typeof err === 'object' && 'message' in err) {
+        return String((err as { message?: unknown }).message ?? '').trim();
+      }
+      return String(err);
+    })
+    .filter(Boolean);
+  return messages.length > 0 ? messages.join('; ') : undefined;
+}
+
+export interface ProbeLoginResult {
+  token: string;
+  payload: unknown;
+}
+
+/**
+ * Runs a GraphQL-style login mutation (POST with `{ query, variables }`) and
+ * extracts a bearer token from the response at the configured path. This keeps
+ * the dev probe compatible with any GraphQL server that returns a JWT under a
+ * known response path (tripmatch/bi-data-mart is the preconfigured default).
+ */
+export async function performProbeLogin(
+  config: ProbeLoginConfig,
+  options: { fetcher?: typeof fetch } = {},
+): Promise<ProbeLoginResult> {
+  const loginUrl = config.loginUrl.trim();
+  if (!loginUrl) {
+    throw new Error('Login URL is required.');
+  }
+
+  const mutation = config.loginMutation.trim();
+  if (!mutation) {
+    throw new Error('Login mutation is required.');
+  }
+
+  const tokenPath = config.loginTokenPath.trim();
+  if (!tokenPath) {
+    throw new Error('Login token path is required.');
+  }
+
+  const email = config.loginEmail.trim();
+  if (!email || !config.loginPassword) {
+    throw new Error('Email and password are required for login.');
+  }
+
+  const fetcher = options.fetcher ?? globalThis.fetch.bind(globalThis);
+  const response = await fetcher(loginUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      query: mutation,
+      variables: { email, password: config.loginPassword },
+    }),
+  });
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = undefined;
+  }
+
+  if (!response.ok) {
+    const gqlError = summarizeGraphqlErrors(
+      payload && typeof payload === 'object' && 'errors' in payload
+        ? (payload as { errors?: unknown }).errors
+        : undefined,
+    );
+    const suffix = gqlError ?? response.statusText ?? 'Unknown error';
+    throw new Error(`Login failed (${response.status}): ${suffix}`);
+  }
+
+  const gqlError = summarizeGraphqlErrors(
+    payload && typeof payload === 'object' && 'errors' in payload
+      ? (payload as { errors?: unknown }).errors
+      : undefined,
+  );
+  if (gqlError) {
+    throw new Error(`Login failed: ${gqlError}`);
+  }
+
+  const rawToken = extractByPath(payload, tokenPath);
+  const token = typeof rawToken === 'string' ? stripLeadingBearerPrefix(rawToken) : '';
+  if (!token) {
+    throw new Error(
+      `Login succeeded but no token was found at "${tokenPath}". Adjust the token path to match the response shape.`,
+    );
+  }
+
+  return { token, payload };
 }
 
 export function saveProbeSession(config: ProbeSessionConfig): void {
@@ -79,6 +242,8 @@ export function loadProbeSession(): ProbeSessionConfig | null {
     const metadataSourceMode: ProbeMetadataSourceMode =
       parsed.metadataSourceMode === 'paste-json' ? 'paste-json' : 'discovery-url';
 
+    const loginDefaults = createDefaultLoginConfig();
+
     return {
       metadataSourceMode,
       discoveryUrl: parsed.discoveryUrl ?? legacyBaseUrl,
@@ -88,6 +253,11 @@ export function loadProbeSession(): ProbeSessionConfig | null {
       jwt: parsed.jwt ?? '',
       customHeaderName: parsed.customHeaderName ?? '',
       customHeaderValue: parsed.customHeaderValue ?? '',
+      loginUrl: parsed.loginUrl ?? loginDefaults.loginUrl,
+      loginMutation: parsed.loginMutation ?? loginDefaults.loginMutation,
+      loginEmail: parsed.loginEmail ?? loginDefaults.loginEmail,
+      loginPassword: parsed.loginPassword ?? loginDefaults.loginPassword,
+      loginTokenPath: parsed.loginTokenPath ?? loginDefaults.loginTokenPath,
     };
   } catch {
     return null;

--- a/packages/dev-app/src/probe/errors.ts
+++ b/packages/dev-app/src/probe/errors.ts
@@ -1,0 +1,27 @@
+export function toProbeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    if (/Failed to fetch/i.test(error.message)) {
+      return 'Connection failed. Check the backend URL and CORS policy, then try again.';
+    }
+
+    return error.message;
+  }
+
+  return 'Unexpected probe error. Please try again.';
+}
+
+export async function parseErrorResponse(response: Response): Promise<never> {
+  let details = '';
+
+  try {
+    const payload = await response.json();
+    if (typeof payload === 'object' && payload && 'message' in payload) {
+      details = String((payload as { message?: unknown }).message ?? '').trim();
+    }
+  } catch {
+    // Ignore body parsing errors and fallback to status text.
+  }
+
+  const suffix = details || response.statusText || 'Unknown error';
+  throw new Error(`Probe request failed (${response.status}): ${suffix}`);
+}

--- a/packages/dev-app/src/probe/http-adapters.test.ts
+++ b/packages/dev-app/src/probe/http-adapters.test.ts
@@ -4,6 +4,35 @@ import { HttpMetadataAdapter, HttpQueryAdapter } from './http-adapters';
 import { toAuthHeader } from './auth';
 
 describe('http adapters', () => {
+  it('binds the default global fetch implementation', async () => {
+    const originalFetch = globalThis.fetch;
+    const calls: string[] = [];
+
+    function sensitiveFetch(this: typeof globalThis, input: RequestInfo | URL): Promise<Response> {
+      if (this !== globalThis) {
+        throw new TypeError('Illegal invocation');
+      }
+
+      calls.push(String(input));
+      return Promise.resolve(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    }
+
+    globalThis.fetch = sensitiveFetch as typeof fetch;
+
+    try {
+      const adapter = new HttpMetadataAdapter();
+      await adapter.getDatasets('https://example.com');
+      expect(calls).toEqual(['https://example.com/supersubset/datasets']);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('injects bearer auth header for metadata probe', async () => {
     const fetcher = vi.fn(
       async () =>

--- a/packages/dev-app/src/probe/http-adapters.test.ts
+++ b/packages/dev-app/src/probe/http-adapters.test.ts
@@ -89,4 +89,20 @@ describe('http adapters', () => {
     expect(headers.get('Content-Type')).toBe('application/json');
     expect(init.body).toContain('"datasetId":"orders"');
   });
+
+  it('accepts direct discovery endpoint URLs without appending another suffix', async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+
+    const adapter = new HttpMetadataAdapter({ fetcher });
+    await adapter.getDatasets('https://example.com/supersubset/datasets');
+
+    const [url] = fetcher.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://example.com/supersubset/datasets');
+  });
 });

--- a/packages/dev-app/src/probe/http-adapters.test.ts
+++ b/packages/dev-app/src/probe/http-adapters.test.ts
@@ -84,6 +84,38 @@ describe('http adapters', () => {
     expect(datasets[0]?.id).toBe('orders');
   });
 
+  it('treats URLs ending in /query as terminal endpoints and does not double-append', async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ columns: [], rows: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+
+    const adapter = new HttpQueryAdapter('http://localhost:3660/api/analytics/query', { fetcher });
+    expect(adapter.resolvedUrl).toBe('http://localhost:3660/api/analytics/query');
+
+    await adapter.execute({ datasetId: 'fact_messages', fields: [{ fieldId: 'sent_date' }] });
+    const [url] = fetcher.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('http://localhost:3660/api/analytics/query');
+  });
+
+  it('treats URLs ending in /datasets as terminal discovery endpoints', async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+
+    const adapter = new HttpMetadataAdapter({ fetcher });
+    await adapter.getDatasets('https://example.com/v2/datasets');
+    const [url] = fetcher.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://example.com/v2/datasets');
+  });
+
   it('posts logical query to query endpoint with custom header', async () => {
     const fetcher = vi.fn(
       async () =>
@@ -117,6 +149,41 @@ describe('http adapters', () => {
     expect(headers.get('X-Api-Key')).toBe('dev-key');
     expect(headers.get('Content-Type')).toBe('application/json');
     expect(init.body).toContain('"datasetId":"orders"');
+  });
+
+  it('infers missing field roles so role-filtered pickers can find them', async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify([
+            {
+              id: 'dim_users',
+              label: 'Users',
+              fields: [
+                { id: 'user_id', dataType: 'integer' },
+                { id: 'signup_date', dataType: 'date' },
+                { id: 'country', dataType: 'string' },
+                { id: 'revenue', dataType: 'number' },
+              ],
+            },
+          ]),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+    );
+
+    const adapter = new HttpMetadataAdapter({ fetcher });
+    const [dataset] = await adapter.getDatasets('https://example.com');
+
+    const byId = Object.fromEntries((dataset?.fields ?? []).map((field) => [field.id, field]));
+
+    expect(byId.user_id?.role).toBe('key');
+    expect(byId.signup_date?.role).toBe('time');
+    expect(byId.country?.role).toBe('dimension');
+    expect(byId.revenue?.role).toBe('measure');
+    expect(byId.country?.label).toBe('Country');
   });
 
   it('accepts direct discovery endpoint URLs without appending another suffix', async () => {

--- a/packages/dev-app/src/probe/http-adapters.test.ts
+++ b/packages/dev-app/src/probe/http-adapters.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { HttpMetadataAdapter, HttpQueryAdapter } from './http-adapters';
+import { toAuthHeader } from './auth';
+
+describe('http adapters', () => {
+  it('injects bearer auth header for metadata probe', async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+
+    const adapter = new HttpMetadataAdapter({
+      authHeader: toAuthHeader('bearer', 'token-123', '', ''),
+      fetcher,
+    });
+
+    await adapter.getDatasets('https://example.com/');
+
+    const [url, init] = fetcher.mock.calls[0] as unknown as [string, RequestInit];
+    const headers = init.headers as Headers;
+
+    expect(url).toBe('https://example.com/supersubset/datasets');
+    expect(init.method).toBe('GET');
+    expect(headers.get('Authorization')).toBe('Bearer token-123');
+  });
+
+  it('accepts payload wrapped under datasets property', async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            datasets: [
+              {
+                id: 'orders',
+                label: 'Orders',
+                fields: [],
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+    );
+
+    const adapter = new HttpMetadataAdapter({ fetcher });
+    const datasets = await adapter.getDatasets('https://example.com');
+
+    expect(datasets).toHaveLength(1);
+    expect(datasets[0]?.id).toBe('orders');
+  });
+
+  it('posts logical query to query endpoint with custom header', async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            columns: [{ fieldId: 'orders', label: 'Orders', dataType: 'integer' }],
+            rows: [{ orders: 12 }],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+    );
+
+    const adapter = new HttpQueryAdapter('https://api.acme.dev/', {
+      authHeader: toAuthHeader('custom', '', 'X-Api-Key', 'dev-key'),
+      fetcher,
+    });
+
+    await adapter.execute({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'orders', aggregation: 'count' }],
+    });
+
+    const [url, init] = fetcher.mock.calls[0] as unknown as [string, RequestInit];
+    const headers = init.headers as Headers;
+
+    expect(url).toBe('https://api.acme.dev/supersubset/query');
+    expect(init.method).toBe('POST');
+    expect(headers.get('X-Api-Key')).toBe('dev-key');
+    expect(headers.get('Content-Type')).toBe('application/json');
+    expect(init.body).toContain('"datasetId":"orders"');
+  });
+});

--- a/packages/dev-app/src/probe/http-adapters.ts
+++ b/packages/dev-app/src/probe/http-adapters.ts
@@ -54,7 +54,7 @@ export class HttpMetadataAdapter implements MetadataAdapter<string> {
 
   constructor(options: HttpAdapterOptions = {}) {
     this.authHeader = options.authHeader;
-    this.fetcher = options.fetcher ?? fetch;
+    this.fetcher = options.fetcher ?? globalThis.fetch.bind(globalThis);
   }
 
   async getDatasets(source: string): Promise<NormalizedDataset[]> {
@@ -98,7 +98,7 @@ export class HttpQueryAdapter implements QueryAdapter {
   constructor(baseUrl: string, options: HttpAdapterOptions = {}) {
     this.baseUrl = normalizeBaseUrl(baseUrl);
     this.authHeader = options.authHeader;
-    this.fetcher = options.fetcher ?? fetch;
+    this.fetcher = options.fetcher ?? globalThis.fetch.bind(globalThis);
   }
 
   async execute(query: LogicalQuery): Promise<QueryResult> {

--- a/packages/dev-app/src/probe/http-adapters.ts
+++ b/packages/dev-app/src/probe/http-adapters.ts
@@ -2,9 +2,11 @@ import type {
   LogicalQuery,
   MetadataAdapter,
   NormalizedDataset,
+  NormalizedField,
   QueryAdapter,
   QueryResult,
 } from '@supersubset/data-model';
+import { humanizeFieldName, inferAggregation, inferFieldRole } from '@supersubset/data-model';
 
 import type { AuthHeader } from './auth';
 import { normalizeBaseUrl } from './auth';
@@ -29,21 +31,71 @@ function createHeaders(authHeader?: AuthHeader, includeJsonContentType?: boolean
   return headers;
 }
 
-function resolveEndpointUrl(input: string, suffix: string): string {
+/**
+ * A URL is considered "already a terminal endpoint" when it ends with the
+ * canonical Supersubset suffix OR a plain `/datasets` / `/query` path —
+ * those aren't plausible base-URL suffixes, so using them as-is is safe and
+ * avoids producing nonsense URLs like `.../api/analytics/query/supersubset/query`.
+ *
+ * Conventional base URLs (e.g. `.../api/analytics/catalog`) are still
+ * auto-suffixed because `catalog` isn't in the terminal list.
+ */
+const DATASETS_TERMINAL_SUFFIXES = ['/supersubset/datasets', '/datasets'];
+const QUERY_TERMINAL_SUFFIXES = ['/supersubset/query', '/query'];
+
+function resolveEndpointUrl(
+  input: string,
+  canonicalSuffix: string,
+  terminalSuffixes: readonly string[],
+): string {
   const normalized = normalizeBaseUrl(input);
-  return normalized.endsWith(suffix) ? normalized : `${normalized}${suffix}`;
+  for (const suffix of terminalSuffixes) {
+    if (normalized.endsWith(suffix)) {
+      return normalized;
+    }
+  }
+  return `${normalized}${canonicalSuffix}`;
 }
 
-function resolveDatasetsUrl(baseUrl: string): string {
-  return resolveEndpointUrl(baseUrl, '/supersubset/datasets');
+export function resolveDatasetsUrl(baseUrl: string): string {
+  return resolveEndpointUrl(baseUrl, '/supersubset/datasets', DATASETS_TERMINAL_SUFFIXES);
 }
 
-function resolveQueryUrl(baseUrl: string): string {
-  return resolveEndpointUrl(baseUrl, '/supersubset/query');
+export function resolveQueryUrl(baseUrl: string): string {
+  return resolveEndpointUrl(baseUrl, '/supersubset/query', QUERY_TERMINAL_SUFFIXES);
 }
 
 function isDatasetArray(value: unknown): value is NormalizedDataset[] {
   return Array.isArray(value);
+}
+
+/**
+ * Backends occasionally return fields without a `role` (or with missing
+ * `label`/`defaultAggregation`) since those are optional hints for the
+ * designer. Infer them here so role-filtered field pickers (X-Axis, Y-Axis,
+ * Series, etc.) can discover the fields. This mirrors the inference that
+ * `@supersubset/adapter-json` applies to pasted metadata.
+ */
+function normalizeFetchedField(field: NormalizedField): NormalizedField {
+  const role = field.role ?? inferFieldRole(field.id, field.dataType);
+  const defaultAggregation = field.defaultAggregation ?? inferAggregation(role, field.dataType);
+  return {
+    ...field,
+    label: field.label ?? humanizeFieldName(field.id),
+    role,
+    ...(defaultAggregation !== undefined && { defaultAggregation }),
+  };
+}
+
+function normalizeFetchedDataset(dataset: NormalizedDataset): NormalizedDataset {
+  return {
+    ...dataset,
+    fields: Array.isArray(dataset.fields) ? dataset.fields.map(normalizeFetchedField) : [],
+  };
+}
+
+function normalizeFetchedDatasets(datasets: NormalizedDataset[]): NormalizedDataset[] {
+  return datasets.map(normalizeFetchedDataset);
 }
 
 export class HttpMetadataAdapter implements MetadataAdapter<string> {
@@ -69,13 +121,13 @@ export class HttpMetadataAdapter implements MetadataAdapter<string> {
 
     const payload = (await response.json()) as unknown;
     if (isDatasetArray(payload)) {
-      return payload;
+      return normalizeFetchedDatasets(payload);
     }
 
     if (typeof payload === 'object' && payload && 'datasets' in payload) {
       const datasets = (payload as { datasets?: unknown }).datasets;
       if (isDatasetArray(datasets)) {
-        return datasets;
+        return normalizeFetchedDatasets(datasets);
       }
     }
 
@@ -101,8 +153,13 @@ export class HttpQueryAdapter implements QueryAdapter {
     this.fetcher = options.fetcher ?? globalThis.fetch.bind(globalThis);
   }
 
+  /** The exact URL this adapter POSTs to — useful for debugging banners. */
+  get resolvedUrl(): string {
+    return resolveQueryUrl(this.baseUrl);
+  }
+
   async execute(query: LogicalQuery): Promise<QueryResult> {
-    const response = await this.fetcher(resolveQueryUrl(this.baseUrl), {
+    const response = await this.fetcher(this.resolvedUrl, {
       method: 'POST',
       headers: createHeaders(this.authHeader, true),
       body: JSON.stringify(query),

--- a/packages/dev-app/src/probe/http-adapters.ts
+++ b/packages/dev-app/src/probe/http-adapters.ts
@@ -29,12 +29,17 @@ function createHeaders(authHeader?: AuthHeader, includeJsonContentType?: boolean
   return headers;
 }
 
+function resolveEndpointUrl(input: string, suffix: string): string {
+  const normalized = normalizeBaseUrl(input);
+  return normalized.endsWith(suffix) ? normalized : `${normalized}${suffix}`;
+}
+
 function resolveDatasetsUrl(baseUrl: string): string {
-  return `${normalizeBaseUrl(baseUrl)}/supersubset/datasets`;
+  return resolveEndpointUrl(baseUrl, '/supersubset/datasets');
 }
 
 function resolveQueryUrl(baseUrl: string): string {
-  return `${normalizeBaseUrl(baseUrl)}/supersubset/query`;
+  return resolveEndpointUrl(baseUrl, '/supersubset/query');
 }
 
 function isDatasetArray(value: unknown): value is NormalizedDataset[] {

--- a/packages/dev-app/src/probe/http-adapters.ts
+++ b/packages/dev-app/src/probe/http-adapters.ts
@@ -1,0 +1,112 @@
+import type {
+  LogicalQuery,
+  MetadataAdapter,
+  NormalizedDataset,
+  QueryAdapter,
+  QueryResult,
+} from '@supersubset/data-model';
+
+import type { AuthHeader } from './auth';
+import { normalizeBaseUrl } from './auth';
+import { parseErrorResponse } from './errors';
+
+export interface HttpAdapterOptions {
+  authHeader?: AuthHeader;
+  fetcher?: typeof fetch;
+}
+
+function createHeaders(authHeader?: AuthHeader, includeJsonContentType?: boolean): Headers {
+  const headers = new Headers();
+
+  if (includeJsonContentType) {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  if (authHeader) {
+    headers.set(authHeader.name, authHeader.value);
+  }
+
+  return headers;
+}
+
+function resolveDatasetsUrl(baseUrl: string): string {
+  return `${normalizeBaseUrl(baseUrl)}/supersubset/datasets`;
+}
+
+function resolveQueryUrl(baseUrl: string): string {
+  return `${normalizeBaseUrl(baseUrl)}/supersubset/query`;
+}
+
+function isDatasetArray(value: unknown): value is NormalizedDataset[] {
+  return Array.isArray(value);
+}
+
+export class HttpMetadataAdapter implements MetadataAdapter<string> {
+  readonly name = 'http-metadata-adapter';
+
+  private readonly authHeader?: AuthHeader;
+  private readonly fetcher: typeof fetch;
+
+  constructor(options: HttpAdapterOptions = {}) {
+    this.authHeader = options.authHeader;
+    this.fetcher = options.fetcher ?? fetch;
+  }
+
+  async getDatasets(source: string): Promise<NormalizedDataset[]> {
+    const response = await this.fetcher(resolveDatasetsUrl(source), {
+      method: 'GET',
+      headers: createHeaders(this.authHeader),
+    });
+
+    if (!response.ok) {
+      await parseErrorResponse(response);
+    }
+
+    const payload = (await response.json()) as unknown;
+    if (isDatasetArray(payload)) {
+      return payload;
+    }
+
+    if (typeof payload === 'object' && payload && 'datasets' in payload) {
+      const datasets = (payload as { datasets?: unknown }).datasets;
+      if (isDatasetArray(datasets)) {
+        return datasets;
+      }
+    }
+
+    throw new Error('Invalid datasets payload. Expected NormalizedDataset[] response.');
+  }
+
+  async getDataset(source: string, datasetId: string): Promise<NormalizedDataset | undefined> {
+    const datasets = await this.getDatasets(source);
+    return datasets.find((dataset) => dataset.id === datasetId);
+  }
+}
+
+export class HttpQueryAdapter implements QueryAdapter {
+  readonly name = 'http-query-adapter';
+
+  private readonly baseUrl: string;
+  private readonly authHeader?: AuthHeader;
+  private readonly fetcher: typeof fetch;
+
+  constructor(baseUrl: string, options: HttpAdapterOptions = {}) {
+    this.baseUrl = normalizeBaseUrl(baseUrl);
+    this.authHeader = options.authHeader;
+    this.fetcher = options.fetcher ?? fetch;
+  }
+
+  async execute(query: LogicalQuery): Promise<QueryResult> {
+    const response = await this.fetcher(resolveQueryUrl(this.baseUrl), {
+      method: 'POST',
+      headers: createHeaders(this.authHeader, true),
+      body: JSON.stringify(query),
+    });
+
+    if (!response.ok) {
+      await parseErrorResponse(response);
+    }
+
+    return (await response.json()) as QueryResult;
+  }
+}

--- a/packages/dev-app/src/probe/metadata.test.ts
+++ b/packages/dev-app/src/probe/metadata.test.ts
@@ -49,6 +49,48 @@ describe('probe metadata helpers', () => {
     });
   });
 
+  it('uses explicit aggregation hints for metric slots', () => {
+    const query = buildPreviewQuery(
+      [
+        {
+          id: 'fact_match_events',
+          label: 'Match Events',
+          fields: [
+            { id: 'event_type', label: 'Event Type', dataType: 'string', role: 'dimension' },
+            { id: 'event_id', label: 'Event Id', dataType: 'string', role: 'key' },
+          ],
+        },
+      ],
+      'fact_match_events',
+      {
+        xField: 'event_type',
+        yField: 'event_id',
+        metricFields: ['event_id'],
+        aggregation: 'count',
+      },
+    );
+
+    expect(query).toEqual({
+      datasetId: 'fact_match_events',
+      limit: 200,
+      fields: [{ fieldId: 'event_type' }, { fieldId: 'event_id', aggregation: 'count' }],
+    });
+  });
+
+  it('lets explicit aggregation none override measure defaults', () => {
+    const query = buildPreviewQuery(DATASETS, 'orders', {
+      yField: 'revenue',
+      metricFields: ['revenue'],
+      aggregation: 'none',
+    });
+
+    expect(query).toEqual({
+      datasetId: 'orders',
+      limit: 200,
+      fields: [{ fieldId: 'revenue' }],
+    });
+  });
+
   it('derives query endpoint from discovery endpoint input', () => {
     expect(deriveQueryEndpointInput('https://api.example.com/supersubset/datasets')).toBe(
       'https://api.example.com/supersubset/query',

--- a/packages/dev-app/src/probe/metadata.test.ts
+++ b/packages/dev-app/src/probe/metadata.test.ts
@@ -1,0 +1,58 @@
+import type { NormalizedDataset } from '@supersubset/data-model';
+import { describe, expect, it } from 'vitest';
+
+import { buildPreviewQuery, deriveQueryEndpointInput, parseProbeMetadataJson } from './metadata';
+
+const DATASETS: NormalizedDataset[] = [
+  {
+    id: 'orders',
+    label: 'Orders',
+    fields: [
+      { id: 'region', label: 'Region', dataType: 'string', role: 'dimension' },
+      {
+        id: 'revenue',
+        label: 'Revenue',
+        dataType: 'number',
+        role: 'measure',
+        defaultAggregation: 'sum',
+      },
+      { id: 'created_at', label: 'Created At', dataType: 'date', role: 'time' },
+    ],
+  },
+];
+
+describe('probe metadata helpers', () => {
+  it('accepts metadata JSON envelope objects', async () => {
+    const datasets = await parseProbeMetadataJson(JSON.stringify({ datasets: DATASETS }));
+
+    expect(datasets).toHaveLength(1);
+    expect(datasets[0]?.id).toBe('orders');
+  });
+
+  it('accepts raw dataset arrays', async () => {
+    const datasets = await parseProbeMetadataJson(JSON.stringify(DATASETS));
+
+    expect(datasets).toHaveLength(1);
+    expect(datasets[0]?.fields[1]?.defaultAggregation).toBe('sum');
+  });
+
+  it('builds preview queries with aggregation for measure fields', () => {
+    const query = buildPreviewQuery(DATASETS, 'orders', {
+      xField: 'region',
+      yField: 'revenue',
+    });
+
+    expect(query).toEqual({
+      datasetId: 'orders',
+      limit: 200,
+      fields: [{ fieldId: 'region' }, { fieldId: 'revenue', aggregation: 'sum' }],
+    });
+  });
+
+  it('derives query endpoint from discovery endpoint input', () => {
+    expect(deriveQueryEndpointInput('https://api.example.com/supersubset/datasets')).toBe(
+      'https://api.example.com/supersubset/query',
+    );
+    expect(deriveQueryEndpointInput('https://api.example.com')).toBe('https://api.example.com');
+  });
+});

--- a/packages/dev-app/src/probe/metadata.ts
+++ b/packages/dev-app/src/probe/metadata.ts
@@ -1,0 +1,111 @@
+import { JsonAdapter } from '@supersubset/adapter-json';
+import type { LogicalQuery, NormalizedDataset } from '@supersubset/data-model';
+
+const jsonAdapter = new JsonAdapter();
+const DEFAULT_PREVIEW_LIMIT = 200;
+const DISCOVERY_SUFFIX = '/supersubset/datasets';
+const QUERY_SUFFIX = '/supersubset/query';
+
+export type ProbeFieldBindings = Record<string, string | string[] | undefined>;
+
+export interface ProbeMetadataEnvelope {
+  datasets: unknown;
+}
+
+function isEnvelope(value: unknown): value is ProbeMetadataEnvelope {
+  return typeof value === 'object' && value !== null && 'datasets' in value;
+}
+
+function flattenFieldBindings(fields: ProbeFieldBindings): string[] {
+  const values = Object.values(fields).flatMap((value) => {
+    if (typeof value === 'string') {
+      return value.length > 0 ? [value] : [];
+    }
+
+    if (Array.isArray(value)) {
+      return value.filter((item): item is string => typeof item === 'string' && item.length > 0);
+    }
+
+    return [];
+  });
+
+  return Array.from(new Set(values));
+}
+
+export async function normalizeProbeMetadataPayload(
+  payload: unknown,
+): Promise<NormalizedDataset[]> {
+  const source = isEnvelope(payload) ? payload.datasets : payload;
+  return jsonAdapter.getDatasets(source as never);
+}
+
+export async function parseProbeMetadataJson(rawInput: string): Promise<NormalizedDataset[]> {
+  const trimmed = rawInput.trim();
+  if (!trimmed) {
+    throw new Error('Paste metadata JSON before opening the designer.');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    throw new Error(
+      'Metadata JSON is invalid. Paste a datasets array or an object with a datasets array.',
+    );
+  }
+
+  try {
+    return await normalizeProbeMetadataPayload(parsed);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown metadata validation error';
+    throw new Error(`Metadata JSON is invalid: ${message}`, {
+      cause: error,
+    });
+  }
+}
+
+export function buildPreviewQuery(
+  datasets: NormalizedDataset[],
+  datasetRef: string,
+  fields: ProbeFieldBindings,
+  limit = DEFAULT_PREVIEW_LIMIT,
+): LogicalQuery | null {
+  const dataset = datasets.find((item) => item.id === datasetRef);
+  if (!dataset) {
+    return null;
+  }
+
+  const fieldIds = flattenFieldBindings(fields);
+  if (fieldIds.length === 0) {
+    return null;
+  }
+
+  return {
+    datasetId: datasetRef,
+    limit,
+    fields: fieldIds.map((fieldId) => {
+      const field = dataset.fields.find((item) => item.id === fieldId);
+      if (field?.role === 'measure') {
+        return {
+          fieldId,
+          aggregation: field.defaultAggregation ?? 'sum',
+        };
+      }
+
+      return { fieldId };
+    }),
+  };
+}
+
+export function deriveQueryEndpointInput(input: string): string {
+  const trimmed = input.trim().replace(/\/+$/, '');
+  if (!trimmed) {
+    return '';
+  }
+
+  if (trimmed.endsWith(DISCOVERY_SUFFIX)) {
+    return `${trimmed.slice(0, -DISCOVERY_SUFFIX.length)}${QUERY_SUFFIX}`;
+  }
+
+  return trimmed;
+}

--- a/packages/dev-app/src/probe/metadata.ts
+++ b/packages/dev-app/src/probe/metadata.ts
@@ -1,5 +1,5 @@
 import { JsonAdapter } from '@supersubset/adapter-json';
-import type { LogicalQuery, NormalizedDataset } from '@supersubset/data-model';
+import type { AggregationType, LogicalQuery, NormalizedDataset } from '@supersubset/data-model';
 
 const jsonAdapter = new JsonAdapter();
 const DEFAULT_PREVIEW_LIMIT = 200;
@@ -12,24 +12,51 @@ export interface ProbeMetadataEnvelope {
   datasets: unknown;
 }
 
+const METADATA_BINDING_KEYS = new Set(['aggregation', 'metricFields']);
+const VALID_AGGREGATIONS: ReadonlySet<AggregationType> = new Set([
+  'sum',
+  'avg',
+  'count',
+  'count_distinct',
+  'min',
+  'max',
+  'none',
+]);
+
 function isEnvelope(value: unknown): value is ProbeMetadataEnvelope {
   return typeof value === 'object' && value !== null && 'datasets' in value;
 }
 
+function toFieldIdList(value: string | string[] | undefined): string[] {
+  if (typeof value === 'string') {
+    return value.length > 0 ? [value] : [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string' && item.length > 0);
+  }
+
+  return [];
+}
+
 function flattenFieldBindings(fields: ProbeFieldBindings): string[] {
-  const values = Object.values(fields).flatMap((value) => {
-    if (typeof value === 'string') {
-      return value.length > 0 ? [value] : [];
+  const values = Object.entries(fields).flatMap(([key, value]) => {
+    if (METADATA_BINDING_KEYS.has(key)) {
+      return [];
     }
 
-    if (Array.isArray(value)) {
-      return value.filter((item): item is string => typeof item === 'string' && item.length > 0);
-    }
-
-    return [];
+    return toFieldIdList(value);
   });
 
   return Array.from(new Set(values));
+}
+
+function toAggregationType(value: string | undefined): AggregationType | undefined {
+  if (!value || !VALID_AGGREGATIONS.has(value as AggregationType)) {
+    return undefined;
+  }
+
+  return value as AggregationType;
 }
 
 export async function normalizeProbeMetadataPayload(
@@ -80,11 +107,36 @@ export function buildPreviewQuery(
     return null;
   }
 
+  const metricFieldIds = new Set(toFieldIdList(fields.metricFields));
+  const rawAggregationHint =
+    typeof fields.aggregation === 'string' ? fields.aggregation : undefined;
+  const hasAggregationHint = Boolean(rawAggregationHint && rawAggregationHint.length > 0);
+  const aggregationHint = toAggregationType(rawAggregationHint);
+
   return {
     datasetId: datasetRef,
     limit,
     fields: fieldIds.map((fieldId) => {
       const field = dataset.fields.find((item) => item.id === fieldId);
+
+      const isMetricField =
+        metricFieldIds.size === 0 ? field?.role === 'measure' : metricFieldIds.has(fieldId);
+
+      if (!isMetricField) {
+        return { fieldId };
+      }
+
+      if (hasAggregationHint) {
+        if (aggregationHint && aggregationHint !== 'none') {
+          return {
+            fieldId,
+            aggregation: aggregationHint,
+          };
+        }
+
+        return { fieldId };
+      }
+
       if (field?.role === 'measure') {
         return {
           fieldId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,6 +265,9 @@ importers:
         specifier: workspace:*
         version: link:../schema
     devDependencies:
+      '@types/node':
+        specifier: ^22.13.14
+        version: 22.19.17
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(postcss@8.5.9)(typescript@5.9.3)(yaml@2.8.3)
@@ -273,7 +276,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.6.0
-        version: 1.6.1(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2)
+        version: 1.6.1(@types/node@22.19.17)(happy-dom@20.8.9)(jsdom@29.0.2)
 
   packages/data-model:
     dependencies:
@@ -12534,6 +12537,24 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@1.6.1(@types/node@22.19.17):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.21(@types/node@22.19.17)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@1.6.1(@types/node@25.5.2):
     dependencies:
       cac: 6.7.14
@@ -12570,6 +12591,15 @@ snapshots:
       - supports-color
       - terser
 
+  vite@5.4.21(@types/node@22.19.17):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.9
+      rollup: 4.60.1
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+
   vite@5.4.21(@types/node@25.5.2):
     dependencies:
       esbuild: 0.21.5
@@ -12595,6 +12625,42 @@ snapshots:
   vitefu@1.1.3(vite@6.4.2(@types/node@25.5.2)(yaml@2.8.3)):
     optionalDependencies:
       vite: 6.4.2(@types/node@25.5.2)(yaml@2.8.3)
+
+  vitest@1.6.1(@types/node@22.19.17)(happy-dom@20.8.9)(jsdom@29.0.2):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.5
+      chai: 4.5.0
+      debug: 4.4.3
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.21(@types/node@22.19.17)
+      vite-node: 1.6.1(@types/node@22.19.17)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+      happy-dom: 20.8.9
+      jsdom: 29.0.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vitest@1.6.1(@types/node@25.5.2)(happy-dom@20.8.9)(jsdom@29.0.2):
     dependencies:


### PR DESCRIPTION
## Summary
- add a new Probe mode in dev-app to test a compatible backend URL from a local dev environment
- support auth input via Bearer JWT or custom header value
- scan backend datasets via HTTP adapter and initialize a blank Supersubset designer with discovered metadata
- add export flow (clipboard best-effort + JSON download) and reconnect flow
- add focused unit tests for auth/session helpers and HTTP adapters

## Testing
- pnpm --filter @supersubset/dev-app lint
- pnpm --filter @supersubset/dev-app test
- pnpm exec playwright test e2e/smoke.spec.ts --config=playwright.e2e.config.ts

## Notes
- implemented in isolated worktree branch: issue/52-backend-probe
- Snyk intentionally deferred per request