### PR TITLE
fix: stabilize docs property variant capture

### DIFF
--- a/packages/docs/capture/helpers.ts
+++ b/packages/docs/capture/helpers.ts
@@ -42,11 +42,21 @@ export function screenshotPath(
 export async function switchToViewer(page: Page): Promise<void> {
   // Try button role first, then fall back to text matching
   const btn = page.getByRole('button', { name: /viewer/i });
-  if (await btn.first().isVisible({ timeout: 2000 }).catch(() => false)) {
+  if (
+    await btn
+      .first()
+      .isVisible({ timeout: 2000 })
+      .catch(() => false)
+  ) {
     await btn.first().click();
   } else {
     const textBtn = page.getByText('Viewer');
-    if (await textBtn.first().isVisible({ timeout: 2000 }).catch(() => false)) {
+    if (
+      await textBtn
+        .first()
+        .isVisible({ timeout: 2000 })
+        .catch(() => false)
+    ) {
       await textBtn.first().click();
     }
   }
@@ -58,11 +68,21 @@ export async function switchToViewer(page: Page): Promise<void> {
  */
 export async function switchToDesigner(page: Page): Promise<void> {
   const btn = page.getByRole('button', { name: /designer/i });
-  if (await btn.first().isVisible({ timeout: 2000 }).catch(() => false)) {
+  if (
+    await btn
+      .first()
+      .isVisible({ timeout: 2000 })
+      .catch(() => false)
+  ) {
     await btn.first().click();
   } else {
     const textBtn = page.getByText('Designer');
-    if (await textBtn.first().isVisible({ timeout: 2000 }).catch(() => false)) {
+    if (
+      await textBtn
+        .first()
+        .isVisible({ timeout: 2000 })
+        .catch(() => false)
+    ) {
       await textBtn.first().click();
     }
   }
@@ -76,21 +96,36 @@ export async function switchToDesigner(page: Page): Promise<void> {
 export async function navigateToPage(page: Page, pageTitle: string): Promise<void> {
   // Try role=tab first
   const tab = page.getByRole('tab', { name: new RegExp(pageTitle, 'i') });
-  if (await tab.first().isVisible({ timeout: 2000 }).catch(() => false)) {
+  if (
+    await tab
+      .first()
+      .isVisible({ timeout: 2000 })
+      .catch(() => false)
+  ) {
     await tab.first().click();
     await page.waitForTimeout(500);
     return;
   }
   // Try nav buttons
   const navBtn = page.locator('nav button', { hasText: new RegExp(pageTitle, 'i') });
-  if (await navBtn.first().isVisible({ timeout: 2000 }).catch(() => false)) {
+  if (
+    await navBtn
+      .first()
+      .isVisible({ timeout: 2000 })
+      .catch(() => false)
+  ) {
     await navBtn.first().click();
     await page.waitForTimeout(500);
     return;
   }
   // Try any button with the text
   const anyBtn = page.locator('button', { hasText: new RegExp(pageTitle, 'i') });
-  if (await anyBtn.first().isVisible({ timeout: 2000 }).catch(() => false)) {
+  if (
+    await anyBtn
+      .first()
+      .isVisible({ timeout: 2000 })
+      .catch(() => false)
+  ) {
     await anyBtn.first().click();
     await page.waitForTimeout(500);
   }
@@ -273,38 +308,79 @@ export async function selectWidgetViaCanvas(
 }
 
 /**
+ * Select a widget in the designer by clicking its stable `data-puck-component`
+ * wrapper inside the canvas iframe.
+ */
+export async function selectWidgetFromCanvasByComponentId(
+  page: Page,
+  puckComponentId: string,
+): Promise<boolean> {
+  const iframe = page.frameLocator('iframe').first();
+  const widget = iframe.locator(`[data-puck-component="${puckComponentId}"]`).first();
+
+  if (!(await widget.isVisible({ timeout: 3000 }).catch(() => false))) {
+    return false;
+  }
+
+  await widget.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(200);
+  await widget.click();
+  await page.waitForTimeout(500);
+  return true;
+}
+
+/**
  * Select a widget in the designer by clicking its layer entry in the Layers panel.
  * For duplicate labels (e.g., multiple KPI Cards), clicks the first match.
  */
-export async function selectWidgetViaLayers(
-  page: Page,
-  widgetLabel: string,
-): Promise<boolean> {
+export async function selectWidgetViaLayers(page: Page, widgetLabel: string): Promise<boolean> {
   // Switch to Layers tab
-  const layersBtn = page.getByText('Layers').first();
-  if (await layersBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+  const layersBtn = page.getByRole('button', { name: /^Layers$/ }).first();
+  if (await layersBtn.isVisible({ timeout: 1000 }).catch(() => false)) {
     await layersBtn.click();
     await page.waitForTimeout(500);
+  } else {
+    const layersText = page.getByText('Layers').first();
+    if (await layersText.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await layersText.click();
+      await page.waitForTimeout(500);
+    }
   }
 
-  // Click the layer button with matching text
-  // Use exact text on the name span to avoid partial matches
-  const layerBtn = page.locator(`[class*="Layer-name"]`).filter({ hasText: new RegExp(`^${widgetLabel}$`) });
-  const count = await layerBtn.count();
-  if (count > 0) {
-    await layerBtn.first().click();
+  const exactWidgetName = new RegExp(`^${escapeRegExp(widgetLabel)}$`);
+  const layerTree = page.locator('nav + ul').first();
+  const rowButtons = layerTree.getByRole('button', { name: /Row \(12-col Grid\)$/ });
+  const rowCount = await rowButtons.count();
+
+  const widgetButton = layerTree.getByRole('button', { name: exactWidgetName }).first();
+  if (await widgetButton.isVisible({ timeout: 300 }).catch(() => false)) {
+    await widgetButton.click();
     await page.waitForTimeout(800);
     return true;
   }
-  
-  // Fallback: try the clickable button with has-text
-  const clickable = page.locator('[class*="Layer-clickable"]').filter({ hasText: widgetLabel });
-  if (await clickable.first().isVisible({ timeout: 2000 }).catch(() => false)) {
-    await clickable.first().click();
-    await page.waitForTimeout(800);
-    return true;
+
+  for (let index = 0; index < rowCount; index += 1) {
+    const rowButton = rowButtons.nth(index);
+    if (!(await rowButton.isVisible({ timeout: 300 }).catch(() => false))) {
+      continue;
+    }
+
+    await rowButton.scrollIntoViewIfNeeded();
+    await rowButton.click();
+    await page.waitForTimeout(150);
+
+    if (await widgetButton.isVisible({ timeout: 300 }).catch(() => false)) {
+      await widgetButton.click();
+      await page.waitForTimeout(800);
+      return true;
+    }
   }
+
   return false;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**
@@ -441,51 +517,56 @@ export async function toggleRadioProperty(
   targetValue: string,
 ): Promise<boolean> {
   // Use page.evaluate for reliable DOM traversal
-  const clicked = await page.evaluate(({ fieldLabel, targetValue }) => {
-    // Find the label div whose text content includes our field name
-    const labelDivs = document.querySelectorAll('[class*="Input-label"]');
-    for (const labelDiv of labelDivs) {
-      // Check direct text content (excluding child element text)
-      const textContent = Array.from(labelDiv.childNodes)
-        .filter(n => n.nodeType === Node.TEXT_NODE)
-        .map(n => n.textContent?.trim())
-        .join('');
-      if (textContent !== fieldLabel) continue;
+  const clicked = await page.evaluate(
+    ({ fieldLabel, targetValue }) => {
+      // Find the label div whose text content includes our field name
+      const labelDivs = document.querySelectorAll('[class*="Input-label"]');
+      for (const labelDiv of labelDivs) {
+        // Check direct text content (excluding child element text)
+        const textContent = Array.from(labelDiv.childNodes)
+          .filter((n) => n.nodeType === Node.TEXT_NODE)
+          .map((n) => n.textContent?.trim())
+          .join('');
+        if (textContent !== fieldLabel) continue;
 
-      // Found the label — now find the radio group in its parent
-      const inputContainer = labelDiv.closest('[class*="Input_"]');
-      if (!inputContainer) continue;
+        // Found the label — now find the radio group in its parent
+        const inputContainer = labelDiv.closest('[class*="Input_"]');
+        if (!inputContainer) continue;
 
-      // Find radio option with matching text
-      const radioInners = inputContainer.querySelectorAll('[class*="Input-radioInner"]');
-      for (const inner of radioInners) {
-        if (inner.textContent?.trim() === targetValue) {
-          // Find the input element (sibling of radioInner inside the label)
-          const radioLabelEl = inner.closest('[class*="Input-radio"]') as HTMLElement;
-          if (!radioLabelEl) continue;
+        // Find radio option with matching text
+        const radioInners = inputContainer.querySelectorAll('[class*="Input-radioInner"]');
+        for (const inner of radioInners) {
+          if (inner.textContent?.trim() === targetValue) {
+            // Find the input element (sibling of radioInner inside the label)
+            const radioLabelEl = inner.closest('[class*="Input-radio"]') as HTMLElement;
+            if (!radioLabelEl) continue;
 
-          const input = radioLabelEl.querySelector('input[type="radio"]') as HTMLInputElement | null;
-          if (input) {
-            // Method 1: Try React onChange via __reactProps$
-            const propsKey = Object.keys(input).find(k => k.startsWith('__reactProps$'));
-            if (propsKey) {
-              const props = (input as any)[propsKey];
-              if (props?.onChange) {
-                input.checked = true;
-                props.onChange({ target: input, currentTarget: input });
-                return true;
+            const input = radioLabelEl.querySelector(
+              'input[type="radio"]',
+            ) as HTMLInputElement | null;
+            if (input) {
+              // Method 1: Try React onChange via __reactProps$
+              const propsKey = Object.keys(input).find((k) => k.startsWith('__reactProps$'));
+              if (propsKey) {
+                const props = (input as any)[propsKey];
+                if (props?.onChange) {
+                  input.checked = true;
+                  props.onChange({ target: input, currentTarget: input });
+                  return true;
+                }
               }
             }
-          }
 
-          // Method 2: Fallback to native click on the label
-          radioLabelEl.click();
-          return true;
+            // Method 2: Fallback to native click on the label
+            radioLabelEl.click();
+            return true;
+          }
         }
       }
-    }
-    return false;
-  }, { fieldLabel, targetValue });
+      return false;
+    },
+    { fieldLabel, targetValue },
+  );
 
   if (clicked) {
     await page.waitForTimeout(1200); // Wait for chart to re-render
@@ -508,64 +589,70 @@ export async function changeSelectProperty(
   // Puck JSON-encodes select option values as {"value":"actual_value"}.
   // We need to find the matching option and use its raw value attribute,
   // then trigger React's onChange handler properly.
-  const changed = await page.evaluate(({ fieldLabel, targetValue }) => {
-    const labelDivs = document.querySelectorAll('[class*="Input-label"]');
-    for (const labelDiv of labelDivs) {
-      const textContent = Array.from(labelDiv.childNodes)
-        .filter(n => n.nodeType === Node.TEXT_NODE)
-        .map(n => n.textContent?.trim())
-        .join('');
-      if (textContent !== fieldLabel) continue;
+  const changed = await page.evaluate(
+    ({ fieldLabel, targetValue }) => {
+      const labelDivs = document.querySelectorAll('[class*="Input-label"]');
+      for (const labelDiv of labelDivs) {
+        const textContent = Array.from(labelDiv.childNodes)
+          .filter((n) => n.nodeType === Node.TEXT_NODE)
+          .map((n) => n.textContent?.trim())
+          .join('');
+        if (textContent !== fieldLabel) continue;
 
-      const fieldContainer = labelDiv.closest('[class*="PuckFields-field"]')
-        ?? labelDiv.closest('[class*="Input_"]');
-      if (!fieldContainer) continue;
+        const fieldContainer =
+          labelDiv.closest('[class*="PuckFields-field"]') ?? labelDiv.closest('[class*="Input_"]');
+        if (!fieldContainer) continue;
 
-      const select = fieldContainer.querySelector('select') as HTMLSelectElement | null;
-      if (!select) continue;
+        const select = fieldContainer.querySelector('select') as HTMLSelectElement | null;
+        if (!select) continue;
 
-      // Find the option whose value matches targetValue.
-      // Puck options may be JSON-encoded ({"value":"20%"}) or plain strings.
-      let matchingOptionValue: string | null = null;
-      for (const opt of select.options) {
-        if (opt.value === targetValue) {
-          matchingOptionValue = opt.value;
-          break;
-        }
-        // Try JSON-decoded match
-        try {
-          const parsed = JSON.parse(opt.value);
-          if (parsed?.value === targetValue) {
+        // Find the option whose value matches targetValue.
+        // Puck options may be JSON-encoded ({"value":"20%"}) or plain strings.
+        let matchingOptionValue: string | null = null;
+        for (const opt of select.options) {
+          if (opt.value === targetValue) {
             matchingOptionValue = opt.value;
             break;
           }
-        } catch { /* not JSON */ }
-      }
-
-      const valueToSet = matchingOptionValue ?? targetValue;
-
-      // Set the native value
-      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-        HTMLSelectElement.prototype, 'value',
-      )?.set;
-      nativeInputValueSetter?.call(select, valueToSet);
-
-      // Try React onChange via __reactProps$
-      const propsKey = Object.keys(select).find(k => k.startsWith('__reactProps$'));
-      if (propsKey) {
-        const props = (select as any)[propsKey];
-        if (props?.onChange) {
-          props.onChange({ target: select, currentTarget: select });
-          return true;
+          // Try JSON-decoded match
+          try {
+            const parsed = JSON.parse(opt.value);
+            if (parsed?.value === targetValue) {
+              matchingOptionValue = opt.value;
+              break;
+            }
+          } catch {
+            /* not JSON */
+          }
         }
-      }
 
-      // Fallback: dispatch native change event
-      select.dispatchEvent(new Event('change', { bubbles: true }));
-      return true;
-    }
-    return false;
-  }, { fieldLabel, targetValue });
+        const valueToSet = matchingOptionValue ?? targetValue;
+
+        // Set the native value
+        const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+          HTMLSelectElement.prototype,
+          'value',
+        )?.set;
+        nativeInputValueSetter?.call(select, valueToSet);
+
+        // Try React onChange via __reactProps$
+        const propsKey = Object.keys(select).find((k) => k.startsWith('__reactProps$'));
+        if (propsKey) {
+          const props = (select as any)[propsKey];
+          if (props?.onChange) {
+            props.onChange({ target: select, currentTarget: select });
+            return true;
+          }
+        }
+
+        // Fallback: dispatch native change event
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+        return true;
+      }
+      return false;
+    },
+    { fieldLabel, targetValue },
+  );
 
   if (changed) {
     await page.waitForTimeout(1200);
@@ -574,17 +661,85 @@ export async function changeSelectProperty(
 }
 
 /**
- * Scroll a property into view within the Puck property panel sidebar.
+ * Change a numeric property in the Puck property panel.
  */
-export async function scrollPropertyIntoView(
+export async function changeNumberProperty(
   page: Page,
   fieldLabel: string,
-): Promise<void> {
+  targetValue: string,
+): Promise<boolean> {
+  const changed = await page.evaluate(
+    ({ fieldLabel, targetValue }) => {
+      const labelDivs = document.querySelectorAll('[class*="Input-label"]');
+      for (const labelDiv of labelDivs) {
+        const textContent = Array.from(labelDiv.childNodes)
+          .filter((node) => node.nodeType === Node.TEXT_NODE)
+          .map((node) => node.textContent?.trim())
+          .join('');
+        if (textContent !== fieldLabel) continue;
+
+        const fieldContainer =
+          labelDiv.closest('[class*="PuckFields-field"]') ?? labelDiv.closest('[class*="Input_"]');
+        if (!fieldContainer) continue;
+
+        const input = fieldContainer.querySelector('input') as HTMLInputElement | null;
+        if (!input) continue;
+
+        const nativeSetter = Object.getOwnPropertyDescriptor(
+          HTMLInputElement.prototype,
+          'value',
+        )?.set;
+        nativeSetter?.call(input, targetValue);
+
+        const propsKey = Object.keys(input).find((key) => key.startsWith('__reactProps$'));
+        if (propsKey) {
+          const props = (input as Record<string, unknown>)[propsKey] as
+            | {
+                onChange?: (event: {
+                  target: HTMLInputElement;
+                  currentTarget: HTMLInputElement;
+                }) => void;
+              }
+            | undefined;
+          if (props?.onChange) {
+            props.onChange({ target: input, currentTarget: input });
+            input.dispatchEvent(new Event('blur', { bubbles: true }));
+            return true;
+          }
+        }
+
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        input.dispatchEvent(new Event('blur', { bubbles: true }));
+        return true;
+      }
+
+      return false;
+    },
+    { fieldLabel, targetValue },
+  );
+
+  if (changed) {
+    await page.waitForTimeout(1200);
+  }
+
+  return changed;
+}
+
+/**
+ * Scroll a property into view within the Puck property panel sidebar.
+ */
+export async function scrollPropertyIntoView(page: Page, fieldLabel: string): Promise<void> {
   const fieldContainer = page.locator('[class*="PuckFields-field"]').filter({
     has: page.locator('[class*="Input-label"]', { hasText: new RegExp(`^${fieldLabel}$`) }),
   });
 
-  if (await fieldContainer.first().isVisible({ timeout: 3000 }).catch(() => false)) {
+  if (
+    await fieldContainer
+      .first()
+      .isVisible({ timeout: 3000 })
+      .catch(() => false)
+  ) {
     await fieldContainer.first().scrollIntoViewIfNeeded();
     await page.waitForTimeout(300);
   } else {
@@ -597,7 +752,12 @@ export async function scrollPropertyIntoView(
           scrollable.scrollBy(0, 200);
         });
         await page.waitForTimeout(200);
-        if (await fieldContainer.first().isVisible({ timeout: 500 }).catch(() => false)) {
+        if (
+          await fieldContainer
+            .first()
+            .isVisible({ timeout: 500 })
+            .catch(() => false)
+        ) {
           await fieldContainer.first().scrollIntoViewIfNeeded();
           break;
         }

--- a/packages/docs/capture/property-variants.spec.ts
+++ b/packages/docs/capture/property-variants.spec.ts
@@ -14,9 +14,11 @@ import {
   waitForChartsReady,
   captureWidgetFromCanvas,
   capturePropertyCallout,
+  selectWidgetFromCanvasByComponentId,
   selectWidgetViaLayers,
   toggleRadioProperty,
   changeSelectProperty,
+  changeNumberProperty,
   scrollPropertyIntoView,
   screenshotPath,
   setupConsoleErrorCapture,
@@ -28,12 +30,12 @@ import {
 interface PropertyVariant {
   /** Property label as shown in Puck panel */
   fieldLabel: string;
-  /** Value to set (for radio: button label; for select: option value) */
+  /** Value to set (for radio: button label; for select: option value; for number: input value) */
   targetValue: string;
   /** Variant slug for the screenshot filename */
   variantSlug: string;
-  /** 'radio' or 'select' */
-  fieldType: 'radio' | 'select';
+  /** 'radio', 'select', or 'number' */
+  fieldType: 'radio' | 'select' | 'number';
 }
 
 interface WidgetVariantSpec {
@@ -64,9 +66,24 @@ const overviewWidgets: WidgetVariantSpec[] = [
     slug: 'line-chart',
     page: 'overview',
     variants: [
-      { fieldLabel: 'Smooth', targetValue: 'No', variantSlug: 'straight-lines', fieldType: 'radio' },
-      { fieldLabel: 'Show Markers', targetValue: 'No', variantSlug: 'no-markers', fieldType: 'radio' },
-      { fieldLabel: 'Connect Nulls', targetValue: 'Yes', variantSlug: 'connect-nulls', fieldType: 'radio' },
+      {
+        fieldLabel: 'Smooth',
+        targetValue: 'No',
+        variantSlug: 'straight-lines',
+        fieldType: 'radio',
+      },
+      {
+        fieldLabel: 'Show Markers',
+        targetValue: 'No',
+        variantSlug: 'no-markers',
+        fieldType: 'radio',
+      },
+      {
+        fieldLabel: 'Step Interpolation',
+        targetValue: 'middle',
+        variantSlug: 'step-middle',
+        fieldType: 'select',
+      },
     ],
   },
   {
@@ -77,9 +94,24 @@ const overviewWidgets: WidgetVariantSpec[] = [
     slug: 'bar-chart',
     page: 'overview',
     variants: [
-      { fieldLabel: 'Orientation', targetValue: 'Horizontal', variantSlug: 'horizontal', fieldType: 'radio' },
-      { fieldLabel: 'Stacked', targetValue: 'Yes', variantSlug: 'stacked', fieldType: 'radio' },
-      { fieldLabel: 'Bar Width', targetValue: '20%', variantSlug: 'slim-bars', fieldType: 'select' },
+      {
+        fieldLabel: 'Orientation',
+        targetValue: 'Horizontal',
+        variantSlug: 'horizontal',
+        fieldType: 'radio',
+      },
+      {
+        fieldLabel: 'Show Values',
+        targetValue: 'Yes',
+        variantSlug: 'show-values',
+        fieldType: 'radio',
+      },
+      {
+        fieldLabel: 'Bar Width',
+        targetValue: '20%',
+        variantSlug: 'slim-bars',
+        fieldType: 'select',
+      },
     ],
   },
   {
@@ -91,8 +123,18 @@ const overviewWidgets: WidgetVariantSpec[] = [
     page: 'overview',
     variants: [
       { fieldLabel: 'Striped', targetValue: 'No', variantSlug: 'no-stripes', fieldType: 'radio' },
-      { fieldLabel: 'Row Numbers', targetValue: 'Yes', variantSlug: 'row-numbers', fieldType: 'radio' },
-      { fieldLabel: 'Show Totals', targetValue: 'Yes', variantSlug: 'show-totals', fieldType: 'radio' },
+      {
+        fieldLabel: 'Row Numbers',
+        targetValue: 'Yes',
+        variantSlug: 'row-numbers',
+        fieldType: 'radio',
+      },
+      {
+        fieldLabel: 'Show Totals',
+        targetValue: 'Yes',
+        variantSlug: 'show-totals',
+        fieldType: 'radio',
+      },
     ],
   },
   {
@@ -103,8 +145,18 @@ const overviewWidgets: WidgetVariantSpec[] = [
     slug: 'alerts',
     page: 'overview',
     variants: [
-      { fieldLabel: 'Layout', targetValue: 'inline', variantSlug: 'inline-layout', fieldType: 'select' },
-      { fieldLabel: 'Show Timestamp', targetValue: 'No', variantSlug: 'no-timestamp', fieldType: 'radio' },
+      {
+        fieldLabel: 'Layout',
+        targetValue: 'inline',
+        variantSlug: 'inline-layout',
+        fieldType: 'select',
+      },
+      {
+        fieldLabel: 'Show Timestamp',
+        targetValue: 'No',
+        variantSlug: 'no-timestamp',
+        fieldType: 'radio',
+      },
     ],
   },
   {
@@ -115,8 +167,18 @@ const overviewWidgets: WidgetVariantSpec[] = [
     slug: 'kpi-card',
     page: 'overview',
     variants: [
-      { fieldLabel: 'Font Size', targetValue: 'lg', variantSlug: 'large-font', fieldType: 'select' },
-      { fieldLabel: 'Trend Direction', targetValue: 'Down = Good', variantSlug: 'down-good', fieldType: 'radio' },
+      {
+        fieldLabel: 'Font Size',
+        targetValue: 'lg',
+        variantSlug: 'large-font',
+        fieldType: 'select',
+      },
+      {
+        fieldLabel: 'Trend Direction',
+        targetValue: 'Down = Good',
+        variantSlug: 'down-good',
+        fieldType: 'radio',
+      },
     ],
   },
 ];
@@ -133,7 +195,12 @@ const galleryWidgets: WidgetVariantSpec[] = [
     page: 'gallery',
     variants: [
       { fieldLabel: 'Variant', targetValue: 'donut', variantSlug: 'donut', fieldType: 'select' },
-      { fieldLabel: 'Label Position', targetValue: 'inside', variantSlug: 'labels-inside', fieldType: 'select' },
+      {
+        fieldLabel: 'Label Position',
+        targetValue: 'inside',
+        variantSlug: 'labels-inside',
+        fieldType: 'select',
+      },
     ],
   },
   {
@@ -144,7 +211,12 @@ const galleryWidgets: WidgetVariantSpec[] = [
     slug: 'scatter-chart',
     page: 'gallery',
     variants: [
-      { fieldLabel: 'Opacity', targetValue: '0.4', variantSlug: 'low-opacity', fieldType: 'select' },
+      {
+        fieldLabel: 'Opacity',
+        targetValue: '0.4',
+        variantSlug: 'low-opacity',
+        fieldType: 'select',
+      },
     ],
   },
   {
@@ -155,9 +227,24 @@ const galleryWidgets: WidgetVariantSpec[] = [
     slug: 'area-chart',
     page: 'gallery',
     variants: [
-      { fieldLabel: 'Stacked', targetValue: 'No', variantSlug: 'unstacked', fieldType: 'radio' },
-      { fieldLabel: 'Area Opacity', targetValue: '1', variantSlug: 'full-opacity', fieldType: 'select' },
-      { fieldLabel: 'Show Markers', targetValue: 'No', variantSlug: 'no-markers', fieldType: 'radio' },
+      {
+        fieldLabel: 'Step Interpolation',
+        targetValue: 'middle',
+        variantSlug: 'step-middle',
+        fieldType: 'select',
+      },
+      {
+        fieldLabel: 'Area Opacity',
+        targetValue: '1',
+        variantSlug: 'full-opacity',
+        fieldType: 'select',
+      },
+      {
+        fieldLabel: 'Show Markers',
+        targetValue: 'No',
+        variantSlug: 'no-markers',
+        fieldType: 'radio',
+      },
     ],
   },
   {
@@ -168,7 +255,12 @@ const galleryWidgets: WidgetVariantSpec[] = [
     slug: 'combo-chart',
     page: 'gallery',
     variants: [
-      { fieldLabel: 'Smooth Lines', targetValue: 'No', variantSlug: 'straight-lines', fieldType: 'radio' },
+      {
+        fieldLabel: 'Smooth Lines',
+        targetValue: 'No',
+        variantSlug: 'straight-lines',
+        fieldType: 'radio',
+      },
     ],
   },
   {
@@ -179,8 +271,18 @@ const galleryWidgets: WidgetVariantSpec[] = [
     slug: 'gauge',
     page: 'gallery',
     variants: [
-      { fieldLabel: 'Round Cap', targetValue: 'Yes', variantSlug: 'round-cap', fieldType: 'radio' },
-      { fieldLabel: 'Progress Mode', targetValue: 'Yes', variantSlug: 'progress', fieldType: 'radio' },
+      {
+        fieldLabel: 'Split Count',
+        targetValue: '5',
+        variantSlug: 'low-split-count',
+        fieldType: 'number',
+      },
+      {
+        fieldLabel: 'Progress Mode',
+        targetValue: 'Yes',
+        variantSlug: 'progress',
+        fieldType: 'radio',
+      },
     ],
   },
   {
@@ -191,8 +293,18 @@ const galleryWidgets: WidgetVariantSpec[] = [
     slug: 'funnel-chart',
     page: 'gallery',
     variants: [
-      { fieldLabel: 'Sort', targetValue: 'ascending', variantSlug: 'ascending', fieldType: 'select' },
-      { fieldLabel: 'Alignment', targetValue: 'Left', variantSlug: 'align-left', fieldType: 'radio' },
+      {
+        fieldLabel: 'Sort',
+        targetValue: 'ascending',
+        variantSlug: 'ascending',
+        fieldType: 'select',
+      },
+      {
+        fieldLabel: 'Alignment',
+        targetValue: 'Left',
+        variantSlug: 'align-left',
+        fieldType: 'radio',
+      },
     ],
   },
   {
@@ -215,7 +327,12 @@ const galleryWidgets: WidgetVariantSpec[] = [
     slug: 'treemap',
     page: 'gallery',
     variants: [
-      { fieldLabel: 'Show Parent Labels', targetValue: 'Yes', variantSlug: 'parent-labels', fieldType: 'radio' },
+      {
+        fieldLabel: 'Show Values',
+        targetValue: 'Yes',
+        variantSlug: 'show-values',
+        fieldType: 'radio',
+      },
     ],
   },
   {
@@ -226,7 +343,12 @@ const galleryWidgets: WidgetVariantSpec[] = [
     slug: 'heatmap',
     page: 'gallery',
     variants: [
-      { fieldLabel: 'Show Values', targetValue: 'Yes', variantSlug: 'show-values', fieldType: 'radio' },
+      {
+        fieldLabel: 'Show Values',
+        targetValue: 'Yes',
+        variantSlug: 'show-values',
+        fieldType: 'radio',
+      },
     ],
   },
   {
@@ -237,7 +359,12 @@ const galleryWidgets: WidgetVariantSpec[] = [
     slug: 'waterfall',
     page: 'gallery',
     variants: [
-      { fieldLabel: 'Show Values', targetValue: 'Yes', variantSlug: 'show-values', fieldType: 'radio' },
+      {
+        fieldLabel: 'Show Values',
+        targetValue: 'Yes',
+        variantSlug: 'show-values',
+        fieldType: 'radio',
+      },
     ],
   },
   {
@@ -248,7 +375,12 @@ const galleryWidgets: WidgetVariantSpec[] = [
     slug: 'sankey',
     page: 'gallery',
     variants: [
-      { fieldLabel: 'Orientation', targetValue: 'Vertical', variantSlug: 'vertical', fieldType: 'radio' },
+      {
+        fieldLabel: 'Orientation',
+        targetValue: 'Vertical',
+        variantSlug: 'vertical',
+        fieldType: 'radio',
+      },
     ],
   },
   {
@@ -259,7 +391,12 @@ const galleryWidgets: WidgetVariantSpec[] = [
     slug: 'box-plot',
     page: 'gallery',
     variants: [
-      { fieldLabel: 'Box Width', targetValue: '50', variantSlug: 'wide-boxes', fieldType: 'select' },
+      {
+        fieldLabel: 'Box Width',
+        targetValue: '50',
+        variantSlug: 'wide-boxes',
+        fieldType: 'select',
+      },
     ],
   },
 ];
@@ -290,12 +427,18 @@ function generateTests(widgets: WidgetVariantSpec[]) {
         }
 
         // 2. Select the widget via Layers
-        const selected = await selectWidgetViaLayers(page, widget.layerLabel);
+        const selected =
+          (await selectWidgetFromCanvasByComponentId(page, widget.puckComponentId)) ||
+          (await selectWidgetViaLayers(page, widget.layerLabel));
         expect(selected, `Could not select ${widget.layerLabel} via Layers`).toBe(true);
 
         // 2b. Capture the DEFAULT viewer from canvas BEFORE toggling
         const beforePath = await captureWidgetFromCanvas(
-          page, widget.puckComponentId, widget.category, widget.slug, `${variant.variantSlug}-before`,
+          page,
+          widget.puckComponentId,
+          widget.category,
+          widget.slug,
+          `${variant.variantSlug}-before`,
         );
 
         // 3. Scroll property into view and toggle it
@@ -304,10 +447,14 @@ function generateTests(widgets: WidgetVariantSpec[]) {
         let toggled: boolean;
         if (variant.fieldType === 'radio') {
           toggled = await toggleRadioProperty(page, variant.fieldLabel, variant.targetValue);
-        } else {
+        } else if (variant.fieldType === 'select') {
           toggled = await changeSelectProperty(page, variant.fieldLabel, variant.targetValue);
+        } else {
+          toggled = await changeNumberProperty(page, variant.fieldLabel, variant.targetValue);
         }
-        expect(toggled, `Could not toggle ${variant.fieldLabel} to ${variant.targetValue}`).toBe(true);
+        expect(toggled, `Could not toggle ${variant.fieldLabel} to ${variant.targetValue}`).toBe(
+          true,
+        );
 
         // 4. Wait for Puck re-render to settle after property change
         await page.waitForTimeout(1500);
@@ -316,12 +463,20 @@ function generateTests(widgets: WidgetVariantSpec[]) {
         await scrollPropertyIntoView(page, variant.fieldLabel);
         await page.waitForTimeout(500);
         await capturePropertyCallout(
-          page, variant.fieldLabel, widget.category, widget.slug, variant.variantSlug,
+          page,
+          variant.fieldLabel,
+          widget.category,
+          widget.slug,
+          variant.variantSlug,
         );
 
         // 5. Capture the AFTER viewer from the Puck canvas iframe
         const afterPath = await captureWidgetFromCanvas(
-          page, widget.puckComponentId, widget.category, widget.slug, variant.variantSlug,
+          page,
+          widget.puckComponentId,
+          widget.category,
+          widget.slug,
+          variant.variantSlug,
         );
 
         // 6. Compare before and after — verify they differ


### PR DESCRIPTION
## Summary
- select widgets for docs capture via stable canvas component ids instead of the brittle Layers path
- harden the Layers fallback and property editing helpers used by the capture harness
- trim the noisy variant set and leave the remaining treemap preview gap tracked separately

## Issues
- closes #76
- follow-up: #90

## Validation
- pnpm --filter @supersubset/docs exec playwright test capture/property-variants.spec.ts
- 31/31 tests passed during revalidation after rebasing the branch onto develop