### PR TITLE
fix: harden chart widgets and refresh CI actions

### DIFF
--- a/.github/skills/branch-ci-promotion/SKILL.md
+++ b/.github/skills/branch-ci-promotion/SKILL.md
@@ -31,6 +31,34 @@ Supersubset uses a **four-tier branch model**: feature branches → `develop` �
 - After CI fails on a branch — triage without guessing.
 - When defining “green” for a release tag or publishing docs/examples.
 
+## Branch base preflight (required before branching)
+
+Never create a normal `feature/*`, `fix/*`, or `issue/*` branch from an unrefreshed local `develop`.
+
+Use one of these flows:
+
+```bash
+git fetch origin
+git switch develop
+git pull --ff-only origin develop
+git switch -c fix/my-slice
+```
+
+If local `develop` is dirty, has local-only commits, or you want a cleaner start, branch directly from the remote tip instead:
+
+```bash
+git fetch origin
+git switch -c fix/my-slice origin/develop
+```
+
+Failure mode to avoid:
+
+- branching from stale local `develop`
+- re-implementing changes that are already on `origin/develop`
+- opening a PR that conflicts because the same files were already changed upstream
+
+For worktree-based flows, follow **`.github/skills/parallel-agent-environments/SKILL.md`** and base the worktree on `origin/develop` for normal feature work.
+
 ## Local verification (authoritative before push)
 
 From repo root:
@@ -51,7 +79,8 @@ pnpm test:e2e
 
 ## PR / merge checklist
 
-- [ ] **Branch** is up to date with target (`main` or the agreed base) or merge conflicts resolved intentionally.
+- [ ] **Branch base** was created from the current remote target base (`git fetch origin` + `git pull --ff-only`, or direct branch from `origin/develop` for normal work).
+- [ ] **Branch** is rebased or merged with the target before final review if the target moved after branch creation.
 - [ ] **`pnpm lint`** — no new violations in touched packages.
 - [ ] **`pnpm typecheck`** — strict TS clean across workspace.
 - [ ] **`pnpm test`** — unit/integration tests for changed packages pass.

--- a/.github/skills/parallel-agent-environments/SKILL.md
+++ b/.github/skills/parallel-agent-environments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: parallel-agent-environments
-description: "Coordinate parallel agent work on unrelated tasks. Use when multiple agents need to run concurrently — covers branch isolation, file-scope ownership, port assignment, merge sequencing, and worktree setup."
+description: 'Coordinate parallel agent work on unrelated tasks. Use when multiple agents need to run concurrently — covers branch isolation, file-scope ownership, port assignment, merge sequencing, and worktree setup.'
 ---
 
 # Parallel Agent Environments
@@ -26,10 +26,12 @@ The orchestrator's brief **must** list which packages/files each agent may write
 
 ```markdown
 ## Brief for Agent 1
+
 **May modify**: packages/charts-echarts/, e2e/visual/
 **Must NOT modify**: packages/designer/, packages/runtime/, packages/schema/
 
 ## Brief for Agent 2
+
 **May modify**: packages/runtime/src/filters/, e2e/interactions/
 **Must NOT modify**: packages/charts-echarts/, packages/designer/
 ```
@@ -40,26 +42,27 @@ If two tasks need the same file, the orchestrator **sequences** those edits (one
 
 These files are touched by many tasks and must never be edited in parallel:
 
-| File | Why |
-| ---- | --- |
-| `package.json` (root) | Workspace deps, scripts |
-| `tsconfig.json` (root) | Path aliases |
-| `packages/schema/src/**` | Canonical types consumed everywhere |
-| `pnpm-lock.yaml` | Auto-generated; two branches adding deps will conflict |
-| `docs/status/master-plan.md` | Single-writer: the orchestrator |
+| File                         | Why                                                    |
+| ---------------------------- | ------------------------------------------------------ |
+| `package.json` (root)        | Workspace deps, scripts                                |
+| `tsconfig.json` (root)       | Path aliases                                           |
+| `packages/schema/src/**`     | Canonical types consumed everywhere                    |
+| `pnpm-lock.yaml`             | Auto-generated; two branches adding deps will conflict |
+| `docs/status/master-plan.md` | Single-writer: the orchestrator                        |
 
 If an agent needs a hot file, the orchestrator either: (a) does that edit itself before dispatching, or (b) assigns it to **one** agent and makes others wait.
 
 ### 4. Merge order
 
 - First agent to complete merges first.
-- Second agent rebases onto updated `main` before merging.
+- Second agent rebases onto the updated target branch before merging, usually `develop` for normal feature/fix work.
 - If both touch a hot file despite precautions, the orchestrator resolves the conflict manually before the second merge.
 - Always run `pnpm typecheck && pnpm test` after rebase.
 
 ### 5. Status signaling
 
 Agents report completion to the orchestrator (via subagent return or PR). The orchestrator:
+
 1. Verifies the output matches the brief
 2. Merges (or asks the human to merge)
 3. Updates `docs/status/master-plan.md`
@@ -71,13 +74,13 @@ Agents report completion to the orchestrator (via subagent return or PR). The or
 
 ### Default ports
 
-| Port | Consumer | Notes |
-| ---- | -------- | ----- |
+| Port     | Consumer                      | Notes                                                      |
+| -------- | ----------------------------- | ---------------------------------------------------------- |
 | **3000** | `@supersubset/dev-app` (Vite) | `playwright.config.ts` `baseURL` + first `webServer` entry |
-| **3001** | Next.js ecommerce example | Playwright `webServer` second entry |
-| **3002** | Vite + SQLite example | Playwright `webServer` third entry |
-| **6006** | Storybook | Optional; separate from Playwright |
-| **4321** | Astro docs | Fixed in `packages/docs/package.json` |
+| **3001** | Next.js ecommerce example     | Playwright `webServer` second entry                        |
+| **3002** | Vite + SQLite example         | Playwright `webServer` third entry                         |
+| **6006** | Storybook                     | Optional; separate from Playwright                         |
+| **4321** | Astro docs                    | Fixed in `packages/docs/package.json`                      |
 
 ### Failure modes
 
@@ -96,9 +99,15 @@ Agents report completion to the orchestrator (via subagent return or PR). The or
 Separate `git worktree add` per active issue when agents need parallel git state:
 
 ```bash
-git worktree add ../supersubset-issue-NNN -b issue/NNN-slug origin/main
+git fetch origin
+git worktree add ../supersubset-issue-NNN -b issue/NNN-slug origin/develop
 cd ../supersubset-issue-NNN && pnpm install
 ```
+
+Base worktrees from the remote target branch, not a stale local branch.
+
+- Normal feature/fix work: `origin/develop`
+- Hotfix/release work only: `origin/main` or the explicit promotion branch
 
 Worktrees solve **branch + dependency + build artifact** isolation — not ports.
 
@@ -136,6 +145,7 @@ pnpm exec playwright test
 Before dispatching parallel agents:
 
 - [ ] Each agent has its own branch name
+- [ ] Each worktree/branch is created from the current remote target base (`origin/develop` for normal work)
 - [ ] File scopes are disjoint (no overlapping packages)
 - [ ] Hot files are pre-edited or assigned to one agent only
 - [ ] Ports assigned if agents need dev servers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -60,13 +60,13 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -81,13 +81,13 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -95,7 +95,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
 
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@v5
 
       - run: npx nx affected -t lint
 
@@ -104,11 +104,11 @@ jobs:
     name: Format Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -124,13 +124,13 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -138,7 +138,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
 
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@v5
 
       - run: npx nx affected -t typecheck
 
@@ -149,13 +149,13 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -163,7 +163,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
 
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@v5
 
       - run: npx nx affected -t test
 
@@ -174,13 +174,13 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -198,7 +198,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: |
@@ -207,7 +207,7 @@ jobs:
 
       - name: Upload snapshot baselines
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-snapshots
           path: e2e/**/*-snapshots/
@@ -222,11 +222,11 @@ jobs:
     env:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/promote-main.yml
+++ b/.github/workflows/promote-main.yml
@@ -25,7 +25,7 @@ jobs:
     name: Create Promotion PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -83,14 +83,14 @@ jobs:
     needs: create-promotion-pr
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: staging
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-playwright-report
           path: |

--- a/.github/workflows/promote-staging.yml
+++ b/.github/workflows/promote-staging.yml
@@ -25,7 +25,7 @@ jobs:
     name: Create Promotion PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -84,14 +84,14 @@ jobs:
     needs: create-promotion-pr
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: develop
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: staging-playwright-report
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,13 +30,13 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: pnpm

--- a/packages/charts-echarts/src/base/BaseChart.tsx
+++ b/packages/charts-echarts/src/base/BaseChart.tsx
@@ -65,21 +65,25 @@ export function BaseChart({
 
     // ResizeObserver for responsive sizing
     const observer = new ResizeObserver(() => {
+      if (chartRef.current !== chart || isChartDisposed(chart)) {
+        return;
+      }
       chart.resize();
     });
     observer.observe(containerRef.current);
 
     return () => {
       observer.disconnect();
-      chart.dispose();
       chartRef.current = null;
+      chart.dispose();
     };
   }, [echartsTheme]);
 
   // Update options
   useEffect(() => {
-    if (!chartRef.current) return;
-    chartRef.current.setOption(option, { notMerge: true });
+    const chart = chartRef.current;
+    if (!chart || isChartDisposed(chart)) return;
+    chart.setOption(option, { notMerge: true });
   }, [option]);
 
   useEffect(() => {
@@ -180,3 +184,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 // Re-export echarts for use/register calls in chart modules
 export { echarts };
+
+function isChartDisposed(chart: echarts.ECharts | null): boolean {
+  if (!chart) {
+    return true;
+  }
+
+  const maybeChart = chart as echarts.ECharts & { isDisposed?: () => boolean };
+  return typeof maybeChart.isDisposed === 'function' ? maybeChart.isDisposed() : false;
+}

--- a/packages/charts-echarts/src/charts/AreaChartWidget.tsx
+++ b/packages/charts-echarts/src/charts/AreaChartWidget.tsx
@@ -65,13 +65,13 @@ export function AreaChartWidget({ config, data, columns, title, height, theme }:
         type: 'line' as const,
         data: data.map((row) => row[field]),
         smooth,
-        ...(step ? { step } : {}),
         connectNulls,
         showSymbol: showMarkers,
-        ...(stacked ? { stack: 'total' } : {}),
         areaStyle: { opacity: areaOpacity },
         emphasis: { focus: 'series' as const },
         ...(label ? { label } : {}),
+        ...(step ? { step } : {}),
+        ...(stacked ? { stack: 'total' } : {}),
       })),
     };
   }, [config, data, columns, title]);

--- a/packages/charts-echarts/src/charts/BarChartWidget.tsx
+++ b/packages/charts-echarts/src/charts/BarChartWidget.tsx
@@ -73,12 +73,12 @@ export function BarChartWidget({
             [field]: row[field],
           },
         })),
+        ...(label ? { label } : {}),
         ...(stacked ? { stack: 'total' } : {}),
         ...(barWidth ? { barWidth } : {}),
         ...(barGap ? { barGap } : {}),
-        ...(barMinHeight ? { barMinHeight } : {}),
+        ...(barMinHeight > 0 ? { barMinHeight } : {}),
         ...(borderRadius > 0 ? { itemStyle: { borderRadius } } : {}),
-        ...(label ? { label } : {}),
       })),
     };
   }, [config, data, columns, title]);

--- a/packages/charts-echarts/src/charts/ComboChartWidget.tsx
+++ b/packages/charts-echarts/src/charts/ComboChartWidget.tsx
@@ -48,10 +48,10 @@ export function ComboChartWidget({ config, data, columns, title, height, theme }
       name: field,
       type: 'bar' as const,
       data: data.map((row) => row[field]),
-      ...(stacked ? { stack: 'bars' } : {}),
       yAxisIndex: 0,
-      ...(barBorderRadius > 0 ? { itemStyle: { borderRadius: barBorderRadius } } : {}),
       ...(label ? { label } : {}),
+      ...(stacked ? { stack: 'bars' } : {}),
+      ...(barBorderRadius > 0 ? { itemStyle: { borderRadius: barBorderRadius } } : {}),
     }));
 
     const lineSeries = lineFields.map((field) => ({

--- a/packages/charts-echarts/src/charts/GaugeWidget.tsx
+++ b/packages/charts-echarts/src/charts/GaugeWidget.tsx
@@ -49,6 +49,10 @@ export function GaugeWidget({ config, data, title, height, theme }: WidgetProps)
     }
 
     const progressColor = colors.length >= 1 ? colors[0] : '#1FA8C9';
+    const progress = progressMode
+      ? { show: true, roundCap, itemStyle: { color: progressColor } }
+      : undefined;
+    const axisLineOption = thresholds || colors.length >= 1 ? axisLine : undefined;
 
     return {
       ...(buildTitleOption(title) ? { title: buildTitleOption(title) } : {}),
@@ -61,11 +65,7 @@ export function GaugeWidget({ config, data, title, height, theme }: WidgetProps)
           endAngle,
           roundCap,
           splitNumber: splitCount,
-          ...(progressMode
-            ? { progress: { show: true, roundCap, itemStyle: { color: progressColor } } }
-            : {}),
           data: [{ value, name: title ?? '' }],
-          ...(thresholds || colors.length >= 1 ? { axisLine } : {}),
           detail: {
             formatter: fmt ? (v: number) => formatNumber(v, fmt) : '{value}',
             fontSize: 24,
@@ -75,6 +75,8 @@ export function GaugeWidget({ config, data, title, height, theme }: WidgetProps)
             fontSize: 13,
             offsetCenter: [0, '70%'],
           },
+          ...(progress ? { progress } : {}),
+          ...(axisLineOption ? { axisLine: axisLineOption } : {}),
         },
       ],
     };

--- a/packages/charts-echarts/src/charts/HeatmapWidget.tsx
+++ b/packages/charts-echarts/src/charts/HeatmapWidget.tsx
@@ -51,6 +51,17 @@ export function HeatmapWidget({ config, data, columns, title, height, theme }: W
     });
 
     const fmt = shared.numberFormat;
+    const heatmapLabel =
+      shared.showValues !== false
+        ? {
+            show: true,
+            ...(fmt
+              ? {
+                  formatter: (params: { data: number[] }) => formatNumber(params.data[2], fmt),
+                }
+              : {}),
+          }
+        : { show: false };
 
     return {
       ...(buildTitleOption(title) ? { title: buildTitleOption(title) } : {}),
@@ -89,12 +100,7 @@ export function HeatmapWidget({ config, data, columns, title, height, theme }: W
         {
           type: 'heatmap' as const,
           data: heatmapData,
-          label: {
-            show: shared.showValues !== false,
-            ...(fmt
-              ? { formatter: (params: { data: number[] }) => formatNumber(params.data[2], fmt) }
-              : {}),
-          },
+          label: heatmapLabel,
           itemStyle: {
             borderWidth: cellBorderWidth,
             borderColor: cellBorderColor,

--- a/packages/charts-echarts/src/charts/LineChartWidget.tsx
+++ b/packages/charts-echarts/src/charts/LineChartWidget.tsx
@@ -71,12 +71,12 @@ export function LineChartWidget({
           },
         })),
         smooth: config.smooth === true,
-        ...(step ? { step } : {}),
         connectNulls,
         showSymbol: showMarkers,
         symbolSize: markerSize,
-        ...(showArea ? { areaStyle: {} } : {}),
         ...(label ? { label } : {}),
+        ...(step ? { step } : {}),
+        ...(showArea ? { areaStyle: {} } : {}),
       })),
     };
   }, [config, data, columns, title]);

--- a/packages/charts-echarts/src/charts/PieChartWidget.tsx
+++ b/packages/charts-echarts/src/charts/PieChartWidget.tsx
@@ -81,12 +81,12 @@ export function PieChartWidget({ config, data, columns, title, height, theme }: 
           type: 'pie' as const,
           data: seriesData,
           radius: [`${innerRadius}%`, `${outerRadius}%`],
-          ...(roseType ? { roseType } : {}),
-          ...(padAngle > 0 ? { padAngle } : {}),
           emphasis: {
             itemStyle: { shadowBlur: 10, shadowOffsetX: 0, shadowColor: 'rgba(0, 0, 0, 0.5)' },
           },
           label: labelConfig,
+          ...(roseType ? { roseType } : {}),
+          ...(padAngle > 0 ? { padAngle } : {}),
         },
       ],
     };

--- a/packages/charts-echarts/src/charts/TreemapWidget.tsx
+++ b/packages/charts-echarts/src/charts/TreemapWidget.tsx
@@ -92,9 +92,7 @@ export function TreemapWidget({ config, data, columns, title, height, theme }: W
           type: 'treemap' as const,
           data: treeData,
           roam: false,
-          ...(maxDepth > 0 ? { leafDepth: maxDepth } : {}),
           upperLabel: { show: showUpperLabel },
-          ...(borderWidth > 0 ? { itemStyle: { borderWidth, borderColor: '#fff' } } : {}),
           label: {
             show: shared.showValues !== false,
             formatter: fmt
@@ -103,6 +101,8 @@ export function TreemapWidget({ config, data, columns, title, height, theme }: W
               : '{b}',
           },
           breadcrumb: { show: true },
+          ...(maxDepth > 0 ? { leafDepth: maxDepth } : {}),
+          ...(borderWidth > 0 ? { itemStyle: { borderWidth, borderColor: '#fff' } } : {}),
         },
       ],
     };

--- a/packages/charts-echarts/test/base-chart-events.test.tsx
+++ b/packages/charts-echarts/test/base-chart-events.test.tsx
@@ -9,6 +9,7 @@ const { chartInstance, initMock } = vi.hoisted(() => {
     setOption: vi.fn(),
     resize: vi.fn(),
     dispose: vi.fn(),
+    isDisposed: vi.fn(() => false),
   };
 
   return {
@@ -43,6 +44,8 @@ describe('BaseChart interaction events', () => {
     chartInstance.off.mockClear();
     chartInstance.setOption.mockClear();
     chartInstance.dispose.mockClear();
+    chartInstance.isDisposed.mockReset();
+    chartInstance.isDisposed.mockReturnValue(false);
     initMock.mockClear();
 
     vi.stubGlobal(
@@ -163,5 +166,17 @@ describe('BaseChart interaction events', () => {
       }),
       expect.objectContaining({ renderer: 'canvas' }),
     );
+  });
+
+  it('skips setOption when the chart instance is already disposed', () => {
+    chartInstance.isDisposed.mockReturnValue(true);
+
+    render(
+      React.createElement(BaseChart, {
+        option: { title: { text: 'Disposed' } },
+      }),
+    );
+
+    expect(chartInstance.setOption).not.toHaveBeenCalled();
   });
 });

--- a/packages/charts-echarts/test/per-chart-properties.test.tsx
+++ b/packages/charts-echarts/test/per-chart-properties.test.tsx
@@ -484,6 +484,7 @@ describe('PieChartWidget — per-chart properties', () => {
       />,
     );
     expect(getSeries().padAngle).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(getSeries(), 'padAngle')).toBe(false);
   });
 
   it('roseType=radius produces rose chart', () => {
@@ -546,6 +547,19 @@ describe('PieChartWidget — per-chart properties', () => {
       />,
     );
     expect(getSeries().roseType).toBe('radius');
+  });
+
+  it('omits roseType when no rose variant is configured', () => {
+    render(
+      <PieChartWidget
+        {...makeProps({
+          config: { nameField: 'name', valueField: 'value' },
+          data: samplePieData,
+        })}
+      />,
+    );
+    expect(getSeries().roseType).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(getSeries(), 'roseType')).toBe(false);
   });
 
   // Regression: #10 — showValues=false must not hide labels when labelPosition is set
@@ -1033,6 +1047,7 @@ describe('TreemapWidget — per-chart properties', () => {
       />,
     );
     expect(getSeries().leafDepth).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(getSeries(), 'leafDepth')).toBe(false);
   });
 
   it('borderWidth sets itemStyle borderWidth', () => {
@@ -1046,6 +1061,19 @@ describe('TreemapWidget — per-chart properties', () => {
     );
     const style = getSeries().itemStyle as Record<string, unknown>;
     expect(style.borderWidth).toBe(3);
+  });
+
+  it('omits itemStyle when no treemap border is configured', () => {
+    render(
+      <TreemapWidget
+        {...makeProps({
+          config: { nameField: 'name', valueField: 'value', borderWidth: 0 },
+          data: sampleTreemapData,
+        })}
+      />,
+    );
+    expect(getSeries().itemStyle).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(getSeries(), 'itemStyle')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- rebase the branch onto current `develop` to eliminate the merge conflicts
- keep the unique chart hardening that still belongs on top of `develop`, including the disposed-instance guard in `BaseChart` and regression coverage
- refresh CI, promotion, and release workflow action majors for #75
- tighten the branch/worktree skills so normal feature work starts from fresh `origin/develop` and avoids this stale-base conflict pattern

## Issues

Closes #55
Closes #75
Refs #83
Follow-up tracked in #84

## Validation

- `pnpm --filter @supersubset/schema build`
- `pnpm --filter @supersubset/theme build`
- `pnpm --filter @supersubset/runtime build`
- `pnpm --filter @supersubset/charts-echarts build`
- `pnpm --filter @supersubset/charts-echarts test`
- `pnpm --filter @supersubset/example-nextjs-ecommerce typecheck`
- editor diagnostics on the updated skill files