### PR TITLE
chore: add patch release changeset

### DIFF
--- a/.changeset/release-patch-april-2026.md
+++ b/.changeset/release-patch-april-2026.md
@@ -1,0 +1,7 @@
+---
+'@supersubset/charts-echarts': patch
+'@supersubset/designer': patch
+'@supersubset/runtime': patch
+---
+
+Patch release for recent runtime, designer, and chart fixes. This includes restoring theme propagation between the runtime and chart widgets, removing unsupported undefined ECharts options that caused chart rendering issues, and tightening designer and runtime filter editing behavior.


### PR DESCRIPTION
Adds the patch changeset needed to make the current release candidate publish-ready. The changeset covers the recent runtime, designer, and chart fixes, and was validated with 'pnpm exec changeset status' to confirm a patch bump for the fixed package group after merge.