### PR TITLE
ci: skip full pipeline for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           filters: |
             code:
               - 'packages/**'
+              - '!packages/docs/**'
               - 'examples/**'
               - 'e2e/**'
               - 'src/**'
@@ -268,4 +269,4 @@ jobs:
               fi
             done
           fi
-          echo "✅ All required checks passed (or skipped for doc-only changes)"
+          echo "✅ All required checks passed (or the product-code pipeline was skipped)"


### PR DESCRIPTION
## Summary
- treat `packages/docs/**` as docs-only work in the CI path filter
- keep the existing CI gate structure intact while skipping build/lint/typecheck/unit/e2e/security for docs-only PRs
- update the gate message so intentional product-pipeline skips are described accurately

## Issues
- closes #84

## Validation
- git diff --check -- .github/workflows/ci.yml
- editor diagnostics on .github/workflows/ci.yml
- workflow change kept to a single file