### PR TITLE
build: tame dev and storybook chunk warnings

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,13 +1,19 @@
 import type { StorybookConfig } from '@storybook/react-vite';
+import { mergeConfig } from 'vite';
 
 const config: StorybookConfig = {
-  stories: [
-    '../packages/designer/src/**/*.stories.@(ts|tsx)',
-  ],
+  stories: ['../packages/designer/src/**/*.stories.@(ts|tsx)'],
   addons: ['@storybook/addon-essentials'],
   framework: {
     name: '@storybook/react-vite',
     options: {},
+  },
+  async viteFinal(baseConfig) {
+    return mergeConfig(baseConfig, {
+      build: {
+        chunkSizeWarningLimit: 1000,
+      },
+    });
   },
 };
 

--- a/packages/dev-app/vite.config.ts
+++ b/packages/dev-app/vite.config.ts
@@ -1,10 +1,72 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 const devPort = Number(process.env.SUPERSUBSET_DEV_APP_PORT ?? 3000);
 
+function chunkDevAppBuild(id: string) {
+  const normalizedId = id.replace(/\\/g, '/');
+
+  if (
+    normalizedId.includes('/node_modules/react/') ||
+    normalizedId.includes('/node_modules/react-dom/') ||
+    normalizedId.includes('/node_modules/scheduler/')
+  ) {
+    return 'react-vendor';
+  }
+
+  if (normalizedId.includes('/packages/charts-echarts/dist/')) {
+    return 'charts-vendor';
+  }
+
+  if (
+    normalizedId.includes('/node_modules/echarts/') ||
+    normalizedId.includes('/node_modules/zrender/')
+  ) {
+    return 'charts-vendor';
+  }
+
+  if (normalizedId.includes('/packages/designer/dist/')) {
+    return 'supersubset-designer';
+  }
+
+  if (normalizedId.includes('/node_modules/@puckeditor/')) {
+    return 'puck-vendor';
+  }
+
+  if (normalizedId.includes('/node_modules/@dnd-kit/')) {
+    return 'dnd-vendor';
+  }
+
+  if (normalizedId.includes('/node_modules/@emotion/')) {
+    return 'emotion-vendor';
+  }
+
+  if (normalizedId.includes('/packages/runtime/dist/')) {
+    return 'runtime-vendor';
+  }
+
+  if (
+    normalizedId.includes('/packages/schema/dist/') ||
+    normalizedId.includes('/packages/theme/dist/') ||
+    normalizedId.includes('/packages/data-model/dist/') ||
+    normalizedId.includes('/packages/adapter-json/dist/')
+  ) {
+    return 'supersubset-support';
+  }
+
+  return undefined;
+}
+
 export default defineConfig({
   plugins: [react()],
+  build: {
+    chunkSizeWarningLimit: 800,
+    rollupOptions: {
+      output: {
+        manualChunks: chunkDevAppBuild,
+      },
+    },
+  },
   server: {
     port: devPort,
     strictPort: Boolean(process.env.SUPERSUBSET_DEV_APP_PORT),


### PR DESCRIPTION
## Summary
- add stable manual chunking to the dev-app build so the demo shell no longer emits a single oversized bundle warning
- set explicit chunk warning thresholds for the dev-app and Storybook builds based on their non-production bundle baselines
- keep Storybook chunking simple to avoid brittle circular chunk boundaries while still suppressing the repeated docs-renderer warning

## Issues
- closes #73

## Validation
- pnpm --filter @supersubset/schema build
- pnpm --filter @supersubset/data-model build
- pnpm --filter @supersubset/theme build
- pnpm --filter @supersubset/runtime build
- pnpm --filter @supersubset/charts-echarts build
- pnpm --filter @supersubset/adapter-json build
- pnpm --filter @supersubset/designer build
- pnpm --filter @supersubset/dev-app build
- pnpm build-storybook

## Notes
- Storybook still prints the existing upstream `@storybook/core` eval warnings during preview build, but the oversized chunk warning tracked by this issue is gone.