### PR TITLE
ci: upgrade workflow Node runtime to 22 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
 
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
 
 permissions:
   contents: read

--- a/.github/workflows/promote-main.yml
+++ b/.github/workflows/promote-main.yml
@@ -18,7 +18,7 @@ permissions:
   pull-requests: write
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
 
 jobs:
   create-promotion-pr:

--- a/.github/workflows/promote-staging.yml
+++ b/.github/workflows/promote-staging.yml
@@ -18,7 +18,7 @@ permissions:
   pull-requests: write
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
 
 jobs:
   create-promotion-pr:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
## Summary
- upgrade the workflow-installed Node runtime from 20 to 22 across CI, staging promotion, main promotion, and release
- keep the existing workflow structure and setup-node usage intact while moving the project runtime baseline forward
- leave the earlier action-version upgrade work from #75 separate from this runtime baseline change

## Issues
- closes #87

## Validation
- git diff --check on the four touched workflow files
- editor diagnostics on the touched workflow files
- no remaining workflow-installed Node 20 pins in the edited workflow set