### PR TITLE
fix: preserve nested widget selection and controlled sync

### DIFF
--- a/packages/designer/src/blocks/layout/index.ts
+++ b/packages/designer/src/blocks/layout/index.ts
@@ -61,7 +61,7 @@ export const RowBlock: ComponentConfig = {
 
 export const ColumnBlock: ComponentConfig = {
   label: 'Column',
-  inline: true,
+  inline: false,
   fields: {
     span: { type: 'number' as const, label: 'Column Span (1–12)' },
     content: { type: 'slot' as const },
@@ -124,10 +124,10 @@ export const ColumnBlock: ComponentConfig = {
                 zIndex: 1,
               },
             },
-            `${span}/12`
+            `${span}/12`,
           )
         : null,
-      React.createElement(Content)
+      React.createElement(Content),
     );
   },
 };

--- a/packages/designer/src/components/SupersubsetDesigner.tsx
+++ b/packages/designer/src/components/SupersubsetDesigner.tsx
@@ -135,6 +135,7 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
     sourceDashboard?.title ?? DEFAULT_DASHBOARD_TITLE,
   );
   const [pendingDeletePageId, setPendingDeletePageId] = useState<string | undefined>();
+  const [controlledSyncRevision, setControlledSyncRevision] = useState(0);
   const canMutateDashboard = !isControlled || !!onChange;
   const pendingDeletePage = pages.find((page) => page.id === pendingDeletePageId);
 
@@ -158,6 +159,12 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
   headerActionsRef.current = headerActions;
   const designerRootRef = useRef<HTMLDivElement | null>(null);
   const a11yInstanceIdRef = useRef(nextDesignerA11yInstanceId++);
+  const lastHandledControlledSignatureRef = useRef<string | undefined>(undefined);
+  const lastEmittedControlledSignatureRef = useRef<string | undefined>(undefined);
+  const controlledValueSignature = useMemo(
+    () => (isControlled ? createDashboardSyncSignature(value) : undefined),
+    [isControlled, value],
+  );
 
   useEffect(() => {
     const nextActivePageId = activePage?.id;
@@ -174,8 +181,37 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
     setDashboardTitleDraft(sourceDashboard?.title ?? DEFAULT_DASHBOARD_TITLE);
   }, [sourceDashboard?.title]);
 
+  useEffect(() => {
+    if (!isControlled) {
+      lastHandledControlledSignatureRef.current = undefined;
+      lastEmittedControlledSignatureRef.current = undefined;
+      return;
+    }
+
+    if (controlledValueSignature === undefined) {
+      lastHandledControlledSignatureRef.current = undefined;
+      return;
+    }
+
+    const lastHandledSignature = lastHandledControlledSignatureRef.current;
+    lastHandledControlledSignatureRef.current = controlledValueSignature;
+
+    if (
+      lastHandledSignature === undefined ||
+      lastHandledSignature === controlledValueSignature ||
+      controlledValueSignature === lastEmittedControlledSignatureRef.current
+    ) {
+      return;
+    }
+
+    setControlledSyncRevision((revision) => revision + 1);
+  }, [controlledValueSignature, isControlled]);
+
   const emitDashboardChange = useCallback(
     (dashboard: DashboardDefinition) => {
+      if (isControlled) {
+        lastEmittedControlledSignatureRef.current = createDashboardSyncSignature(dashboard);
+      }
       if (!isControlled) {
         setUncontrolledDashboard(dashboard);
       }
@@ -736,7 +772,7 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
     ],
   );
 
-  const editorKey = `${sourceDashboard?.id ?? 'new-dashboard'}:${activePage?.id ?? 'page-0'}`;
+  const editorKey = `${sourceDashboard?.id ?? 'new-dashboard'}:${activePage?.id ?? 'page-0'}:${controlledSyncRevision}`;
 
   useEffect(() => {
     const root = designerRootRef.current;
@@ -860,6 +896,12 @@ function createUniquePageId(existingPages: PageDefinition[], title: string): str
   }
 
   return candidateId;
+}
+
+function createDashboardSyncSignature(
+  dashboard: DashboardDefinition | undefined,
+): string | undefined {
+  return dashboard ? JSON.stringify(dashboard) : undefined;
 }
 
 function normalizePageTitle(nextTitle: string, fallbackTitle: string): string {

--- a/packages/designer/test/designer-controlled-sync.test.tsx
+++ b/packages/designer/test/designer-controlled-sync.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { SupersubsetDesigner } from '../src/components/SupersubsetDesigner';
+import { UndoRedoToolbar, useUndoRedo } from '../src/components/UndoRedo';
+import type { DashboardDefinition } from '@supersubset/schema';
+
+vi.mock('@puckeditor/core', async () => {
+  const ReactModule = await import('react');
+
+  return {
+    Puck: (props: Record<string, unknown>) => {
+      const [data] = ReactModule.useState(
+        props.data as { content?: Array<Record<string, unknown>> } | undefined,
+      );
+      const overrides = props.overrides as Record<string, unknown> | undefined;
+      const headerActionsOverride = overrides?.headerActions as
+        | ((p: { children: React.ReactNode }) => React.ReactElement)
+        | undefined;
+
+      return ReactModule.createElement(
+        'div',
+        {
+          'data-testid': 'sticky-puck-editor',
+          'data-puck-payload': JSON.stringify(data?.content ?? []),
+        },
+        headerActionsOverride
+          ? headerActionsOverride({
+              children: ReactModule.createElement('span', { 'data-testid': 'default-actions' }),
+            })
+          : null,
+      );
+    },
+    blocksPlugin: () => ({ name: 'blocks', label: 'Blocks' }),
+    outlinePlugin: () => ({ name: 'outline', label: 'Outline' }),
+  };
+});
+
+vi.mock('@puckeditor/core/puck.css', () => ({}));
+
+const dashboardA: DashboardDefinition = {
+  schemaVersion: '0.2.0',
+  id: 'sync-dash',
+  title: 'Sync Dashboard',
+  pages: [
+    {
+      id: 'page-1',
+      title: 'Overview',
+      rootNodeId: 'root',
+      layout: {
+        root: { id: 'root', type: 'root', children: ['grid-main'], meta: {} },
+        'grid-main': {
+          id: 'grid-main',
+          type: 'grid',
+          children: ['header-1'],
+          parentId: 'root',
+          meta: { columns: 12 },
+        },
+        'header-1': {
+          id: 'header-1',
+          type: 'header',
+          children: [],
+          parentId: 'grid-main',
+          meta: { text: 'Original Header', headerSize: 'large' },
+        },
+      },
+      widgets: [],
+    },
+  ],
+};
+
+const dashboardB: DashboardDefinition = {
+  ...dashboardA,
+  pages: [
+    {
+      ...dashboardA.pages[0],
+      layout: {
+        root: { id: 'root', type: 'root', children: ['grid-main'], meta: {} },
+        'grid-main': {
+          id: 'grid-main',
+          type: 'grid',
+          children: ['header-2'],
+          parentId: 'root',
+          meta: { columns: 12 },
+        },
+        'header-2': {
+          id: 'header-2',
+          type: 'header',
+          children: [],
+          parentId: 'grid-main',
+          meta: { text: 'Updated Header', headerSize: 'large' },
+        },
+      },
+    },
+  ],
+};
+
+function UndoHarness() {
+  const undoRedo = useUndoRedo(dashboardA, { debounceMs: 0 });
+
+  return React.createElement(SupersubsetDesigner, {
+    value: undoRedo.current,
+    onChange: undoRedo.push,
+    headerActions: React.createElement(UndoRedoToolbar, {
+      canUndo: undoRedo.canUndo,
+      canRedo: undoRedo.canRedo,
+      onUndo: undoRedo.undo,
+      onRedo: undoRedo.redo,
+      undoCount: undoRedo.undoCount,
+      redoCount: undoRedo.redoCount,
+    }),
+  });
+}
+
+describe('SupersubsetDesigner controlled sync', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('re-mounts Puck when a controlled value changes externally on the same page', () => {
+    const { rerender } = render(
+      React.createElement(SupersubsetDesigner, {
+        value: dashboardA,
+        onChange: vi.fn(),
+      }),
+    );
+
+    expect(screen.getByTestId('sticky-puck-editor').getAttribute('data-puck-payload')).toContain(
+      'header-1',
+    );
+
+    rerender(
+      React.createElement(SupersubsetDesigner, {
+        value: dashboardB,
+        onChange: vi.fn(),
+      }),
+    );
+
+    expect(screen.getByTestId('sticky-puck-editor').getAttribute('data-puck-payload')).toContain(
+      'header-2',
+    );
+  });
+
+  it('keeps dashboard title edits on the host undo stack', async () => {
+    render(React.createElement(UndoHarness));
+
+    const undoButton = screen.getByTestId('undo-btn');
+    expect(undoButton.hasAttribute('disabled')).toBe(true);
+
+    const titleInput = screen.getByTestId('designer-dashboard-title-input');
+    fireEvent.change(titleInput, { target: { value: 'Executive Dashboard' } });
+    fireEvent.blur(titleInput);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('undo-btn').hasAttribute('disabled')).toBe(false);
+    });
+  });
+});

--- a/packages/designer/test/integration.test.ts
+++ b/packages/designer/test/integration.test.ts
@@ -20,7 +20,11 @@ import type { Data } from '@puckeditor/core';
 describe('Config integration — all blocks registered', () => {
   const config = createPuckConfig();
   const allComponentNames = Object.keys(config.components);
-  const totalBlockCount = CHART_BLOCK_NAMES.length + CONTENT_BLOCK_NAMES.length + CONTROL_BLOCK_NAMES.length + LAYOUT_BLOCK_NAMES.length;
+  const totalBlockCount =
+    CHART_BLOCK_NAMES.length +
+    CONTENT_BLOCK_NAMES.length +
+    CONTROL_BLOCK_NAMES.length +
+    LAYOUT_BLOCK_NAMES.length;
 
   it('registers the expected total number of components', () => {
     expect(allComponentNames).toHaveLength(totalBlockCount);
@@ -78,8 +82,9 @@ describe('Category integration', () => {
   const cats = config.categories!;
 
   it('all chart components appear in exactly one category', () => {
-    const allCatComponents = Object.values(cats)
-      .flatMap((cat) => (cat as { components?: string[] }).components ?? []);
+    const allCatComponents = Object.values(cats).flatMap(
+      (cat) => (cat as { components?: string[] }).components ?? [],
+    );
 
     for (const name of CHART_BLOCK_NAMES) {
       const count = allCatComponents.filter((c) => c === name).length;
@@ -88,8 +93,9 @@ describe('Category integration', () => {
   });
 
   it('all content components appear in exactly one category', () => {
-    const allCatComponents = Object.values(cats)
-      .flatMap((cat) => (cat as { components?: string[] }).components ?? []);
+    const allCatComponents = Object.values(cats).flatMap(
+      (cat) => (cat as { components?: string[] }).components ?? [],
+    );
 
     for (const name of CONTENT_BLOCK_NAMES) {
       expect(allCatComponents).toContain(name);
@@ -97,8 +103,9 @@ describe('Category integration', () => {
   });
 
   it('all control components appear in exactly one category', () => {
-    const allCatComponents = Object.values(cats)
-      .flatMap((cat) => (cat as { components?: string[] }).components ?? []);
+    const allCatComponents = Object.values(cats).flatMap(
+      (cat) => (cat as { components?: string[] }).components ?? [],
+    );
 
     for (const name of CONTROL_BLOCK_NAMES) {
       expect(allCatComponents).toContain(name);
@@ -106,8 +113,9 @@ describe('Category integration', () => {
   });
 
   it('all layout components appear in exactly one category', () => {
-    const allCatComponents = Object.values(cats)
-      .flatMap((cat) => (cat as { components?: string[] }).components ?? []);
+    const allCatComponents = Object.values(cats).flatMap(
+      (cat) => (cat as { components?: string[] }).components ?? [],
+    );
 
     for (const name of LAYOUT_BLOCK_NAMES) {
       expect(allCatComponents).toContain(name);
@@ -134,8 +142,9 @@ describe('Category integration', () => {
   });
 
   it('every categorized component is registered in config.components', () => {
-    const allCatComponents = Object.values(cats)
-      .flatMap((cat) => (cat as { components?: string[] }).components ?? []);
+    const allCatComponents = Object.values(cats).flatMap(
+      (cat) => (cat as { components?: string[] }).components ?? [],
+    );
 
     for (const name of allCatComponents) {
       expect(config.components[name], `${name} is categorized but not registered`).toBeDefined();
@@ -258,14 +267,77 @@ describe('Full pipeline — build dashboard → serialize → restore', () => {
     const puckData: Data = {
       root: { props: { title: 'Mixed Dashboard' } },
       content: [
-        { type: 'HeaderBlock', props: { id: 'h1', text: 'Sales Overview', size: 'large', align: 'center' } },
+        {
+          type: 'HeaderBlock',
+          props: { id: 'h1', text: 'Sales Overview', size: 'large', align: 'center' },
+        },
         { type: 'DividerBlock', props: { id: 'd1', color: '#e0e0e0', thickness: 1, margin: 16 } },
-        { type: 'FilterBarBlock', props: { id: 'fb1', title: 'Filters', scope: 'global', layout: 'horizontal' } },
-        { type: 'LineChart', props: { id: 'lc1', title: 'Revenue Trend', datasetRef: 'sales', xAxisField: 'month', yAxisField: 'revenue', seriesField: '', aggregation: 'sum', smooth: 'true' } },
-        { type: 'BarChart', props: { id: 'bc1', title: 'Sales by Category', datasetRef: 'sales', xAxisField: 'category', yAxisField: 'amount', seriesField: '', aggregation: 'none', orientation: 'vertical', stacked: 'false' } },
-        { type: 'PieChart', props: { id: 'pc1', title: 'Market Share', datasetRef: 'sales', categoryField: 'region', valueField: 'share', aggregation: 'none', variant: 'donut' } },
-        { type: 'KPICard', props: { id: 'kpi1', title: 'Total Revenue', datasetRef: 'sales', valueField: 'total', aggregation: 'sum', prefix: '$', suffix: '', comparisonField: 'prev_total' } },
-        { type: 'Table', props: { id: 't1', title: 'Transaction Details', datasetRef: 'transactions', pageSize: 25, striped: 'true' } },
+        {
+          type: 'FilterBarBlock',
+          props: { id: 'fb1', title: 'Filters', scope: 'global', layout: 'horizontal' },
+        },
+        {
+          type: 'LineChart',
+          props: {
+            id: 'lc1',
+            title: 'Revenue Trend',
+            datasetRef: 'sales',
+            xAxisField: 'month',
+            yAxisField: 'revenue',
+            seriesField: '',
+            aggregation: 'sum',
+            smooth: 'true',
+          },
+        },
+        {
+          type: 'BarChart',
+          props: {
+            id: 'bc1',
+            title: 'Sales by Category',
+            datasetRef: 'sales',
+            xAxisField: 'category',
+            yAxisField: 'amount',
+            seriesField: '',
+            aggregation: 'none',
+            orientation: 'vertical',
+            stacked: 'false',
+          },
+        },
+        {
+          type: 'PieChart',
+          props: {
+            id: 'pc1',
+            title: 'Market Share',
+            datasetRef: 'sales',
+            categoryField: 'region',
+            valueField: 'share',
+            aggregation: 'none',
+            variant: 'donut',
+          },
+        },
+        {
+          type: 'KPICard',
+          props: {
+            id: 'kpi1',
+            title: 'Total Revenue',
+            datasetRef: 'sales',
+            valueField: 'total',
+            aggregation: 'sum',
+            prefix: '$',
+            suffix: '',
+            comparisonField: 'prev_total',
+          },
+        },
+        {
+          type: 'Table',
+          props: {
+            id: 't1',
+            title: 'Transaction Details',
+            datasetRef: 'transactions',
+            pageSize: 25,
+            striped: 'true',
+          },
+        },
         { type: 'SpacerBlock', props: { id: 's1', height: 32 } },
         { type: 'MarkdownBlock', props: { id: 'm1', content: '*Data refreshed daily*' } },
       ],
@@ -307,10 +379,10 @@ describe('Layout blocks integration', () => {
     expect((row.fields?.content as { type: string }).type).toBe('slot');
   });
 
-  it('ColumnBlock is inline and has slot field', () => {
+  it('ColumnBlock is not inline and has slot field', () => {
     const col = config.components['ColumnBlock'];
     expect(col).toBeDefined();
-    expect(col.inline).toBe(true);
+    expect(col.inline).toBe(false);
     expect((col.fields?.content as { type: string }).type).toBe('slot');
   });
 
@@ -445,7 +517,9 @@ describe('Root render integration', () => {
   });
 
   it('root does not set dashboard metadata defaults', () => {
-    expect((config.root as { defaultProps?: Record<string, unknown> })?.defaultProps ?? {}).toEqual({});
+    expect((config.root as { defaultProps?: Record<string, unknown> })?.defaultProps ?? {}).toEqual(
+      {},
+    );
   });
 
   it('root render function wraps children', () => {

--- a/packages/designer/test/layout-blocks.test.ts
+++ b/packages/designer/test/layout-blocks.test.ts
@@ -3,7 +3,12 @@
  */
 import { describe, it, expect } from 'vitest';
 import React from 'react';
-import { RowBlock, ColumnBlock, LAYOUT_BLOCK_NAMES, LAYOUT_PUCK_NAME_TO_TYPE } from '../src/blocks/layout';
+import {
+  RowBlock,
+  ColumnBlock,
+  LAYOUT_BLOCK_NAMES,
+  LAYOUT_PUCK_NAME_TO_TYPE,
+} from '../src/blocks/layout';
 
 describe('RowBlock', () => {
   it('has label', () => {
@@ -50,8 +55,8 @@ describe('ColumnBlock', () => {
     expect(ColumnBlock.label).toBe('Column');
   });
 
-  it('is inline', () => {
-    expect(ColumnBlock.inline).toBe(true);
+  it('is not inline so nested widgets can own canvas selection', () => {
+    expect(ColumnBlock.inline).toBe(false);
   });
 
   it('has content slot field', () => {


### PR DESCRIPTION
## Summary
- stop `ColumnBlock` from stealing nested widget selection so chart properties remain editable
- re-mount the controlled Puck editor only when an external controlled value actually changes
- keep dashboard title edits on the host undo stack and cover the controlled sync path with regression tests

## Issues
- closes #82
- closes #61
- closes #60

## Validation
- pnpm --filter @supersubset/designer test -- test/layout-blocks.test.ts test/integration.test.ts test/designer-controlled-sync.test.tsx
- pnpm --filter @supersubset/designer typecheck
- pnpm exec playwright test e2e/workflows/designer-to-renderer.spec.ts e2e/workflows/host-integration.spec.ts --project=chromium