### PR TITLE
test: isolate local playwright host ports

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,113 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
 import { defineConfig, devices } from '@playwright/test';
 
-const devAppPort = process.env.SUPERSUBSET_DEV_APP_PORT ?? '3000';
-const devAppOrigin = `http://localhost:${devAppPort}`;
-const nextjsExamplePort = process.env.SUPERSUBSET_EXAMPLE_NEXTJS_PORT ?? '3001';
-const nextjsExampleOrigin = `http://localhost:${nextjsExamplePort}`;
-const viteSqliteExamplePort = process.env.SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT ?? '3002';
-const viteSqliteExampleOrigin = `http://localhost:${viteSqliteExamplePort}`;
+type LocalPortSelection = {
+  devApp: string;
+  nextjsExample: string;
+  viteSqliteExample: string;
+};
+
+const DEFAULT_PORTS: LocalPortSelection = {
+  devApp: '3000',
+  nextjsExample: '3001',
+  viteSqliteExample: '3002',
+};
+
+const DEVENV_STATE_PATH = path.resolve(process.cwd(), 'tmp/devenv-state.json');
+const FIND_FREE_PORT_SCRIPT = path.resolve(process.cwd(), 'scripts/find-free-port.mjs');
+
+function readPersistedPorts(): LocalPortSelection | null {
+  if (!existsSync(DEVENV_STATE_PATH)) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(DEVENV_STATE_PATH, 'utf8')) as {
+      ports?: { devApp?: number; nextjsExample?: number; viteSqliteExample?: number };
+    };
+
+    if (
+      parsed.ports?.devApp == null ||
+      parsed.ports.nextjsExample == null ||
+      parsed.ports.viteSqliteExample == null
+    ) {
+      return null;
+    }
+
+    return {
+      devApp: String(parsed.ports.devApp),
+      nextjsExample: String(parsed.ports.nextjsExample),
+      viteSqliteExample: String(parsed.ports.viteSqliteExample),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function leaseLocalPorts(): LocalPortSelection {
+  const output = execFileSync(
+    process.execPath,
+    [
+      FIND_FREE_PORT_SCRIPT,
+      '--start',
+      '3110',
+      '--end',
+      '3199',
+      '--count',
+      '3',
+      '--host',
+      '127.0.0.1',
+    ],
+    { encoding: 'utf8' },
+  );
+
+  const [devApp, nextjsExample, viteSqliteExample] = output.trim().split(/\s+/).filter(Boolean);
+
+  if (!devApp || !nextjsExample || !viteSqliteExample) {
+    throw new Error('Could not resolve a full local Playwright port tuple.');
+  }
+
+  return {
+    devApp,
+    nextjsExample,
+    viteSqliteExample,
+  };
+}
+
+function resolvePlaywrightPorts() {
+  const hasExplicitPorts = Boolean(
+    process.env.SUPERSUBSET_DEV_APP_PORT ||
+    process.env.SUPERSUBSET_EXAMPLE_NEXTJS_PORT ||
+    process.env.SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT,
+  );
+  const persistedPorts = readPersistedPorts();
+
+  // Local runs should avoid silently reusing arbitrary processes on the shared defaults.
+  const fallbackPorts = process.env.CI ? DEFAULT_PORTS : (persistedPorts ?? leaseLocalPorts());
+  const ports: LocalPortSelection = {
+    devApp: process.env.SUPERSUBSET_DEV_APP_PORT ?? fallbackPorts.devApp,
+    nextjsExample: process.env.SUPERSUBSET_EXAMPLE_NEXTJS_PORT ?? fallbackPorts.nextjsExample,
+    viteSqliteExample:
+      process.env.SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT ?? fallbackPorts.viteSqliteExample,
+  };
+
+  return {
+    ports,
+    reuseExistingServer: !process.env.CI && (hasExplicitPorts || persistedPorts !== null),
+  };
+}
+
+const { ports, reuseExistingServer } = resolvePlaywrightPorts();
+
+process.env.SUPERSUBSET_DEV_APP_PORT = ports.devApp;
+process.env.SUPERSUBSET_EXAMPLE_NEXTJS_PORT = ports.nextjsExample;
+process.env.SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT = ports.viteSqliteExample;
+
+const devAppOrigin = `http://localhost:${ports.devApp}`;
+const nextjsExampleOrigin = `http://localhost:${ports.nextjsExample}`;
+const viteSqliteExampleOrigin = `http://localhost:${ports.viteSqliteExample}`;
 
 export default defineConfig({
   testDir: './e2e',
@@ -33,8 +135,8 @@ export default defineConfig({
     {
       command: 'pnpm --filter @supersubset/dev-app dev',
       url: devAppOrigin,
-      env: { ...process.env, SUPERSUBSET_DEV_APP_PORT: devAppPort },
-      reuseExistingServer: !process.env.CI,
+      env: { ...process.env, SUPERSUBSET_DEV_APP_PORT: ports.devApp },
+      reuseExistingServer,
       timeout: 120_000,
     },
     {
@@ -42,9 +144,9 @@ export default defineConfig({
       url: nextjsExampleOrigin,
       env: {
         ...process.env,
-        SUPERSUBSET_EXAMPLE_NEXTJS_PORT: nextjsExamplePort,
+        SUPERSUBSET_EXAMPLE_NEXTJS_PORT: ports.nextjsExample,
       },
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer,
       timeout: 120_000,
     },
     {
@@ -52,9 +154,9 @@ export default defineConfig({
       url: viteSqliteExampleOrigin,
       env: {
         ...process.env,
-        SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT: viteSqliteExamplePort,
+        SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT: ports.viteSqliteExample,
       },
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer,
       timeout: 120_000,
     },
   ],


### PR DESCRIPTION
## Summary
- resolve Playwright host app ports from the active DevEnv lease when present and otherwise claim a fresh local tuple for standalone runs
- avoid blindly reusing arbitrary processes on the shared 3000/3001/3002 defaults during local Playwright execution
- keep the config loader-compatible by resolving helper paths from the repo cwd instead of using import.meta in the root Playwright config

## Issues
- closes #72

## Validation
- pnpm install --frozen-lockfile
- pnpm --filter @supersubset/schema build
- pnpm --filter @supersubset/data-model build
- pnpm --filter @supersubset/theme build
- pnpm --filter @supersubset/runtime build
- pnpm --filter @supersubset/charts-echarts build
- pnpm --filter @supersubset/adapter-json build
- pnpm --filter @supersubset/designer build
- pnpm exec playwright test e2e/workflows/host-integration.spec.ts --project=firefox