### PR TITLE
feat: support placeable filter bar widgets

### DIFF
--- a/e2e/interactions/dashboard-filter.spec.ts
+++ b/e2e/interactions/dashboard-filter.spec.ts
@@ -1,58 +1,111 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 /**
  * E2E: Dashboard filter interactions.
  * Test Plan B — Renderer happy path with filter + cross-filter.
  */
 
+const DEV_APP_ORIGIN = `http://localhost:${process.env.SUPERSUBSET_DEV_APP_PORT ?? '3006'}`;
+const FILTER_BAR_REGISTRY_ERROR = 'No widget registered for type: filter-bar';
+
+async function openViewerLiveDashboard(page: Page) {
+  await page.goto(DEV_APP_ORIGIN);
+
+  const viewerBtn = page.getByRole('button', { name: /viewer/i });
+  if (await viewerBtn.isVisible()) {
+    await viewerBtn.click();
+  }
+
+  const liveScenarioBtn = page.getByTestId('viewer-scenario-live');
+  if (await liveScenarioBtn.isVisible()) {
+    await liveScenarioBtn.click();
+  }
+
+  await expect(page.locator('[data-ss-dashboard="demo-sales"]')).toBeVisible();
+}
+
+function trackConsoleErrors(page: Page) {
+  const consoleErrors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      consoleErrors.push(msg.text());
+    }
+  });
+  return consoleErrors;
+}
+
+function filterBarWidget(page: Page, layoutNodeId: 'w-filter-bar-all' | 'w-filter-bar-region') {
+  return page.locator(`[data-ss-dashboard="demo-sales"] [data-ss-node="${layoutNodeId}"]`);
+}
+
 test.describe('Dashboard Filters', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/');
-    // Ensure viewer mode
-    const viewerBtn = page.getByRole('button', { name: /viewer/i });
-    if (await viewerBtn.isVisible()) {
-      await viewerBtn.click();
-    }
+  test('viewer renders placed filter-bar widgets without registry errors', async ({ page }) => {
+    const consoleErrors = trackConsoleErrors(page);
+
+    await openViewerLiveDashboard(page);
+
+    const dashboard = page.locator('[data-ss-dashboard="demo-sales"]');
+    const filterBarRow = dashboard.locator('[data-ss-node="row-filter-bars"]');
+    const allFiltersWidget = filterBarWidget(page, 'w-filter-bar-all');
+    const regionFiltersWidget = filterBarWidget(page, 'w-filter-bar-region');
+    const allFiltersBar = allFiltersWidget.locator('.ss-filter-bar');
+    const regionFiltersBar = regionFiltersWidget.locator('.ss-filter-bar');
+
+    await expect(filterBarRow).toBeVisible();
+    await expect(dashboard.locator('.ss-dashboard-content > .ss-filter-bar')).toHaveCount(0);
+    await expect(filterBarRow.getByText(FILTER_BAR_REGISTRY_ERROR)).toHaveCount(0);
+    await expect(dashboard.locator('.ss-filter-bar')).toHaveCount(2);
+    await expect(allFiltersBar).toBeVisible();
+    await expect(regionFiltersBar).toBeVisible();
+
+    await expect(allFiltersBar.getByLabel('Region')).toBeVisible();
+    await expect(allFiltersBar.getByLabel('Category')).toBeVisible();
+    await expect(allFiltersBar.getByLabel('Order Date')).toBeVisible();
+
+    await expect(regionFiltersBar.getByLabel('Region')).toBeVisible();
+    await expect(regionFiltersBar.getByLabel('Category')).toHaveCount(0);
+    await expect(regionFiltersBar.getByLabel('Order Date')).toHaveCount(0);
+
+    const allFilterControlCount = await allFiltersBar.locator('.ss-filter-control').count();
+    const regionFilterControlCount = await regionFiltersBar.locator('.ss-filter-control').count();
+
+    expect(allFilterControlCount).toBeGreaterThan(regionFilterControlCount);
+    expect(regionFilterControlCount).toBeGreaterThan(0);
+
+    await expect(page.getByText(FILTER_BAR_REGISTRY_ERROR)).toHaveCount(0);
+    expect(
+      consoleErrors.filter((message) => message.includes(FILTER_BAR_REGISTRY_ERROR)),
+    ).toHaveLength(0);
   });
 
-  test('filter bar renders when dashboard has filters', async ({ page }) => {
-    // The demo dashboard now has filters defined
-    const filterBar = page.locator('.ss-filter-bar');
-    // FilterBar should be visible with at least one control
-    if (await filterBar.isVisible()) {
-      const controls = page.locator('.ss-filter-control');
-      expect(await controls.count()).toBeGreaterThan(0);
-    }
-  });
+  test('placed filter-bar widgets share filter state and reset together', async ({ page }) => {
+    await openViewerLiveDashboard(page);
 
-  test('selecting a filter value updates filter state', async ({ page }) => {
-    const filterBar = page.locator('.ss-filter-bar');
-    if (await filterBar.isVisible()) {
-      const firstSelect = filterBar.locator('select').first();
-      if (await firstSelect.isVisible()) {
-        // Select should have options
-        const options = firstSelect.locator('option');
-        expect(await options.count()).toBeGreaterThan(0);
-      }
-    }
-  });
+    const allFiltersBar = filterBarWidget(page, 'w-filter-bar-all').locator('.ss-filter-bar');
+    const regionFiltersBar = filterBarWidget(page, 'w-filter-bar-region').locator('.ss-filter-bar');
+    const regionFilter = regionFiltersBar.getByLabel('Region');
 
-  test('reset all button clears filters', async ({ page }) => {
-    const resetBtn = page.locator('.ss-filter-bar button').filter({ hasText: /reset/i });
-    if (await resetBtn.isVisible()) {
-      await resetBtn.click();
-      // After reset, filter selects should be back to default
-    }
+    await expect(allFiltersBar).toBeVisible();
+    await expect(regionFiltersBar).toBeVisible();
+    await expect(regionFilter).toBeVisible();
+
+    await regionFilter.selectOption({ label: 'East' });
+
+    await expect(regionFilter).toHaveValue('East');
+    await expect(allFiltersBar.getByLabel('Region')).toHaveValue('East');
+    await expect(allFiltersBar.getByRole('button', { name: /clear filters/i })).toBeVisible();
+    await expect(regionFiltersBar.getByRole('button', { name: /clear filters/i })).toBeVisible();
+
+    await allFiltersBar.getByRole('button', { name: /clear filters/i }).click();
+
+    await expect(regionFiltersBar.getByLabel('Region')).toHaveValue('');
+    await expect(allFiltersBar.getByLabel('Region')).toHaveValue('');
   });
 });
 
 test.describe('Cross-Filtering', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/');
-    const viewerBtn = page.getByRole('button', { name: /viewer/i });
-    if (await viewerBtn.isVisible()) {
-      await viewerBtn.click();
-    }
+    await openViewerLiveDashboard(page);
   });
 
   test('clicking a chart data point logs a widget event', async ({ page }) => {

--- a/e2e/workflows/filter-cascade.spec.ts
+++ b/e2e/workflows/filter-cascade.spec.ts
@@ -27,7 +27,9 @@ test.describe('Filter Cascade Workflow', () => {
   test('filter bar is present when filters are defined', async ({ page }) => {
     const filterBar = page.locator('.ss-filter-bar');
     // The demo dashboard has filters, so filter bar should appear
-    if (await filterBar.isVisible()) {
+    await expect(filterBar.first()).toBeVisible();
+
+    if ((await filterBar.count()) > 0) {
       // Region and Category filters should be present
       const controls = page.locator('.ss-filter-control');
       expect(await controls.count()).toBeGreaterThanOrEqual(1);

--- a/examples/nextjs-ecommerce/lib/workbench-dashboard.ts
+++ b/examples/nextjs-ecommerce/lib/workbench-dashboard.ts
@@ -64,7 +64,14 @@ export const workbenchStarterDashboard: DashboardDefinition = {
           id: 'grid-main',
           type: 'grid',
           parentId: 'root',
-          children: ['header-title', 'divider', 'row-kpis', 'row-charts', 'row-table'],
+          children: [
+            'header-title',
+            'divider',
+            'row-filter-bars',
+            'row-kpis',
+            'row-charts',
+            'row-table',
+          ],
           meta: { columns: 12 },
         },
         'header-title': {
@@ -80,6 +87,20 @@ export const workbenchStarterDashboard: DashboardDefinition = {
           parentId: 'grid-main',
           children: [],
           meta: {},
+        },
+        'row-filter-bars': {
+          id: 'row-filter-bars',
+          type: 'row',
+          parentId: 'grid-main',
+          children: ['w-filter-bar-all'],
+          meta: {},
+        },
+        'w-filter-bar-all': {
+          id: 'w-filter-bar-all',
+          type: 'widget',
+          parentId: 'row-filter-bars',
+          children: [],
+          meta: { widgetRef: 'filters-all', width: 12, height: 88 },
         },
         'row-kpis': {
           id: 'row-kpis',
@@ -146,6 +167,12 @@ export const workbenchStarterDashboard: DashboardDefinition = {
         },
       },
       widgets: [
+        {
+          id: 'filters-all',
+          type: 'filter-bar',
+          title: 'All Dashboard Filters',
+          config: {},
+        },
         {
           id: 'kpi-revenue',
           type: 'kpi-card',

--- a/examples/vite-sqlite/src/dashboard.ts
+++ b/examples/vite-sqlite/src/dashboard.ts
@@ -4,7 +4,8 @@ export const defaultDashboard: DashboardDefinition = {
   schemaVersion: '0.2.0',
   id: 'vite-sqlite-dashboard',
   title: 'SQLite Analytics Workbench',
-  description: 'A Vite host app that re-queries an in-browser SQLite database based on Supersubset filter state.',
+  description:
+    'A Vite host app that re-queries an in-browser SQLite database based on Supersubset filter state.',
   filters: [
     {
       id: 'filter-region',
@@ -45,7 +46,14 @@ export const defaultDashboard: DashboardDefinition = {
           id: 'grid-main',
           type: 'grid',
           parentId: 'root',
-          children: ['header-title', 'divider', 'row-kpis', 'row-charts', 'row-table'],
+          children: [
+            'header-title',
+            'divider',
+            'row-filter-bars',
+            'row-kpis',
+            'row-charts',
+            'row-table',
+          ],
           meta: { columns: 12 },
         },
         'header-title': {
@@ -61,6 +69,20 @@ export const defaultDashboard: DashboardDefinition = {
           parentId: 'grid-main',
           children: [],
           meta: {},
+        },
+        'row-filter-bars': {
+          id: 'row-filter-bars',
+          type: 'row',
+          parentId: 'grid-main',
+          children: ['w-filter-bar-all'],
+          meta: {},
+        },
+        'w-filter-bar-all': {
+          id: 'w-filter-bar-all',
+          type: 'widget',
+          parentId: 'row-filter-bars',
+          children: [],
+          meta: { widgetRef: 'filters-all', width: 12, height: 88 },
         },
         'row-kpis': {
           id: 'row-kpis',
@@ -128,6 +150,12 @@ export const defaultDashboard: DashboardDefinition = {
       },
       widgets: [
         {
+          id: 'filters-all',
+          type: 'filter-bar',
+          title: 'All Dashboard Filters',
+          config: {},
+        },
+        {
           id: 'kpi-revenue',
           type: 'kpi-card',
           title: 'Revenue',
@@ -138,7 +166,12 @@ export const defaultDashboard: DashboardDefinition = {
               { role: 'comparison', fieldRef: 'previousRevenue' },
             ],
           },
-          config: { valueField: 'revenue', comparisonField: 'previousRevenue', format: 'currency', prefix: '$' },
+          config: {
+            valueField: 'revenue',
+            comparisonField: 'previousRevenue',
+            format: 'currency',
+            prefix: '$',
+          },
         },
         {
           id: 'kpi-orders',
@@ -164,7 +197,12 @@ export const defaultDashboard: DashboardDefinition = {
               { role: 'comparison', fieldRef: 'previousAov' },
             ],
           },
-          config: { valueField: 'aov', comparisonField: 'previousAov', format: 'currency', prefix: '$' },
+          config: {
+            valueField: 'aov',
+            comparisonField: 'previousAov',
+            format: 'currency',
+            prefix: '$',
+          },
         },
         {
           id: 'chart-monthly-sales',

--- a/packages/designer/src/adapters/puck-canonical.ts
+++ b/packages/designer/src/adapters/puck-canonical.ts
@@ -162,6 +162,14 @@ function generateId(): string {
   return `ss-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+}
+
 const layoutTypeToPuckName: Record<string, string> = {
   row: 'RowBlock',
   column: 'ColumnBlock',
@@ -423,6 +431,16 @@ function buildWidgetDefinition(
     'yAxisField',
   ]);
   for (const [key, value] of Object.entries(props)) {
+    if (widgetType === 'filter-bar' && key === 'filterIds') {
+      const filterIds = normalizeStringArray(value);
+
+      if (filterIds.length > 0) {
+        widget.config[key] = filterIds;
+      }
+
+      continue;
+    }
+
     if (!NON_CONFIG_KEYS.has(key) && value !== undefined && value !== '') {
       widget.config[key] = value;
     }
@@ -538,6 +556,16 @@ function widgetConfigToPuckProps(widget: WidgetDefinition): Record<string, unkno
 
   // Spread config props
   for (const [key, value] of Object.entries(widget.config)) {
+    if (key === 'filterIds') {
+      const filterIds = normalizeStringArray(value);
+
+      if (filterIds.length > 0) {
+        props[key] = filterIds;
+      }
+
+      continue;
+    }
+
     props[key] = value;
   }
 

--- a/packages/designer/src/blocks/controls/index.ts
+++ b/packages/designer/src/blocks/controls/index.ts
@@ -3,65 +3,133 @@
  * FilterBar and other interactive controls.
  */
 import type { ComponentConfig } from '@puckeditor/core';
+import type { FilterDefinition } from '@supersubset/schema';
 import React from 'react';
+import {
+  createFilterSelectionField,
+  type FilterSelectionOption,
+} from '../../fields/filter-selection-field';
 
-export const FilterBarBlock: ComponentConfig = {
-  label: 'Filter Bar',
-  fields: {
-    title: { type: 'text' as const, label: 'Title' },
-    scope: {
-      type: 'select' as const,
-      label: 'Scope',
-      options: [
-        { label: 'Global', value: 'global' },
-        { label: 'Page', value: 'page' },
-      ],
-    },
-    layout: {
-      type: 'radio' as const,
-      label: 'Layout',
-      options: [
-        { label: 'Horizontal', value: 'horizontal' },
-        { label: 'Vertical', value: 'vertical' },
-      ],
-    },
-  },
-  defaultProps: {
-    title: 'Filters',
-    scope: 'global',
-    layout: 'horizontal',
-  },
-  render: ({ title, layout }: Record<string, unknown>) => {
-    return React.createElement(
-      'div',
-      {
-        style: {
-          border: '1px dashed #b0c4de',
-          borderRadius: 8,
-          padding: 12,
-          minHeight: 48,
-          display: 'flex',
-          flexDirection: layout === 'vertical' ? 'column' as const : 'row' as const,
-          alignItems: 'center',
-          gap: 8,
-          background: '#f0f5ff',
-          fontFamily: 'sans-serif',
-        },
+export interface ControlBlockFactoryOptions {
+  filterDefinitions?: readonly FilterDefinition[];
+}
+
+function createFilterSelectionOptions(
+  filterDefinitions: readonly FilterDefinition[],
+): FilterSelectionOption[] {
+  return filterDefinitions.map((filter) => {
+    const label = filter.title?.trim() || filter.id;
+    const helperParts = [filter.id];
+
+    if (filter.fieldRef && filter.fieldRef !== label) {
+      helperParts.push(filter.fieldRef);
+    }
+
+    return {
+      id: filter.id,
+      label,
+      helperText: helperParts.join(' • '),
+    };
+  });
+}
+
+function normalizeFilterIds(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+}
+
+function describeSelectedFilters(
+  filterOptions: FilterSelectionOption[],
+  filterIds: unknown,
+): string {
+  const selectedIds = normalizeFilterIds(filterIds);
+
+  if (selectedIds.length === 0) {
+    return 'Showing all authored filters';
+  }
+
+  const selectedLabels = filterOptions
+    .filter((option) => selectedIds.includes(option.id))
+    .map((option) => option.label);
+
+  if (selectedLabels.length === 0) {
+    return `Showing ${selectedIds.length} selected filter${selectedIds.length === 1 ? '' : 's'}`;
+  }
+
+  if (selectedLabels.length <= 2) {
+    return `Showing ${selectedLabels.join(', ')}`;
+  }
+
+  return `Showing ${selectedLabels.slice(0, 2).join(', ')} +${selectedLabels.length - 2} more`;
+}
+
+export function createFilterBarBlock(options: ControlBlockFactoryOptions = {}): ComponentConfig {
+  const filterOptions = createFilterSelectionOptions(options.filterDefinitions ?? []);
+
+  return {
+    label: 'Filter Bar',
+    fields: {
+      title: { type: 'text' as const, label: 'Title' },
+      scope: {
+        type: 'select' as const,
+        label: 'Scope',
+        options: [
+          { label: 'Global', value: 'global' },
+          { label: 'Page', value: 'page' },
+        ],
       },
-      React.createElement('span', { style: { fontSize: 18 } }, '🔍'),
-      React.createElement(
-        'span',
-        { style: { fontWeight: 600, fontSize: 13 } },
-        (title as string) || 'Filter Bar'
-      ),
-      React.createElement(
-        'span',
-        { style: { fontSize: 11, color: '#666' } },
-        'Filters will appear at runtime'
-      )
-    );
-  },
-};
+      layout: {
+        type: 'radio' as const,
+        label: 'Layout',
+        options: [
+          { label: 'Horizontal', value: 'horizontal' },
+          { label: 'Vertical', value: 'vertical' },
+        ],
+      },
+      filterIds: createFilterSelectionField(filterOptions),
+    },
+    defaultProps: {
+      title: 'Filters',
+      scope: 'global',
+      layout: 'horizontal',
+    },
+    render: ({ title, layout, filterIds }: Record<string, unknown>) => {
+      return React.createElement(
+        'div',
+        {
+          style: {
+            border: '1px dashed #b0c4de',
+            borderRadius: 8,
+            padding: 12,
+            minHeight: 48,
+            display: 'flex',
+            flexDirection: layout === 'vertical' ? ('column' as const) : ('row' as const),
+            alignItems: 'center',
+            gap: 8,
+            background: '#f0f5ff',
+            fontFamily: 'sans-serif',
+          },
+        },
+        React.createElement('span', { style: { fontSize: 18 } }, '🔍'),
+        React.createElement(
+          'span',
+          { style: { fontWeight: 600, fontSize: 13 } },
+          (title as string) || 'Filter Bar',
+        ),
+        React.createElement(
+          'span',
+          { style: { fontSize: 11, color: '#666' } },
+          describeSelectedFilters(filterOptions, filterIds),
+        ),
+      );
+    },
+  };
+}
+
+export const FilterBarBlock: ComponentConfig = createFilterBarBlock();
 
 export const CONTROL_BLOCK_NAMES = ['FilterBarBlock'] as const;
 

--- a/packages/designer/src/components/FilterBuilderPanel.stories.tsx
+++ b/packages/designer/src/components/FilterBuilderPanel.stories.tsx
@@ -12,7 +12,13 @@ const ordersDataset: NormalizedDataset = {
     { id: 'order_date', label: 'Order Date', dataType: 'date', role: 'time' },
     { id: 'category', label: 'Category', dataType: 'string', role: 'dimension' },
     { id: 'region', label: 'Region', dataType: 'string', role: 'dimension' },
-    { id: 'revenue', label: 'Revenue', dataType: 'number', role: 'measure', defaultAggregation: 'sum' },
+    {
+      id: 'revenue',
+      label: 'Revenue',
+      dataType: 'number',
+      role: 'measure',
+      defaultAggregation: 'sum',
+    },
   ],
   source: { type: 'table', ref: 'orders' },
 };
@@ -30,7 +36,7 @@ const sampleFilters: FilterDefinition[] = [
   {
     id: 'f-date',
     title: 'Date Range',
-    type: 'date-range',
+    type: 'date',
     fieldRef: 'order_date',
     datasetRef: 'ds-orders',
     operator: 'between',

--- a/packages/designer/src/components/FilterBuilderPanel.tsx
+++ b/packages/designer/src/components/FilterBuilderPanel.tsx
@@ -9,7 +9,7 @@
  *
  * Emits FilterDefinition[] changes to the host.
  */
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import type { NormalizedDataset } from '@supersubset/data-model';
 
 // Re-declare filter types inline to avoid hard dep on schema at runtime.
@@ -69,6 +69,42 @@ export const FILTER_OPERATORS: { value: string; label: string; types: string[] }
   },
 ];
 
+const FILTER_CONTROL_OPTIONS = [
+  { value: 'select', label: 'Dropdown' },
+  { value: 'range', label: 'Range slider' },
+  { value: 'date', label: 'Date picker' },
+  { value: 'text', label: 'Text search' },
+] as const;
+
+type SupportedFilterControlType = (typeof FILTER_CONTROL_OPTIONS)[number]['value'];
+
+const LEGACY_FILTER_CONTROL_TYPE_MAP: Record<string, SupportedFilterControlType> = {
+  'multi-select': 'select',
+  'date-range': 'date',
+};
+
+function normalizeFilterControlType(type: string): SupportedFilterControlType {
+  if (type in LEGACY_FILTER_CONTROL_TYPE_MAP) {
+    return LEGACY_FILTER_CONTROL_TYPE_MAP[type];
+  }
+
+  const supportedOption = FILTER_CONTROL_OPTIONS.find((option) => option.value === type);
+  return supportedOption?.value ?? 'select';
+}
+
+function normalizeFilterDefinition(filter: FilterDefinition): FilterDefinition {
+  const normalizedType = normalizeFilterControlType(filter.type);
+
+  if (normalizedType === filter.type) {
+    return filter;
+  }
+
+  return {
+    ...filter,
+    type: normalizedType,
+  };
+}
+
 // ─── Props ────────────────────────────────────────────────────
 
 export interface FilterBuilderPanelProps {
@@ -119,10 +155,14 @@ function FilterEditor({
     const dt = field?.dataType ?? 'string';
     return FILTER_OPERATORS.filter((op) => op.types.includes(dt));
   }, [field]);
+  const normalizedFilterType = useMemo(
+    () => normalizeFilterControlType(filter.type),
+    [filter.type],
+  );
 
   const handleChange = useCallback(
     (patch: Partial<FilterDefinition>) => {
-      onUpdate({ ...filter, ...patch });
+      onUpdate(normalizeFilterDefinition({ ...filter, ...patch }));
     },
     [filter, onUpdate],
   );
@@ -312,16 +352,16 @@ function FilterEditor({
         <select
           id={typeSelectId}
           name={`filter-type-${filter.id}`}
-          value={filter.type}
+          value={normalizedFilterType}
           onChange={(e) => handleChange({ type: e.target.value })}
           data-testid={`filter-type-${filter.id}`}
           style={selectStyle}
         >
-          <option value="select">Dropdown</option>
-          <option value="multi-select">Multi-select</option>
-          <option value="range">Range slider</option>
-          <option value="date-range">Date range</option>
-          <option value="text">Text search</option>
+          {FILTER_CONTROL_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
         </select>
       </div>
 
@@ -449,6 +489,17 @@ export function FilterBuilderPanel({
     },
     [filters, onChange],
   );
+
+  useEffect(() => {
+    const normalizedFilters = filters.map((filter) => normalizeFilterDefinition(filter));
+    const hasUnsupportedFilterTypes = normalizedFilters.some(
+      (filter, index) => filter.type !== filters[index]?.type,
+    );
+
+    if (hasUnsupportedFilterTypes) {
+      onChange(normalizedFilters);
+    }
+  }, [filters, onChange]);
 
   return (
     <div

--- a/packages/designer/src/components/FilterBuilderPanel.tsx
+++ b/packages/designer/src/components/FilterBuilderPanel.tsx
@@ -9,7 +9,7 @@
  *
  * Emits FilterDefinition[] changes to the host.
  */
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { NormalizedDataset } from '@supersubset/data-model';
 
 // Re-declare filter types inline to avoid hard dep on schema at runtime.
@@ -103,6 +103,26 @@ function normalizeFilterDefinition(filter: FilterDefinition): FilterDefinition {
     ...filter,
     type: normalizedType,
   };
+}
+
+function getNormalizedFiltersNeedingMigration(
+  filters: FilterDefinition[],
+): FilterDefinition[] | null {
+  let normalizedFilters: FilterDefinition[] | undefined;
+
+  filters.forEach((filter, index) => {
+    const normalizedFilter = normalizeFilterDefinition(filter);
+
+    if (normalizedFilter === filter) {
+      normalizedFilters?.push(filter);
+      return;
+    }
+
+    normalizedFilters ??= filters.slice(0, index);
+    normalizedFilters.push(normalizedFilter);
+  });
+
+  return normalizedFilters ?? null;
 }
 
 // ─── Props ────────────────────────────────────────────────────
@@ -461,6 +481,32 @@ export function FilterBuilderPanel({
   widgetIds = [],
   className,
 }: FilterBuilderPanelProps) {
+  const normalizedFilters = useMemo(() => getNormalizedFiltersNeedingMigration(filters), [filters]);
+  const normalizedFiltersKey = useMemo(
+    () => (normalizedFilters ? JSON.stringify(normalizedFilters) : null),
+    [normalizedFilters],
+  );
+  const latestOnChangeRef = useRef(onChange);
+  const lastNormalizedFiltersKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    latestOnChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    if (!normalizedFilters || !normalizedFiltersKey) {
+      lastNormalizedFiltersKeyRef.current = null;
+      return;
+    }
+
+    if (lastNormalizedFiltersKeyRef.current === normalizedFiltersKey) {
+      return;
+    }
+
+    lastNormalizedFiltersKeyRef.current = normalizedFiltersKey;
+    latestOnChangeRef.current(normalizedFilters);
+  }, [normalizedFilters, normalizedFiltersKey]);
+
   const handleAdd = useCallback(() => {
     const defaultDataset = datasets[0]?.id ?? '';
     const newFilter: FilterDefinition = {
@@ -489,17 +535,6 @@ export function FilterBuilderPanel({
     },
     [filters, onChange],
   );
-
-  useEffect(() => {
-    const normalizedFilters = filters.map((filter) => normalizeFilterDefinition(filter));
-    const hasUnsupportedFilterTypes = normalizedFilters.some(
-      (filter, index) => filter.type !== filters[index]?.type,
-    );
-
-    if (hasUnsupportedFilterTypes) {
-      onChange(normalizedFilters);
-    }
-  }, [filters, onChange]);
 
   return (
     <div

--- a/packages/designer/src/components/SupersubsetDesigner.tsx
+++ b/packages/designer/src/components/SupersubsetDesigner.tsx
@@ -149,7 +149,10 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
   const canMutateDashboard = !isControlled || !!onChange;
   const pendingDeletePage = pages.find((page) => page.id === pendingDeletePageId);
 
-  const config = useMemo(() => createPuckConfig(), []);
+  const config = useMemo(
+    () => createPuckConfig({ filterDefinitions: sourceDashboard?.filters ?? [] }),
+    [sourceDashboard?.filters],
+  );
 
   // Inject sidebar CSS overrides once
   useMemo(() => injectSidebarStyles(), []);

--- a/packages/designer/src/config/puck-config.ts
+++ b/packages/designer/src/config/puck-config.ts
@@ -3,6 +3,7 @@
  * Defines all components and categories for the editor sidebar.
  */
 import type { Config } from '@puckeditor/core';
+import type { FilterDefinition } from '@supersubset/schema';
 import React from 'react';
 
 import * as chartBlocks from '../blocks/charts';
@@ -13,7 +14,11 @@ import * as layoutBlocks from '../blocks/layout';
 /**
  * Build the complete Puck Config with all Supersubset blocks.
  */
-export function createPuckConfig(): Config {
+export interface CreatePuckConfigOptions {
+  filterDefinitions?: readonly FilterDefinition[];
+}
+
+export function createPuckConfig(options: CreatePuckConfigOptions = {}): Config {
   return {
     root: {
       defaultProps: {},
@@ -27,7 +32,7 @@ export function createPuckConfig(): Config {
               minHeight: '100%',
             },
           },
-          children as React.ReactNode
+          children as React.ReactNode,
         );
       },
     },
@@ -56,7 +61,9 @@ export function createPuckConfig(): Config {
       DividerBlock: contentBlocks.DividerBlock,
       SpacerBlock: contentBlocks.SpacerBlock,
       // Controls
-      FilterBarBlock: controlBlocks.FilterBarBlock,
+      FilterBarBlock: controlBlocks.createFilterBarBlock({
+        filterDefinitions: options.filterDefinitions,
+      }),
       // Layout
       RowBlock: layoutBlocks.RowBlock,
       ColumnBlock: layoutBlocks.ColumnBlock,

--- a/packages/designer/src/fields/filter-selection-field.tsx
+++ b/packages/designer/src/fields/filter-selection-field.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+
+export interface FilterSelectionOption {
+  id: string;
+  label: string;
+  helperText?: string;
+}
+
+const LABEL_STYLE: React.CSSProperties = {
+  display: 'block',
+  fontSize: 12,
+  fontWeight: 600,
+  color: '#64748b',
+  marginBottom: 6,
+};
+
+const PANEL_STYLE: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  padding: 10,
+  borderRadius: 8,
+  border: '1px solid #d9d9d9',
+  background: '#fff',
+};
+
+const DESCRIPTION_STYLE: React.CSSProperties = {
+  fontSize: 11,
+  lineHeight: 1.45,
+  color: '#64748b',
+  margin: 0,
+};
+
+const OPTION_ROW_STYLE: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: 8,
+  fontSize: 12,
+  color: '#0f172a',
+};
+
+function normalizeSelectedFilterIds(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+}
+
+function FilterSelectionFieldControl({
+  value,
+  onChange,
+  id,
+  name,
+  options,
+  readOnly,
+}: {
+  value: string[] | undefined;
+  onChange: (value: string[] | undefined) => void;
+  id: string;
+  name: string;
+  options: FilterSelectionOption[];
+  readOnly?: boolean;
+}) {
+  const selectedIds = normalizeSelectedFilterIds(value);
+  const isShowingAllFilters = selectedIds.length === 0;
+
+  const handleToggleFilter = (filterId: string) => {
+    if (readOnly) {
+      return;
+    }
+
+    if (selectedIds.includes(filterId)) {
+      const nextSelection = selectedIds.filter((currentId) => currentId !== filterId);
+      onChange(nextSelection.length > 0 ? nextSelection : undefined);
+      return;
+    }
+
+    onChange([...selectedIds, filterId]);
+  };
+
+  return React.createElement(
+    'div',
+    null,
+    React.createElement('span', { style: LABEL_STYLE }, 'Shown Filters'),
+    React.createElement(
+      'div',
+      {
+        id,
+        style: PANEL_STYLE,
+        'data-testid': `filter-selection-${name}`,
+      },
+      React.createElement(
+        'label',
+        { style: OPTION_ROW_STYLE },
+        React.createElement('input', {
+          type: 'radio',
+          name,
+          checked: isShowingAllFilters,
+          onChange: () => onChange(undefined),
+          disabled: readOnly,
+          'aria-label': 'Show all authored filters',
+        }),
+        React.createElement(
+          'span',
+          null,
+          React.createElement('strong', null, 'Show all authored filters'),
+          React.createElement(
+            'p',
+            { style: DESCRIPTION_STYLE },
+            'Leave the subset empty to render every authored dashboard filter in this bar.',
+          ),
+        ),
+      ),
+      options.length === 0
+        ? React.createElement(
+            'p',
+            { style: DESCRIPTION_STYLE },
+            'No authored filters are available yet. Once the dashboard defines filters, you can limit this bar to a subset here.',
+          )
+        : React.createElement(
+            'div',
+            {
+              style: {
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 6,
+                paddingTop: 2,
+              },
+            },
+            ...options.map((option) =>
+              React.createElement(
+                'label',
+                { key: option.id, style: OPTION_ROW_STYLE },
+                React.createElement('input', {
+                  type: 'checkbox',
+                  name: `${name}-${option.id}`,
+                  checked: selectedIds.includes(option.id),
+                  onChange: () => handleToggleFilter(option.id),
+                  disabled: readOnly,
+                  'aria-label': `Show filter ${option.label}`,
+                }),
+                React.createElement(
+                  'span',
+                  null,
+                  React.createElement('strong', null, option.label),
+                  option.helperText
+                    ? React.createElement('p', { style: DESCRIPTION_STYLE }, option.helperText)
+                    : null,
+                ),
+              ),
+            ),
+          ),
+    ),
+  );
+}
+
+export function createFilterSelectionField(options: FilterSelectionOption[]) {
+  return {
+    type: 'custom' as const,
+    label: 'Shown Filters',
+    render: ({
+      value,
+      onChange,
+      id,
+      name,
+      readOnly,
+    }: {
+      value: string[] | undefined;
+      onChange: (value: string[] | undefined) => void;
+      id: string;
+      name: string;
+      readOnly?: boolean;
+    }) =>
+      React.createElement(FilterSelectionFieldControl, {
+        value,
+        onChange,
+        id,
+        name,
+        options,
+        readOnly,
+      }),
+  };
+}

--- a/packages/designer/test/adapter-comprehensive.test.ts
+++ b/packages/designer/test/adapter-comprehensive.test.ts
@@ -27,44 +27,77 @@ const CHART_TEST_CASES: ChartTestCase[] = [
     puckName: 'LineChart',
     widgetType: 'line-chart',
     props: {
-      id: 'line-1', title: 'Revenue Trend', datasetRef: 'sales',
-      xAxisField: 'month', yAxisField: 'revenue', seriesField: 'region',
-      aggregation: 'sum', smooth: 'true',
+      id: 'line-1',
+      title: 'Revenue Trend',
+      datasetRef: 'sales',
+      xAxisField: 'month',
+      yAxisField: 'revenue',
+      seriesField: 'region',
+      aggregation: 'sum',
+      smooth: 'true',
     },
-    expectedFields: [{ role: 'x-axis', fieldRef: 'month' }, { role: 'y-axis', fieldRef: 'revenue' }, { role: 'series', fieldRef: 'region' }],
+    expectedFields: [
+      { role: 'x-axis', fieldRef: 'month' },
+      { role: 'y-axis', fieldRef: 'revenue' },
+      { role: 'series', fieldRef: 'region' },
+    ],
     configKeys: ['smooth'],
   },
   {
     puckName: 'BarChart',
     widgetType: 'bar-chart',
     props: {
-      id: 'bar-1', title: 'Sales', datasetRef: 'sales',
-      xAxisField: 'category', yAxisField: 'amount', seriesField: '',
-      aggregation: 'avg', orientation: 'horizontal', stacked: 'true',
+      id: 'bar-1',
+      title: 'Sales',
+      datasetRef: 'sales',
+      xAxisField: 'category',
+      yAxisField: 'amount',
+      seriesField: '',
+      aggregation: 'avg',
+      orientation: 'horizontal',
+      stacked: 'true',
     },
-    expectedFields: [{ role: 'x-axis', fieldRef: 'category' }, { role: 'y-axis', fieldRef: 'amount' }],
+    expectedFields: [
+      { role: 'x-axis', fieldRef: 'category' },
+      { role: 'y-axis', fieldRef: 'amount' },
+    ],
     configKeys: ['orientation', 'stacked'],
   },
   {
     puckName: 'PieChart',
     widgetType: 'pie-chart',
     props: {
-      id: 'pie-1', title: 'Share', datasetRef: 'ds',
-      categoryField: 'category', valueField: 'value', aggregation: 'none', variant: 'donut',
+      id: 'pie-1',
+      title: 'Share',
+      datasetRef: 'ds',
+      categoryField: 'category',
+      valueField: 'value',
+      aggregation: 'none',
+      variant: 'donut',
     },
-    expectedFields: [{ role: 'category', fieldRef: 'category' }, { role: 'value', fieldRef: 'value' }],
+    expectedFields: [
+      { role: 'category', fieldRef: 'category' },
+      { role: 'value', fieldRef: 'value' },
+    ],
     configKeys: ['variant'],
   },
   {
     puckName: 'ScatterChart',
     widgetType: 'scatter-chart',
     props: {
-      id: 'scatter-1', title: 'Scatter', datasetRef: 'ds',
-      xAxisField: 'x', yAxisField: 'y', sizeField: 'size', colorGroupField: 'group',
+      id: 'scatter-1',
+      title: 'Scatter',
+      datasetRef: 'ds',
+      xAxisField: 'x',
+      yAxisField: 'y',
+      sizeField: 'size',
+      colorGroupField: 'group',
     },
     expectedFields: [
-      { role: 'x-axis', fieldRef: 'x' }, { role: 'y-axis', fieldRef: 'y' },
-      { role: 'size', fieldRef: 'size' }, { role: 'color-group', fieldRef: 'group' },
+      { role: 'x-axis', fieldRef: 'x' },
+      { role: 'y-axis', fieldRef: 'y' },
+      { role: 'size', fieldRef: 'size' },
+      { role: 'color-group', fieldRef: 'group' },
     ],
     configKeys: [],
   },
@@ -72,98 +105,170 @@ const CHART_TEST_CASES: ChartTestCase[] = [
     puckName: 'AreaChart',
     widgetType: 'area-chart',
     props: {
-      id: 'area-1', title: 'Area', datasetRef: 'ds',
-      xAxisField: 'month', yAxisField: 'val', seriesField: '', aggregation: 'sum', stacked: 'true',
+      id: 'area-1',
+      title: 'Area',
+      datasetRef: 'ds',
+      xAxisField: 'month',
+      yAxisField: 'val',
+      seriesField: '',
+      aggregation: 'sum',
+      stacked: 'true',
     },
-    expectedFields: [{ role: 'x-axis', fieldRef: 'month' }, { role: 'y-axis', fieldRef: 'val' }],
+    expectedFields: [
+      { role: 'x-axis', fieldRef: 'month' },
+      { role: 'y-axis', fieldRef: 'val' },
+    ],
     configKeys: ['stacked'],
   },
   {
     puckName: 'ComboChart',
     widgetType: 'combo-chart',
     props: {
-      id: 'combo-1', title: 'Combo', datasetRef: 'ds',
-      xAxisField: 'month', barField: 'revenue', lineField: 'orders', aggregation: 'none',
+      id: 'combo-1',
+      title: 'Combo',
+      datasetRef: 'ds',
+      xAxisField: 'month',
+      barField: 'revenue',
+      lineField: 'orders',
+      aggregation: 'none',
     },
-    expectedFields: [{ role: 'x-axis', fieldRef: 'month' }, { role: 'bar-y', fieldRef: 'revenue' }, { role: 'line-y', fieldRef: 'orders' }],
+    expectedFields: [
+      { role: 'x-axis', fieldRef: 'month' },
+      { role: 'bar-y', fieldRef: 'revenue' },
+      { role: 'line-y', fieldRef: 'orders' },
+    ],
     configKeys: [],
   },
   {
     puckName: 'HeatmapChart',
     widgetType: 'heatmap',
     props: {
-      id: 'heat-1', title: 'Heatmap', datasetRef: 'ds',
-      xAxisField: 'x', yAxisField: 'y', valueField: 'temp',
+      id: 'heat-1',
+      title: 'Heatmap',
+      datasetRef: 'ds',
+      xAxisField: 'x',
+      yAxisField: 'y',
+      valueField: 'temp',
     },
-    expectedFields: [{ role: 'x-axis', fieldRef: 'x' }, { role: 'y-axis', fieldRef: 'y' }, { role: 'value', fieldRef: 'temp' }],
+    expectedFields: [
+      { role: 'x-axis', fieldRef: 'x' },
+      { role: 'y-axis', fieldRef: 'y' },
+      { role: 'value', fieldRef: 'temp' },
+    ],
     configKeys: [],
   },
   {
     puckName: 'RadarChart',
     widgetType: 'radar-chart',
     props: {
-      id: 'radar-1', title: 'Radar', datasetRef: 'ds',
-      categoryField: 'metric', valueField: 'score', seriesField: 'team',
+      id: 'radar-1',
+      title: 'Radar',
+      datasetRef: 'ds',
+      categoryField: 'metric',
+      valueField: 'score',
+      seriesField: 'team',
     },
-    expectedFields: [{ role: 'category', fieldRef: 'metric' }, { role: 'value', fieldRef: 'score' }, { role: 'series', fieldRef: 'team' }],
+    expectedFields: [
+      { role: 'category', fieldRef: 'metric' },
+      { role: 'value', fieldRef: 'score' },
+      { role: 'series', fieldRef: 'team' },
+    ],
     configKeys: [],
   },
   {
     puckName: 'FunnelChart',
     widgetType: 'funnel-chart',
     props: {
-      id: 'funnel-1', title: 'Funnel', datasetRef: 'ds',
-      categoryField: 'stage', valueField: 'count',
+      id: 'funnel-1',
+      title: 'Funnel',
+      datasetRef: 'ds',
+      categoryField: 'stage',
+      valueField: 'count',
     },
-    expectedFields: [{ role: 'category', fieldRef: 'stage' }, { role: 'value', fieldRef: 'count' }],
+    expectedFields: [
+      { role: 'category', fieldRef: 'stage' },
+      { role: 'value', fieldRef: 'count' },
+    ],
     configKeys: [],
   },
   {
     puckName: 'TreemapChart',
     widgetType: 'treemap',
     props: {
-      id: 'tree-1', title: 'Treemap', datasetRef: 'ds',
-      nameField: 'name', valueField: 'size', parentField: 'parent',
+      id: 'tree-1',
+      title: 'Treemap',
+      datasetRef: 'ds',
+      nameField: 'name',
+      valueField: 'size',
+      parentField: 'parent',
     },
-    expectedFields: [{ role: 'value', fieldRef: 'size' }, { role: 'name', fieldRef: 'name' }, { role: 'parent', fieldRef: 'parent' }],
+    expectedFields: [
+      { role: 'value', fieldRef: 'size' },
+      { role: 'name', fieldRef: 'name' },
+      { role: 'parent', fieldRef: 'parent' },
+    ],
     configKeys: [],
   },
   {
     puckName: 'SankeyChart',
     widgetType: 'sankey',
     props: {
-      id: 'sankey-1', title: 'Sankey', datasetRef: 'ds',
-      sourceField: 'from', targetField: 'to', valueField: 'flow',
+      id: 'sankey-1',
+      title: 'Sankey',
+      datasetRef: 'ds',
+      sourceField: 'from',
+      targetField: 'to',
+      valueField: 'flow',
     },
-    expectedFields: [{ role: 'value', fieldRef: 'flow' }, { role: 'source', fieldRef: 'from' }, { role: 'target', fieldRef: 'to' }],
+    expectedFields: [
+      { role: 'value', fieldRef: 'flow' },
+      { role: 'source', fieldRef: 'from' },
+      { role: 'target', fieldRef: 'to' },
+    ],
     configKeys: [],
   },
   {
     puckName: 'WaterfallChart',
     widgetType: 'waterfall',
     props: {
-      id: 'waterfall-1', title: 'Waterfall', datasetRef: 'ds',
-      categoryField: 'item', valueField: 'amount',
+      id: 'waterfall-1',
+      title: 'Waterfall',
+      datasetRef: 'ds',
+      categoryField: 'item',
+      valueField: 'amount',
     },
-    expectedFields: [{ role: 'category', fieldRef: 'item' }, { role: 'value', fieldRef: 'amount' }],
+    expectedFields: [
+      { role: 'category', fieldRef: 'item' },
+      { role: 'value', fieldRef: 'amount' },
+    ],
     configKeys: [],
   },
   {
     puckName: 'BoxPlotChart',
     widgetType: 'box-plot',
     props: {
-      id: 'box-1', title: 'Box Plot', datasetRef: 'ds',
-      categoryField: 'department', valueField: 'salary',
+      id: 'box-1',
+      title: 'Box Plot',
+      datasetRef: 'ds',
+      categoryField: 'department',
+      valueField: 'salary',
     },
-    expectedFields: [{ role: 'category', fieldRef: 'department' }, { role: 'value', fieldRef: 'salary' }],
+    expectedFields: [
+      { role: 'category', fieldRef: 'department' },
+      { role: 'value', fieldRef: 'salary' },
+    ],
     configKeys: [],
   },
   {
     puckName: 'GaugeChart',
     widgetType: 'gauge',
     props: {
-      id: 'gauge-1', title: 'Score', datasetRef: 'ds',
-      valueField: 'metric', minValue: 0, maxValue: 100,
+      id: 'gauge-1',
+      title: 'Score',
+      datasetRef: 'ds',
+      valueField: 'metric',
+      minValue: 0,
+      maxValue: 100,
     },
     expectedFields: [{ role: 'value', fieldRef: 'metric' }],
     configKeys: ['minValue', 'maxValue'],
@@ -172,8 +277,11 @@ const CHART_TEST_CASES: ChartTestCase[] = [
     puckName: 'Table',
     widgetType: 'table',
     props: {
-      id: 'table-1', title: 'Data Table', datasetRef: 'ds',
-      pageSize: 50, striped: 'true',
+      id: 'table-1',
+      title: 'Data Table',
+      datasetRef: 'ds',
+      pageSize: 50,
+      striped: 'true',
     },
     expectedFields: [],
     configKeys: ['pageSize', 'striped'],
@@ -182,11 +290,19 @@ const CHART_TEST_CASES: ChartTestCase[] = [
     puckName: 'KPICard',
     widgetType: 'kpi-card',
     props: {
-      id: 'kpi-1', title: 'Revenue', datasetRef: 'ds',
-      valueField: 'revenue', aggregation: 'sum',
-      prefix: '$', suffix: 'M', comparisonField: 'prev_revenue',
+      id: 'kpi-1',
+      title: 'Revenue',
+      datasetRef: 'ds',
+      valueField: 'revenue',
+      aggregation: 'sum',
+      prefix: '$',
+      suffix: 'M',
+      comparisonField: 'prev_revenue',
     },
-    expectedFields: [{ role: 'value', fieldRef: 'revenue' }, { role: 'comparison', fieldRef: 'prev_revenue' }],
+    expectedFields: [
+      { role: 'value', fieldRef: 'revenue' },
+      { role: 'comparison', fieldRef: 'prev_revenue' },
+    ],
     configKeys: ['prefix', 'suffix'],
   },
 ];
@@ -229,7 +345,7 @@ describe('puckToCanonical — all chart types', () => {
       // Verify layout entries exist
       expect(page.layout[`layout-${props.id}`]).toBeDefined();
       expect(page.layout[`layout-${props.id}`].type).toBe('widget');
-    }
+    },
   );
 });
 
@@ -257,7 +373,7 @@ describe('Round-trip conversion — all chart types', () => {
       if (props.datasetRef && expectedFields.length > 0) {
         expect(restored.content![0].props.datasetRef).toBe(props.datasetRef);
       }
-    }
+    },
   );
 });
 
@@ -289,10 +405,38 @@ describe('Multi-chart dashboard conversion', () => {
     const puckData: Data = {
       root: { props: { title: 'Mixed' } },
       content: [
-        { type: 'HeaderBlock', props: { id: 'h1', text: 'Section 1', size: 'large', align: 'left' } },
-        { type: 'LineChart', props: { id: 'lc1', title: 'Sales', datasetRef: 'ds', xAxisField: 'month', yAxisField: 'val', seriesField: '', aggregation: 'none', smooth: 'false' } },
+        {
+          type: 'HeaderBlock',
+          props: { id: 'h1', text: 'Section 1', size: 'large', align: 'left' },
+        },
+        {
+          type: 'LineChart',
+          props: {
+            id: 'lc1',
+            title: 'Sales',
+            datasetRef: 'ds',
+            xAxisField: 'month',
+            yAxisField: 'val',
+            seriesField: '',
+            aggregation: 'none',
+            smooth: 'false',
+          },
+        },
         { type: 'DividerBlock', props: { id: 'd1', color: '#ccc', thickness: 1, margin: 16 } },
-        { type: 'BarChart', props: { id: 'bc1', title: 'Revenue', datasetRef: 'ds', xAxisField: 'cat', yAxisField: 'rev', seriesField: '', aggregation: 'sum', orientation: 'vertical', stacked: 'false' } },
+        {
+          type: 'BarChart',
+          props: {
+            id: 'bc1',
+            title: 'Revenue',
+            datasetRef: 'ds',
+            xAxisField: 'cat',
+            yAxisField: 'rev',
+            seriesField: '',
+            aggregation: 'sum',
+            orientation: 'vertical',
+            stacked: 'false',
+          },
+        },
       ],
     };
 
@@ -326,7 +470,19 @@ describe('Adapter edge cases', () => {
       root: { props: { title: 'Test' } },
       content: [
         { type: 'UnknownWidget', props: { id: 'u1' } },
-        { type: 'LineChart', props: { id: 'lc1', title: 'Line', datasetRef: 'ds', xAxisField: 'x', yAxisField: 'y', seriesField: '', aggregation: 'none', smooth: 'false' } },
+        {
+          type: 'LineChart',
+          props: {
+            id: 'lc1',
+            title: 'Line',
+            datasetRef: 'ds',
+            xAxisField: 'x',
+            yAxisField: 'y',
+            seriesField: '',
+            aggregation: 'none',
+            smooth: 'false',
+          },
+        },
       ],
     };
 
@@ -340,7 +496,19 @@ describe('Adapter edge cases', () => {
     const puckData: Data = {
       root: { props: { title: 'Test' } },
       content: [
-        { type: 'LineChart', props: { id: 'lc1', title: 'Empty', datasetRef: '', xAxisField: '', yAxisField: '', seriesField: '', aggregation: 'none', smooth: 'false' } },
+        {
+          type: 'LineChart',
+          props: {
+            id: 'lc1',
+            title: 'Empty',
+            datasetRef: '',
+            xAxisField: '',
+            yAxisField: '',
+            seriesField: '',
+            aggregation: 'none',
+            smooth: 'false',
+          },
+        },
       ],
     };
 
@@ -353,7 +521,20 @@ describe('Adapter edge cases', () => {
     const puckData: Data = {
       root: { props: { title: 'Test' } },
       content: [
-        { type: 'BarChart', props: { id: 'bar1', title: 'Bar', datasetRef: 'ds', xAxisField: 'cat', yAxisField: 'val', seriesField: '', aggregation: 'none', orientation: 'vertical', stacked: 'false' } },
+        {
+          type: 'BarChart',
+          props: {
+            id: 'bar1',
+            title: 'Bar',
+            datasetRef: 'ds',
+            xAxisField: 'cat',
+            yAxisField: 'val',
+            seriesField: '',
+            aggregation: 'none',
+            orientation: 'vertical',
+            stacked: 'false',
+          },
+        },
       ],
     };
 
@@ -368,7 +549,20 @@ describe('Adapter edge cases', () => {
     const puckData: Data = {
       root: { props: { title: 'Test' } },
       content: [
-        { type: 'BarChart', props: { id: 'bar1', title: 'Bar', datasetRef: 'ds', xAxisField: 'cat', yAxisField: 'val', seriesField: '', aggregation: 'sum', orientation: 'vertical', stacked: 'false' } },
+        {
+          type: 'BarChart',
+          props: {
+            id: 'bar1',
+            title: 'Bar',
+            datasetRef: 'ds',
+            xAxisField: 'cat',
+            yAxisField: 'val',
+            seriesField: '',
+            aggregation: 'sum',
+            orientation: 'vertical',
+            stacked: 'false',
+          },
+        },
       ],
     };
 
@@ -396,13 +590,15 @@ describe('Adapter edge cases', () => {
       schemaVersion: '0.2.0',
       id: 'test',
       title: 'No Root',
-      pages: [{
-        id: 'p1',
-        title: 'Page',
-        layout: {},
-        rootNodeId: 'missing',
-        widgets: [],
-      }],
+      pages: [
+        {
+          id: 'p1',
+          title: 'Page',
+          layout: {},
+          rootNodeId: 'missing',
+          widgets: [],
+        },
+      ],
     };
 
     const result = canonicalToPuck(dashboard);
@@ -416,7 +612,12 @@ describe('Content block adapter', () => {
   it('converts HeaderBlock to header layout node', () => {
     const puckData: Data = {
       root: { props: { title: 'Test' } },
-      content: [{ type: 'HeaderBlock', props: { id: 'h1', text: 'Welcome', size: 'large', align: 'center' } }],
+      content: [
+        {
+          type: 'HeaderBlock',
+          props: { id: 'h1', text: 'Welcome', size: 'large', align: 'center' },
+        },
+      ],
     };
 
     const result = puckToCanonical(puckData);
@@ -431,7 +632,9 @@ describe('Content block adapter', () => {
   it('converts DividerBlock to divider layout node', () => {
     const puckData: Data = {
       root: { props: { title: 'Test' } },
-      content: [{ type: 'DividerBlock', props: { id: 'd1', color: '#ccc', thickness: 2, margin: 16 } }],
+      content: [
+        { type: 'DividerBlock', props: { id: 'd1', color: '#ccc', thickness: 2, margin: 16 } },
+      ],
     };
 
     const result = puckToCanonical(puckData);
@@ -471,12 +674,95 @@ describe('Content block adapter', () => {
   it('converts FilterBarBlock to filter-bar widget', () => {
     const puckData: Data = {
       root: { props: { title: 'Test' } },
-      content: [{ type: 'FilterBarBlock', props: { id: 'fb1', title: 'Filters', scope: 'global', layout: 'horizontal' } }],
+      content: [
+        {
+          type: 'FilterBarBlock',
+          props: {
+            id: 'fb1',
+            title: 'Filters',
+            scope: 'global',
+            layout: 'horizontal',
+            filterIds: ['region-filter', 'date-filter'],
+          },
+        },
+      ],
     };
 
     const result = puckToCanonical(puckData);
     // Filter bar is treated as a widget (control)
     expect(result.pages[0].widgets).toHaveLength(1);
     expect(result.pages[0].widgets[0].type).toBe('filter-bar');
+    expect(result.pages[0].widgets[0].config.filterIds).toEqual(['region-filter', 'date-filter']);
+  });
+
+  it('omits empty filterIds when exporting FilterBarBlock config', () => {
+    const puckData: Data = {
+      root: { props: { title: 'Test' } },
+      content: [
+        {
+          type: 'FilterBarBlock',
+          props: {
+            id: 'fb1',
+            title: 'Filters',
+            scope: 'global',
+            layout: 'horizontal',
+            filterIds: [],
+          },
+        },
+      ],
+    };
+
+    const result = puckToCanonical(puckData);
+    expect(result.pages[0].widgets[0].config.filterIds).toBeUndefined();
+  });
+
+  it('canonicalToPuck restores filterIds for filter-bar widgets', () => {
+    const dashboard: DashboardDefinition = {
+      schemaVersion: '0.2.0',
+      id: 'dashboard-1',
+      title: 'Filters',
+      pages: [
+        {
+          id: 'page-1',
+          title: 'Page 1',
+          rootNodeId: 'root',
+          layout: {
+            root: { id: 'root', type: 'root', children: ['grid-main'], meta: {} },
+            'grid-main': {
+              id: 'grid-main',
+              type: 'grid',
+              children: ['layout-fb1'],
+              parentId: 'root',
+              meta: { columns: 12 },
+            },
+            'layout-fb1': {
+              id: 'layout-fb1',
+              type: 'widget',
+              children: [],
+              parentId: 'grid-main',
+              meta: { widgetRef: 'fb1', width: 12 },
+            },
+          },
+          widgets: [
+            {
+              id: 'fb1',
+              type: 'filter-bar',
+              title: 'Filters',
+              config: {
+                scope: 'global',
+                layout: 'horizontal',
+                filterIds: ['region-filter'],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const restored = canonicalToPuck(dashboard);
+
+    expect(restored.content).toHaveLength(1);
+    expect(restored.content?.[0].type).toBe('FilterBarBlock');
+    expect(restored.content?.[0].props.filterIds).toEqual(['region-filter']);
   });
 });

--- a/packages/designer/test/config.test.ts
+++ b/packages/designer/test/config.test.ts
@@ -14,7 +14,11 @@ import { LAYOUT_BLOCK_NAMES } from '../src/blocks/layout';
 
 describe('createPuckConfig', () => {
   const config = createPuckConfig();
-  const totalBlockCount = CHART_BLOCK_NAMES.length + CONTENT_BLOCK_NAMES.length + CONTROL_BLOCK_NAMES.length + LAYOUT_BLOCK_NAMES.length;
+  const totalBlockCount =
+    CHART_BLOCK_NAMES.length +
+    CONTENT_BLOCK_NAMES.length +
+    CONTROL_BLOCK_NAMES.length +
+    LAYOUT_BLOCK_NAMES.length;
 
   it('returns a valid Puck Config object', () => {
     expect(config).toBeDefined();
@@ -79,7 +83,11 @@ describe('createPuckConfig', () => {
   });
 
   it('tables category contains Table, KPICard, and AlertsWidgetBlock', () => {
-    expect(config.categories!.tables!.components).toEqual(['Table', 'KPICard', 'AlertsWidgetBlock']);
+    expect(config.categories!.tables!.components).toEqual([
+      'Table',
+      'KPICard',
+      'AlertsWidgetBlock',
+    ]);
   });
 
   it('every chart component has a title field', () => {
@@ -87,6 +95,27 @@ describe('createPuckConfig', () => {
       const comp = config.components[name];
       expect(comp.fields?.title).toBeDefined();
     }
+  });
+
+  it('builds FilterBarBlock with a custom filter subset field', () => {
+    const filterAwareConfig = createPuckConfig({
+      filterDefinitions: [
+        {
+          id: 'region-filter',
+          title: 'Region',
+          type: 'select',
+          fieldRef: 'region',
+          datasetRef: 'orders',
+          operator: 'equals',
+          scope: { type: 'global' },
+        },
+      ],
+    });
+
+    expect(filterAwareConfig.components.FilterBarBlock.fields?.filterIds).toBeDefined();
+    expect(
+      (filterAwareConfig.components.FilterBarBlock.fields?.filterIds as { type: string }).type,
+    ).toBe('custom');
   });
 });
 

--- a/packages/designer/test/feature-panels-2.test.tsx
+++ b/packages/designer/test/feature-panels-2.test.tsx
@@ -567,6 +567,70 @@ describe('FilterBuilderPanel', () => {
     expect((screen.getByTestId('filter-type-f1') as HTMLSelectElement).value).toBe('select');
   });
 
+  it('does not renormalize equivalent legacy filters when props churn', () => {
+    const initialOnChange = vi.fn();
+    const rerenderOnChange = vi.fn();
+    const filter: FilterDefinition = {
+      id: 'f1',
+      type: 'multi-select',
+      fieldRef: 'region',
+      datasetRef: 'ds-orders',
+      operator: 'equals',
+      scope: { type: 'global' },
+    };
+    const { rerender } = render(
+      <FilterBuilderPanel
+        filters={[filter]}
+        onChange={initialOnChange}
+        datasets={[MOCK_DATASET]}
+      />,
+    );
+
+    expect(initialOnChange).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <FilterBuilderPanel
+        filters={[{ ...filter }]}
+        onChange={rerenderOnChange}
+        datasets={[MOCK_DATASET]}
+      />,
+    );
+
+    expect(rerenderOnChange).not.toHaveBeenCalled();
+  });
+
+  it('does not emit onChange for supported filters when props churn', () => {
+    const initialOnChange = vi.fn();
+    const rerenderOnChange = vi.fn();
+    const filter: FilterDefinition = {
+      id: 'f1',
+      type: 'select',
+      fieldRef: 'region',
+      datasetRef: 'ds-orders',
+      operator: 'equals',
+      scope: { type: 'global' },
+    };
+    const { rerender } = render(
+      <FilterBuilderPanel
+        filters={[filter]}
+        onChange={initialOnChange}
+        datasets={[MOCK_DATASET]}
+      />,
+    );
+
+    expect(initialOnChange).not.toHaveBeenCalled();
+
+    rerender(
+      <FilterBuilderPanel
+        filters={[{ ...filter }]}
+        onChange={rerenderOnChange}
+        datasets={[MOCK_DATASET]}
+      />,
+    );
+
+    expect(rerenderOnChange).not.toHaveBeenCalled();
+  });
+
   it('only renders runtime-supported control types', () => {
     const filter: FilterDefinition = {
       id: 'f1',

--- a/packages/designer/test/feature-panels-2.test.tsx
+++ b/packages/designer/test/feature-panels-2.test.tsx
@@ -12,10 +12,7 @@ import type { NormalizedDataset, NormalizedField } from '@supersubset/data-model
 
 vi.mock('@supersubset/data-model', () => ({}));
 
-import {
-  ChartTypePicker,
-  CHART_TYPE_OPTIONS,
-} from '../src/components/ChartTypePicker';
+import { ChartTypePicker, CHART_TYPE_OPTIONS } from '../src/components/ChartTypePicker';
 import {
   FieldBindingPicker,
   type BindingSlot,
@@ -33,8 +30,20 @@ const MOCK_FIELDS: NormalizedField[] = [
   { id: 'order_date', label: 'Order Date', dataType: 'date', role: 'time' },
   { id: 'category', label: 'Category', dataType: 'string', role: 'dimension' },
   { id: 'region', label: 'Region', dataType: 'string', role: 'dimension' },
-  { id: 'revenue', label: 'Revenue', dataType: 'number', role: 'measure', defaultAggregation: 'sum' },
-  { id: 'quantity', label: 'Quantity', dataType: 'integer', role: 'measure', defaultAggregation: 'sum' },
+  {
+    id: 'revenue',
+    label: 'Revenue',
+    dataType: 'number',
+    role: 'measure',
+    defaultAggregation: 'sum',
+  },
+  {
+    id: 'quantity',
+    label: 'Quantity',
+    dataType: 'integer',
+    role: 'measure',
+    defaultAggregation: 'sum',
+  },
   { id: 'customer_id', label: 'Customer ID', dataType: 'string', role: 'key' },
 ];
 
@@ -78,9 +87,7 @@ describe('ChartTypePicker', () => {
   });
 
   it('highlights the selected chart type', () => {
-    render(
-      <ChartTypePicker onChange={vi.fn()} value="bar-chart" />
-    );
+    render(<ChartTypePicker onChange={vi.fn()} value="bar-chart" />);
     const barBtn = screen.getByTestId('chart-type-bar-chart');
     expect(barBtn.dataset.selected).toBe('true');
   });
@@ -131,12 +138,7 @@ describe('FieldBindingPicker', () => {
   afterEach(cleanup);
 
   it('renders fields grouped by role', () => {
-    render(
-      <FieldBindingPicker
-        datasets={[MOCK_DATASET]}
-        selectedDatasetId="ds-orders"
-      />
-    );
+    render(<FieldBindingPicker datasets={[MOCK_DATASET]} selectedDatasetId="ds-orders" />);
     expect(screen.getByTestId('field-binding-picker')).toBeTruthy();
     // Should see role groups
     expect(screen.getByText(/Times \(1\)/)).toBeTruthy();
@@ -146,12 +148,7 @@ describe('FieldBindingPicker', () => {
   });
 
   it('shows all field labels', () => {
-    render(
-      <FieldBindingPicker
-        datasets={[MOCK_DATASET]}
-        selectedDatasetId="ds-orders"
-      />
-    );
+    render(<FieldBindingPicker datasets={[MOCK_DATASET]} selectedDatasetId="ds-orders" />);
     expect(screen.getByText('Order Date')).toBeTruthy();
     expect(screen.getByText('Category')).toBeTruthy();
     expect(screen.getByText('Revenue')).toBeTruthy();
@@ -165,22 +162,17 @@ describe('FieldBindingPicker', () => {
         datasets={[MOCK_DATASET]}
         selectedDatasetId="ds-orders"
         onFieldSelect={onFieldSelect}
-      />
+      />,
     );
     fireEvent.click(screen.getByTestId('field-revenue'));
     expect(onFieldSelect).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'revenue', role: 'measure' }),
-      'ds-orders'
+      'ds-orders',
     );
   });
 
   it('filters fields by search', () => {
-    render(
-      <FieldBindingPicker
-        datasets={[MOCK_DATASET]}
-        selectedDatasetId="ds-orders"
-      />
-    );
+    render(<FieldBindingPicker datasets={[MOCK_DATASET]} selectedDatasetId="ds-orders" />);
     fireEvent.change(screen.getByTestId('field-search'), {
       target: { value: 'rev' },
     });
@@ -195,7 +187,7 @@ describe('FieldBindingPicker', () => {
         datasets={[MOCK_DATASET, MOCK_DATASET_2]}
         selectedDatasetId="ds-orders"
         onDatasetChange={onDatasetChange}
-      />
+      />,
     );
     const select = screen.getByTestId('dataset-select');
     expect(select).toBeTruthy();
@@ -208,7 +200,7 @@ describe('FieldBindingPicker', () => {
       <FieldBindingPicker
         datasets={[MOCK_DATASET, MOCK_DATASET_2]}
         selectedDatasetId="ds-orders"
-      />
+      />,
     );
 
     const datasetSelect = screen.getByTestId('dataset-select');
@@ -223,22 +215,12 @@ describe('FieldBindingPicker', () => {
   });
 
   it('does not show dataset selector for single dataset', () => {
-    render(
-      <FieldBindingPicker
-        datasets={[MOCK_DATASET]}
-        selectedDatasetId="ds-orders"
-      />
-    );
+    render(<FieldBindingPicker datasets={[MOCK_DATASET]} selectedDatasetId="ds-orders" />);
     expect(screen.queryByTestId('dataset-select')).toBeNull();
   });
 
   it('toggles role group expand/collapse', () => {
-    render(
-      <FieldBindingPicker
-        datasets={[MOCK_DATASET]}
-        selectedDatasetId="ds-orders"
-      />
-    );
+    render(<FieldBindingPicker datasets={[MOCK_DATASET]} selectedDatasetId="ds-orders" />);
     // Initially expanded — field visible
     expect(screen.getByText('Revenue')).toBeTruthy();
     // Collapse measures
@@ -261,7 +243,7 @@ describe('FieldBindingPicker', () => {
         slots={slots}
         bindings={[]}
         onBindingsChange={vi.fn()}
-      />
+      />,
     );
     expect(screen.getByTestId('binding-slots')).toBeTruthy();
     // Dimension fields should show X Axis bind button (not Y Axis)
@@ -284,7 +266,7 @@ describe('FieldBindingPicker', () => {
         slots={slots}
         bindings={[]}
         onBindingsChange={onBindingsChange}
-      />
+      />,
     );
     // Bind category to x-axis
     fireEvent.click(screen.getByTestId('bind-category-x-axis'));
@@ -303,7 +285,7 @@ describe('FieldBindingPicker', () => {
         slots={slots}
         bindings={bindings}
         onBindingsChange={onBindingsChange}
-      />
+      />,
     );
     fireEvent.click(screen.getByTestId('unbind-x-axis-category'));
     expect(onBindingsChange).toHaveBeenLastCalledWith([]);
@@ -323,26 +305,14 @@ describe('FilterBuilderPanel', () => {
   afterEach(cleanup);
 
   it('renders empty state', () => {
-    render(
-      <FilterBuilderPanel
-        filters={[]}
-        onChange={vi.fn()}
-        datasets={[MOCK_DATASET]}
-      />
-    );
+    render(<FilterBuilderPanel filters={[]} onChange={vi.fn()} datasets={[MOCK_DATASET]} />);
     expect(screen.getByTestId('no-filters')).toBeTruthy();
     expect(screen.getByText('Filters (0)')).toBeTruthy();
   });
 
   it('adds a new filter', () => {
     const onChange = vi.fn();
-    render(
-      <FilterBuilderPanel
-        filters={[]}
-        onChange={onChange}
-        datasets={[MOCK_DATASET]}
-      />
-    );
+    render(<FilterBuilderPanel filters={[]} onChange={onChange} datasets={[MOCK_DATASET]} />);
     fireEvent.click(screen.getByTestId('add-filter'));
     expect(onChange).toHaveBeenCalledWith([
       expect.objectContaining({
@@ -364,13 +334,7 @@ describe('FilterBuilderPanel', () => {
       operator: 'equals',
       scope: { type: 'global' },
     };
-    render(
-      <FilterBuilderPanel
-        filters={[filter]}
-        onChange={vi.fn()}
-        datasets={[MOCK_DATASET]}
-      />
-    );
+    render(<FilterBuilderPanel filters={[filter]} onChange={vi.fn()} datasets={[MOCK_DATASET]} />);
     expect(screen.getByTestId('filter-editor-f1')).toBeTruthy();
     expect(screen.getByTestId('filter-title-f1')).toBeTruthy();
     expect(screen.getByTestId('filter-dataset-f1')).toBeTruthy();
@@ -395,7 +359,7 @@ describe('FilterBuilderPanel', () => {
         onChange={vi.fn()}
         datasets={[MOCK_DATASET]}
         pageIds={['page-1', 'page-2']}
-      />
+      />,
     );
 
     const datasetLabel = screen.getByText('Dataset');
@@ -420,13 +384,7 @@ describe('FilterBuilderPanel', () => {
       operator: 'equals',
       scope: { type: 'global' },
     };
-    render(
-      <FilterBuilderPanel
-        filters={[filter]}
-        onChange={onChange}
-        datasets={[MOCK_DATASET]}
-      />
-    );
+    render(<FilterBuilderPanel filters={[filter]} onChange={onChange} datasets={[MOCK_DATASET]} />);
     fireEvent.change(screen.getByTestId('filter-title-f1'), {
       target: { value: 'My Filter' },
     });
@@ -450,7 +408,7 @@ describe('FilterBuilderPanel', () => {
         filters={[filter]}
         onChange={onChange}
         datasets={[MOCK_DATASET, MOCK_DATASET_2]}
-      />
+      />,
     );
     fireEvent.change(screen.getByTestId('filter-dataset-f1'), {
       target: { value: 'ds-products' },
@@ -474,19 +432,11 @@ describe('FilterBuilderPanel', () => {
       operator: 'equals',
       scope: { type: 'global' },
     };
-    render(
-      <FilterBuilderPanel
-        filters={[filter]}
-        onChange={onChange}
-        datasets={[MOCK_DATASET]}
-      />
-    );
+    render(<FilterBuilderPanel filters={[filter]} onChange={onChange} datasets={[MOCK_DATASET]} />);
     fireEvent.change(screen.getByTestId('filter-operator-f1'), {
       target: { value: 'contains' },
     });
-    expect(onChange).toHaveBeenCalledWith([
-      expect.objectContaining({ operator: 'contains' }),
-    ]);
+    expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ operator: 'contains' })]);
   });
 
   it('deletes a filter', () => {
@@ -509,17 +459,9 @@ describe('FilterBuilderPanel', () => {
         scope: { type: 'global' },
       },
     ];
-    render(
-      <FilterBuilderPanel
-        filters={filters}
-        onChange={onChange}
-        datasets={[MOCK_DATASET]}
-      />
-    );
+    render(<FilterBuilderPanel filters={filters} onChange={onChange} datasets={[MOCK_DATASET]} />);
     fireEvent.click(screen.getByTestId('filter-delete-f1'));
-    expect(onChange).toHaveBeenCalledWith([
-      expect.objectContaining({ id: 'f2' }),
-    ]);
+    expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ id: 'f2' })]);
   });
 
   it('changes scope to page', () => {
@@ -538,7 +480,7 @@ describe('FilterBuilderPanel', () => {
         onChange={onChange}
         datasets={[MOCK_DATASET]}
         pageIds={['page-1', 'page-2']}
-      />
+      />,
     );
     fireEvent.click(screen.getByTestId('filter-scope-page-f1'));
     expect(onChange).toHaveBeenCalledWith([
@@ -564,7 +506,7 @@ describe('FilterBuilderPanel', () => {
         onChange={onChange}
         datasets={[MOCK_DATASET]}
         widgetIds={['w1', 'w2', 'w3']}
-      />
+      />,
     );
     // Widget checkboxes should be visible
     fireEvent.click(screen.getByTestId('filter-scope-widget-w1-f1'));
@@ -585,19 +527,11 @@ describe('FilterBuilderPanel', () => {
       operator: 'equals',
       scope: { type: 'global' },
     };
-    render(
-      <FilterBuilderPanel
-        filters={[filter]}
-        onChange={onChange}
-        datasets={[MOCK_DATASET]}
-      />
-    );
+    render(<FilterBuilderPanel filters={[filter]} onChange={onChange} datasets={[MOCK_DATASET]} />);
     fireEvent.change(screen.getByTestId('filter-default-f1'), {
       target: { value: 'West' },
     });
-    expect(onChange).toHaveBeenCalledWith([
-      expect.objectContaining({ defaultValue: 'West' }),
-    ]);
+    expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ defaultValue: 'West' })]);
   });
 
   it('changes control type', () => {
@@ -610,19 +544,45 @@ describe('FilterBuilderPanel', () => {
       operator: 'equals',
       scope: { type: 'global' },
     };
-    render(
-      <FilterBuilderPanel
-        filters={[filter]}
-        onChange={onChange}
-        datasets={[MOCK_DATASET]}
-      />
-    );
+    render(<FilterBuilderPanel filters={[filter]} onChange={onChange} datasets={[MOCK_DATASET]} />);
     fireEvent.change(screen.getByTestId('filter-type-f1'), {
-      target: { value: 'multi-select' },
+      target: { value: 'date' },
     });
-    expect(onChange).toHaveBeenCalledWith([
-      expect.objectContaining({ type: 'multi-select' }),
-    ]);
+    expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ type: 'date' })]);
+  });
+
+  it('normalizes legacy unsupported control types on mount', () => {
+    const onChange = vi.fn();
+    const filter: FilterDefinition = {
+      id: 'f1',
+      type: 'multi-select',
+      fieldRef: 'region',
+      datasetRef: 'ds-orders',
+      operator: 'equals',
+      scope: { type: 'global' },
+    };
+    render(<FilterBuilderPanel filters={[filter]} onChange={onChange} datasets={[MOCK_DATASET]} />);
+
+    expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ type: 'select' })]);
+    expect((screen.getByTestId('filter-type-f1') as HTMLSelectElement).value).toBe('select');
+  });
+
+  it('only renders runtime-supported control types', () => {
+    const filter: FilterDefinition = {
+      id: 'f1',
+      type: 'select',
+      fieldRef: 'region',
+      datasetRef: 'ds-orders',
+      operator: 'equals',
+      scope: { type: 'global' },
+    };
+    render(<FilterBuilderPanel filters={[filter]} onChange={vi.fn()} datasets={[MOCK_DATASET]} />);
+
+    const optionValues = Array.from(
+      screen.getByTestId('filter-type-f1').querySelectorAll('option'),
+    ).map((option) => option.getAttribute('value'));
+
+    expect(optionValues).toEqual(['select', 'range', 'date', 'text']);
   });
 
   it('has correct operator list', () => {

--- a/packages/designer/test/integration.test.ts
+++ b/packages/designer/test/integration.test.ts
@@ -505,6 +505,51 @@ describe('Controls integration', () => {
     const el = fb.render({ title: 'Filters', layout: 'vertical' });
     expect(React.isValidElement(el)).toBe(true);
   });
+
+  it('FilterBarBlock preview distinguishes filter subsets', () => {
+    const filterAwareConfig = createPuckConfig({
+      filterDefinitions: [
+        {
+          id: 'region-filter',
+          title: 'Region',
+          type: 'select',
+          fieldRef: 'region',
+          datasetRef: 'orders',
+          operator: 'equals',
+          scope: { type: 'global' },
+        },
+        {
+          id: 'date-filter',
+          title: 'Order Date',
+          type: 'date',
+          fieldRef: 'order_date',
+          datasetRef: 'orders',
+          operator: 'equals',
+          scope: { type: 'global' },
+        },
+      ],
+    });
+    const fb = filterAwareConfig.components['FilterBarBlock'];
+    const allFiltersElement = fb.render({
+      title: 'Filters',
+      layout: 'horizontal',
+    }) as React.ReactElement;
+    const subsetElement = fb.render({
+      title: 'Filters',
+      layout: 'horizontal',
+      filterIds: ['region-filter'],
+    }) as React.ReactElement;
+
+    const allFiltersChildren = React.Children.toArray(
+      allFiltersElement.props.children,
+    ) as React.ReactElement[];
+    const subsetChildren = React.Children.toArray(
+      subsetElement.props.children,
+    ) as React.ReactElement[];
+
+    expect(allFiltersChildren[2].props.children).toBe('Showing all authored filters');
+    expect(subsetChildren[2].props.children).toBe('Showing Region');
+  });
 });
 
 // ─── Root render function ────────────────────────────────────

--- a/packages/dev-app/src/demo-dashboard.test.ts
+++ b/packages/dev-app/src/demo-dashboard.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { demoDashboard } from './demo-dashboard';
+
+describe('demo dashboard fixture', () => {
+  it('places both all-filter and subset filter-bar widgets on the overview page', () => {
+    const overviewPage = demoDashboard.pages.find((page) => page.id === 'page-overview');
+
+    expect(overviewPage).toBeDefined();
+
+    const allFiltersBar = overviewPage?.widgets.find((widget) => widget.id === 'filters-all');
+    const regionFiltersBar = overviewPage?.widgets.find((widget) => widget.id === 'filters-region');
+    const rowFilterBars = overviewPage?.layout['row-filter-bars'];
+
+    expect(rowFilterBars?.children).toEqual(['w-filter-bar-all', 'w-filter-bar-region']);
+    expect(overviewPage?.layout['w-filter-bar-all']?.meta.widgetRef).toBe('filters-all');
+    expect(overviewPage?.layout['w-filter-bar-region']?.meta.widgetRef).toBe('filters-region');
+
+    expect(allFiltersBar?.type).toBe('filter-bar');
+    expect(
+      (allFiltersBar?.config as { filterIds?: string[] } | undefined)?.filterIds,
+    ).toBeUndefined();
+
+    expect(regionFiltersBar).toMatchObject({
+      type: 'filter-bar',
+      config: { filterIds: ['filter-region'] },
+    });
+  });
+});

--- a/packages/dev-app/src/demo-dashboard.ts
+++ b/packages/dev-app/src/demo-dashboard.ts
@@ -58,6 +58,7 @@ export const demoDashboard: DashboardDefinition = {
           children: [
             'header-title',
             'divider-1',
+            'row-filter-bars',
             'row-alerts',
             'row-kpis',
             'row-charts',
@@ -79,6 +80,27 @@ export const demoDashboard: DashboardDefinition = {
           children: [],
           parentId: 'grid-main',
           meta: {},
+        },
+        'row-filter-bars': {
+          id: 'row-filter-bars',
+          type: 'row',
+          children: ['w-filter-bar-all', 'w-filter-bar-region'],
+          parentId: 'grid-main',
+          meta: {},
+        },
+        'w-filter-bar-all': {
+          id: 'w-filter-bar-all',
+          type: 'widget',
+          children: [],
+          parentId: 'row-filter-bars',
+          meta: { widgetRef: 'filters-all', width: 8, height: 88 },
+        },
+        'w-filter-bar-region': {
+          id: 'w-filter-bar-region',
+          type: 'widget',
+          children: [],
+          parentId: 'row-filter-bars',
+          meta: { widgetRef: 'filters-region', width: 4, height: 88 },
         },
         'row-alerts': {
           id: 'row-alerts',
@@ -159,6 +181,18 @@ export const demoDashboard: DashboardDefinition = {
         },
       },
       widgets: [
+        {
+          id: 'filters-all',
+          type: 'filter-bar',
+          title: 'All Dashboard Filters',
+          config: {},
+        },
+        {
+          id: 'filters-region',
+          type: 'filter-bar',
+          title: 'Region Quick Filter',
+          config: { filterIds: ['filter-region'] },
+        },
         {
           id: 'alerts-overview',
           type: 'alerts',

--- a/packages/docs/capture/filters.spec.ts
+++ b/packages/docs/capture/filters.spec.ts
@@ -30,7 +30,7 @@ test.describe('Filter screenshots', () => {
     await switchToViewer(page);
     await waitForChartsReady(page);
 
-    const filterBar = page.locator('.ss-filter-bar');
+    const filterBar = page.locator('.ss-filter-bar').first();
     if (await filterBar.isVisible({ timeout: 3000 }).catch(() => false)) {
       await captureElement(filterBar, 'filters', 'filter-bar', 'default', 'viewer');
     } else {
@@ -57,7 +57,7 @@ test.describe('Filter screenshots', () => {
     await switchToViewer(page);
     await waitForChartsReady(page);
     // Scroll to make the filter bar visible at the top
-    const filterBar = page.locator('.ss-filter-bar');
+    const filterBar = page.locator('.ss-filter-bar').first();
     if (await filterBar.isVisible({ timeout: 3000 }).catch(() => false)) {
       await filterBar.scrollIntoViewIfNeeded();
       await page.waitForTimeout(300);

--- a/packages/docs/capture/layout-filters.spec.ts
+++ b/packages/docs/capture/layout-filters.spec.ts
@@ -149,7 +149,7 @@ test.describe('Filter-specific screenshots', () => {
       await waitForChartsReady(page);
     }
     // Capture just the filter bar area with active selection
-    const filterBar = page.locator('.ss-filter-bar');
+    const filterBar = page.locator('.ss-filter-bar').first();
     if (await filterBar.isVisible({ timeout: 3000 }).catch(() => false)) {
       await captureElement(filterBar, 'filters', 'select-filter', 'region-north', 'viewer');
     }
@@ -164,7 +164,7 @@ test.describe('Filter-specific screenshots', () => {
       await catSelect.selectOption({ index: 1 }); // Pick first non-empty option
       await waitForChartsReady(page);
     }
-    const filterBar = page.locator('.ss-filter-bar');
+    const filterBar = page.locator('.ss-filter-bar').first();
     if (await filterBar.isVisible({ timeout: 3000 }).catch(() => false)) {
       await captureElement(filterBar, 'filters', 'select-filter', 'category-active', 'viewer');
     }
@@ -193,7 +193,7 @@ test.describe('Filter-specific screenshots', () => {
     await switchToViewer(page);
     await waitForChartsReady(page);
     // Capture the filter bar showing the date filter
-    const filterBar = page.locator('.ss-filter-bar');
+    const filterBar = page.locator('.ss-filter-bar').first();
     if (await filterBar.isVisible({ timeout: 3000 }).catch(() => false)) {
       await captureElement(filterBar, 'filters', 'date-filter', 'bar', 'viewer');
     }

--- a/packages/docs/src/content/docs/filters/cross-filtering.mdx
+++ b/packages/docs/src/content/docs/filters/cross-filtering.mdx
@@ -56,8 +56,8 @@ The field that gets filtered when the user clicks a chart element.
 
 <FeatureScreenshot
   src={filter_bar_active_viewer}
-  alt="Filter bar showing active filter state from cross-filtering"
-  caption="Cross-filter updates the filter bar with the selected field value"
+  alt="Placed filter bar widget showing active filter state from cross-filtering"
+  caption="Cross-filtering updates any placed Filter Bar widgets that include the matching authored filter"
 />
 
 ## Tips
@@ -65,6 +65,7 @@ The field that gets filtered when the user clicks a chart element.
 - Cross-filtering is most intuitive on [Bar Charts](/chart-types/bar-chart/) and [Pie Charts](/chart-types/pie-chart/)
 - Users expect to click a bar/slice and see the rest of the dashboard update
 - Combine with explicit [Select Filters](/filters/select-filter/) for a "Reset All" capability
+- If you use multiple Filter Bar widgets, only the bars that include the matching authored filter will show the updated value
 - Keep the interaction intuitive — filter on the same field that labels the clicked element
 
 ## Related Features

--- a/packages/docs/src/content/docs/filters/date-filter.mdx
+++ b/packages/docs/src/content/docs/filters/date-filter.mdx
@@ -15,18 +15,18 @@ import date_filter_bar_viewer from '../../../assets/screenshots/filters/date-fil
 
 # Date Filter
 
-Date filters let dashboard viewers select a date range, filtering time-series data across all widgets in scope. Essential for any dashboard with temporal data.
+Date filters let dashboard viewers select a date range, filtering time-series data across all widgets in scope. They appear anywhere you place a Filter Bar widget that includes the authored date filter.
 
 <ExpandAll />
 
 ## Default Appearance
 
-A date filter with default settings shows a date range picker.
+A date filter with default settings shows a date range picker inside a placed Filter Bar widget.
 
 <ScreenshotComparison
   label="Default date filter"
   viewerSrc={date_filter_bar_viewer}
-  viewerAlt="Date filter in the filter bar"
+  viewerAlt="Date filter in a placed filter bar widget"
 />
 
 ## Configuration Options
@@ -57,14 +57,19 @@ Controls which widgets are affected. See [Filter Scope](/filters/filter-scope/).
 
 <FeatureScreenshot
   src={filter_bar_viewer}
-  alt="Filter bar showing all filters including date"
-  caption="Date filter alongside select filters in the filter bar"
+  alt="Placed filter bar widget showing date and select filters"
+  caption="A Filter Bar widget can show the date filter alongside other authored filters"
 />
+
+### Filter Bar Visibility
+
+The authored date filter exists independently from its placement. It will only be visible to viewers in Filter Bar widgets whose `Shown Filters` configuration includes that filter, or in bars configured to show all authored filters.
 
 ## Tips
 
 - Use with [Line Charts](/chart-types/line-chart/) and [Area Charts](/chart-types/area-chart/) for time-series drill-down
 - The `between` operator creates a date range picker — the most common use case
+- Place the date filter in a dedicated Filter Bar widget when you want time controls separated from categorical filters
 - Pair with [Select Filters](/filters/select-filter/) for multi-dimensional filtering
 
 ## Related Features

--- a/packages/docs/src/content/docs/filters/filter-scope.mdx
+++ b/packages/docs/src/content/docs/filters/filter-scope.mdx
@@ -15,6 +15,8 @@ import filter_scope_multiple_viewer from '../../../assets/screenshots/filters/fi
 
 Filter scope determines which widgets are affected when a viewer changes a filter value. By default, filters are **global** — they affect all widgets. You can narrow the scope to target specific widgets or pages.
 
+Scope is separate from Filter Bar composition. Scope controls which widgets update; the Filter Bar widget's `Shown Filters` setting controls which authored filters a specific bar displays.
+
 <ExpandAll />
 
 ## Scope Types
@@ -39,10 +41,17 @@ Limit a filter to affect only specific widgets. Useful when different sections o
   caption="Multiple filters active — each filter's scope determines which widgets update"
 />
 
+## Scope vs. Shown Filters
+
+- **Scope** decides which widgets respond when a filter value changes.
+- **Shown Filters** on a Filter Bar widget decides which authored filters are visible in that bar.
+- These settings combine cleanly: one page can have an all-filters bar and a smaller subset bar, while each authored filter still targets only the widgets in its scope.
+
 ## Tips
 
 - Start with **global scope** — it works for most dashboards
 - Use **widget-specific scope** when you have widgets from different datasets on the same page
+- Use a second Filter Bar widget when you want viewers to see only a focused subset of the authored filters
 - Cross-filtering (click-based filtering) has its own scope rules — see [Cross-Filtering](/filters/cross-filtering/)
 
 ## Related Features

--- a/packages/docs/src/content/docs/filters/select-filter.mdx
+++ b/packages/docs/src/content/docs/filters/select-filter.mdx
@@ -16,13 +16,13 @@ import select_filter_category_viewer from '../../../assets/screenshots/filters/s
 
 # Select Filter
 
-Select filters present a dropdown list of values from a data field, letting dashboard viewers narrow down data across all (or specific) widgets. The most common filter type for categorical data.
+Select filters present a dropdown list of values from a data field, letting dashboard viewers narrow down data across all (or specific) widgets. Authors place one or more Filter Bar widgets in the layout, and each bar can show all authored filters or only a selected subset.
 
 <ExpandAll />
 
 ## Default Appearance
 
-A select filter with default settings shows a dropdown with all unique values from the bound field.
+A select filter with default settings shows a dropdown with all unique values from the bound field inside a placed Filter Bar widget.
 
 <ScreenshotComparison
   label="Default select filter"
@@ -58,8 +58,8 @@ The comparison operator: `equals` (exact match), `contains`, `in` (multiple valu
 
 <FeatureScreenshot
   src={select_filter_region_viewer}
-  alt="Filter bar with Region set to North"
-  caption="Select filter with 'equals' operator applied to Region"
+  alt="Placed filter bar widget with Region set to North"
+  caption="A placed Filter Bar widget with the Region filter set to North"
 />
 
 ### Scope
@@ -68,13 +68,18 @@ Controls which widgets are affected by this filter. See [Filter Scope](/filters/
 
 <FeatureScreenshot
   src={select_filter_category_viewer}
-  alt="Filter bar with Category filter active"
-  caption="Multiple select filters can target different fields"
+  alt="Placed filter bar widget with Category filter active"
+  caption="Select filters affect only the widgets in their configured scope"
 />
+
+### Filter Bar Placement
+
+Select filters only appear in viewer mode when a dashboard page includes at least one Filter Bar widget. Each Filter Bar can show every authored filter or a selected subset using the widget's `Shown Filters` setting.
 
 ## Tips
 
-- Place filters in a **filter bar** at the top of the dashboard
+- Add one or more **Filter Bar** widgets wherever viewers should interact with filters
+- Use the Filter Bar widget's **Shown Filters** setting to create all-filters and subset bars on the same page
 - Use select filters for fields with **a limited set of values** (regions, categories, statuses)
 - For date ranges, use a [Date Filter](/filters/date-filter/) instead
 - Filters update all widgets in their scope in real time

--- a/packages/runtime/src/components/FilterBar.tsx
+++ b/packages/runtime/src/components/FilterBar.tsx
@@ -2,7 +2,7 @@
  * FilterBar — renders dashboard-level filter controls from FilterDefinition[].
  * Uses plain HTML elements with inline styles for a clean, horizontal layout.
  */
-import { createElement, type ReactNode } from 'react';
+import { createElement, useId, type ReactNode } from 'react';
 import type { FilterDefinition, DatasetDefinition } from '@supersubset/schema';
 import { useFilters } from '../filters/FilterEngine';
 
@@ -82,6 +82,7 @@ export interface FilterBarProps {
 
 export function FilterBar({ filters, datasets, filterOptions, className }: FilterBarProps) {
   const { state, setFilter, resetAll } = useFilters();
+  const inputIdPrefix = useId();
 
   if (filters.length === 0) return null;
 
@@ -96,6 +97,7 @@ export function FilterBar({ filters, datasets, filterOptions, className }: Filte
         filter: f,
         value: state.values[f.id],
         datasets,
+        inputIdPrefix,
         options: filterOptions?.[f.id],
         onChangeValue: (value: unknown) => setFilter(f.id, value),
       }),
@@ -121,14 +123,22 @@ interface FilterControlProps {
   filter: FilterDefinition;
   value: unknown;
   datasets?: DatasetDefinition[];
+  inputIdPrefix: string;
   options?: string[];
   onChangeValue: (value: unknown) => void;
 }
 
-function FilterControl({ filter, value, datasets, options, onChangeValue }: FilterControlProps) {
+function FilterControl({
+  filter,
+  value,
+  datasets,
+  inputIdPrefix,
+  options,
+  onChangeValue,
+}: FilterControlProps) {
   const label = filter.title ?? filter.fieldRef;
   const resolvedOptions = options ?? getFieldOptions(filter, datasets);
-  const inputIdBase = `ss-filter-${filter.id}`;
+  const inputIdBase = `${inputIdPrefix}-ss-filter-${filter.id}`;
 
   return createElement(
     'div',

--- a/packages/runtime/src/components/SupersubsetRenderer.tsx
+++ b/packages/runtime/src/components/SupersubsetRenderer.tsx
@@ -7,7 +7,6 @@ import type { DashboardDefinition, PageDefinition } from '@supersubset/schema';
 import type { WidgetRegistry, WidgetEvent } from '../widgets/registry';
 import { LayoutRenderer } from '../layout/LayoutRenderer';
 import { FilterProvider, useFilters, type FilterState } from '../filters/FilterEngine';
-import { FilterBar } from './FilterBar';
 import {
   InteractionProvider,
   useInteractions,
@@ -160,7 +159,6 @@ function DashboardContent({
   const { state } = useFilters();
   const { handleWidgetEvent } = useInteractions();
   const filters = definition.filters ?? [];
-  const hasFilters = filters.length > 0;
 
   // Build active filter values list from current state
   const activeFilterValues = useMemo(
@@ -175,13 +173,6 @@ function DashboardContent({
   return createElement(
     'div',
     { className: 'ss-dashboard-content' },
-    hasFilters
-      ? createElement(FilterBar, {
-          filters,
-          datasets: definition.dataModel?.datasets,
-          filterOptions,
-        })
-      : null,
     createElement(DrillBreadcrumbBar),
     createElement(LayoutRenderer, {
       layout: page.layout,
@@ -190,6 +181,8 @@ function DashboardContent({
       registry,
       theme,
       filters,
+      datasets: definition.dataModel?.datasets,
+      filterOptions,
       activeFilterValues,
       onWidgetEvent: handleWidgetEvent,
     }),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,10 +1,18 @@
 // @supersubset/runtime — Dashboard rendering engine
 
 // Main renderer component
-export { SupersubsetRenderer, type SupersubsetRendererProps } from './components/SupersubsetRenderer';
+export {
+  SupersubsetRenderer,
+  type SupersubsetRendererProps,
+} from './components/SupersubsetRenderer';
 
 // FilterBar component
-export { FilterBar, type FilterBarProps, DATE_PRESETS, resolveRelativeDate } from './components/FilterBar';
+export {
+  FilterBar,
+  type FilterBarProps,
+  DATE_PRESETS,
+  resolveRelativeDate,
+} from './components/FilterBar';
 
 // DrillBreadcrumbBar component
 export { DrillBreadcrumbBar } from './components/DrillBreadcrumbBar';
@@ -13,6 +21,7 @@ export { DrillBreadcrumbBar } from './components/DrillBreadcrumbBar';
 export {
   WidgetRegistry,
   createWidgetRegistry,
+  getBuiltInWidgetEntries,
   type WidgetProps,
   type WidgetEvent,
   type WidgetComponent,

--- a/packages/runtime/src/layout/LayoutRenderer.tsx
+++ b/packages/runtime/src/layout/LayoutRenderer.tsx
@@ -17,6 +17,7 @@ import type {
   LayoutComponentType,
   WidgetDefinition,
   FilterDefinition,
+  DatasetDefinition,
 } from '@supersubset/schema';
 import type { WidgetRegistry, WidgetProps, WidgetEvent } from '../widgets/registry';
 import type { FilterValue } from '../filters/FilterEngine';
@@ -33,6 +34,8 @@ export interface LayoutRendererProps {
   registry: WidgetRegistry;
   theme?: Record<string, unknown>;
   filters?: FilterDefinition[];
+  datasets?: DatasetDefinition[];
+  filterOptions?: Record<string, string[]>;
   activeFilterValues?: FilterValue[];
   onWidgetEvent?: (event: WidgetEvent) => void;
   className?: string;
@@ -47,6 +50,8 @@ export function LayoutRenderer({
   registry,
   theme,
   filters,
+  datasets,
+  filterOptions,
   activeFilterValues,
   onWidgetEvent,
   className,
@@ -66,6 +71,8 @@ export function LayoutRenderer({
       registry,
       theme,
       filters,
+      datasets,
+      filterOptions,
       activeFilterValues,
       onWidgetEvent,
       new Set([rootNodeId]),
@@ -83,6 +90,8 @@ function renderChildren(
   registry: WidgetRegistry,
   theme: Record<string, unknown> | undefined,
   filters: FilterDefinition[] | undefined,
+  datasets: DatasetDefinition[] | undefined,
+  filterOptions: Record<string, string[]> | undefined,
   activeFilterValues: FilterValue[] | undefined,
   onWidgetEvent: ((event: WidgetEvent) => void) | undefined,
   visited: Set<string>,
@@ -116,6 +125,8 @@ function renderChildren(
       registry,
       theme,
       filters,
+      datasets,
+      filterOptions,
       activeFilterValues,
       onWidgetEvent,
       nextVisited,
@@ -131,6 +142,8 @@ function renderNode(
   registry: WidgetRegistry,
   theme: Record<string, unknown> | undefined,
   filters: FilterDefinition[] | undefined,
+  datasets: DatasetDefinition[] | undefined,
+  filterOptions: Record<string, string[]> | undefined,
   activeFilterValues: FilterValue[] | undefined,
   onWidgetEvent: ((event: WidgetEvent) => void) | undefined,
   visited: Set<string>,
@@ -147,6 +160,8 @@ function renderNode(
     registry,
     theme,
     filters,
+    datasets,
+    filterOptions,
     activeFilterValues,
     onWidgetEvent,
     visited,
@@ -163,6 +178,8 @@ type NodeRenderer = (
   registry: WidgetRegistry,
   theme: Record<string, unknown> | undefined,
   filters: FilterDefinition[] | undefined,
+  datasets: DatasetDefinition[] | undefined,
+  filterOptions: Record<string, string[]> | undefined,
   activeFilterValues: FilterValue[] | undefined,
   onWidgetEvent: ((event: WidgetEvent) => void) | undefined,
   visited: Set<string>,
@@ -189,6 +206,8 @@ function renderGrid(
   registry: WidgetRegistry,
   theme: Record<string, unknown> | undefined,
   filters: FilterDefinition[] | undefined,
+  datasets: DatasetDefinition[] | undefined,
+  filterOptions: Record<string, string[]> | undefined,
   activeFilterValues: FilterValue[] | undefined,
   onWidgetEvent: ((event: WidgetEvent) => void) | undefined,
   visited: Set<string>,
@@ -210,6 +229,8 @@ function renderGrid(
       registry,
       theme,
       filters,
+      datasets,
+      filterOptions,
       activeFilterValues,
       onWidgetEvent,
       visited,
@@ -225,6 +246,8 @@ function renderRow(
   registry: WidgetRegistry,
   theme: Record<string, unknown> | undefined,
   filters: FilterDefinition[] | undefined,
+  datasets: DatasetDefinition[] | undefined,
+  filterOptions: Record<string, string[]> | undefined,
   activeFilterValues: FilterValue[] | undefined,
   onWidgetEvent: ((event: WidgetEvent) => void) | undefined,
   visited: Set<string>,
@@ -246,6 +269,8 @@ function renderRow(
       registry,
       theme,
       filters,
+      datasets,
+      filterOptions,
       activeFilterValues,
       onWidgetEvent,
       visited,
@@ -275,6 +300,8 @@ function renderColumn(
   registry: WidgetRegistry,
   theme: Record<string, unknown> | undefined,
   filters: FilterDefinition[] | undefined,
+  datasets: DatasetDefinition[] | undefined,
+  filterOptions: Record<string, string[]> | undefined,
   activeFilterValues: FilterValue[] | undefined,
   onWidgetEvent: ((event: WidgetEvent) => void) | undefined,
   visited: Set<string>,
@@ -295,6 +322,8 @@ function renderColumn(
       registry,
       theme,
       filters,
+      datasets,
+      filterOptions,
       activeFilterValues,
       onWidgetEvent,
       visited,
@@ -310,6 +339,8 @@ function renderWidget(
   registry: WidgetRegistry,
   theme: Record<string, unknown> | undefined,
   filters: FilterDefinition[] | undefined,
+  datasets: DatasetDefinition[] | undefined,
+  filterOptions: Record<string, string[]> | undefined,
   activeFilterValues: FilterValue[] | undefined,
   onWidgetEvent: ((event: WidgetEvent) => void) | undefined,
   _visited: Set<string>,
@@ -356,6 +387,9 @@ function renderWidget(
     config: mergedConfig,
     theme,
     activeFilters: widgetActiveFilters.length > 0 ? widgetActiveFilters : undefined,
+    dashboardFilters: filters,
+    datasets,
+    filterOptions,
     onEvent: onWidgetEvent,
   };
 
@@ -406,6 +440,8 @@ function renderTabs(
   registry: WidgetRegistry,
   theme: Record<string, unknown> | undefined,
   filters: FilterDefinition[] | undefined,
+  datasets: DatasetDefinition[] | undefined,
+  filterOptions: Record<string, string[]> | undefined,
   activeFilterValues: FilterValue[] | undefined,
   onWidgetEvent: ((event: WidgetEvent) => void) | undefined,
   visited: Set<string>,
@@ -419,6 +455,8 @@ function renderTabs(
     registry,
     theme,
     filters,
+    datasets,
+    filterOptions,
     activeFilterValues,
     onWidgetEvent,
     visited,
@@ -436,6 +474,8 @@ function TabsContainer({
   registry,
   theme,
   filters,
+  datasets,
+  filterOptions,
   activeFilterValues,
   onWidgetEvent,
   visited,
@@ -447,6 +487,8 @@ function TabsContainer({
   registry: WidgetRegistry;
   theme?: Record<string, unknown>;
   filters?: FilterDefinition[];
+  datasets?: DatasetDefinition[];
+  filterOptions?: Record<string, string[]>;
   activeFilterValues?: FilterValue[];
   onWidgetEvent?: (event: WidgetEvent) => void;
   visited: Set<string>;
@@ -508,6 +550,8 @@ function TabsContainer({
             registry,
             theme,
             filters,
+            datasets,
+            filterOptions,
             activeFilterValues,
             onWidgetEvent,
             visited,
@@ -525,6 +569,8 @@ function renderTab(
   registry: WidgetRegistry,
   theme: Record<string, unknown> | undefined,
   filters: FilterDefinition[] | undefined,
+  datasets: DatasetDefinition[] | undefined,
+  filterOptions: Record<string, string[]> | undefined,
   activeFilterValues: FilterValue[] | undefined,
   onWidgetEvent: ((event: WidgetEvent) => void) | undefined,
   visited: Set<string>,
@@ -541,6 +587,8 @@ function renderTab(
       registry,
       theme,
       filters,
+      datasets,
+      filterOptions,
       activeFilterValues,
       onWidgetEvent,
       visited,
@@ -556,6 +604,8 @@ function renderSpacer(
   _registry: WidgetRegistry,
   _theme: Record<string, unknown> | undefined,
   _filters: FilterDefinition[] | undefined,
+  _datasets: DatasetDefinition[] | undefined,
+  _filterOptions: Record<string, string[]> | undefined,
   _activeFilterValues: FilterValue[] | undefined,
   _onWidgetEvent: ((event: WidgetEvent) => void) | undefined,
   _visited: Set<string>,
@@ -579,6 +629,8 @@ function renderHeader(
   _registry: WidgetRegistry,
   _theme: Record<string, unknown> | undefined,
   _filters: FilterDefinition[] | undefined,
+  _datasets: DatasetDefinition[] | undefined,
+  _filterOptions: Record<string, string[]> | undefined,
   _activeFilterValues: FilterValue[] | undefined,
   _onWidgetEvent: ((event: WidgetEvent) => void) | undefined,
   _visited: Set<string>,
@@ -603,6 +655,8 @@ function renderDivider(
   _registry: WidgetRegistry,
   _theme: Record<string, unknown> | undefined,
   _filters: FilterDefinition[] | undefined,
+  _datasets: DatasetDefinition[] | undefined,
+  _filterOptions: Record<string, string[]> | undefined,
   _activeFilterValues: FilterValue[] | undefined,
   _onWidgetEvent: ((event: WidgetEvent) => void) | undefined,
   _visited: Set<string>,

--- a/packages/runtime/src/widgets/FilterBarWidget.tsx
+++ b/packages/runtime/src/widgets/FilterBarWidget.tsx
@@ -1,0 +1,43 @@
+import { createElement } from 'react';
+import type { FilterDefinition } from '@supersubset/schema';
+import { FilterBar } from '../components/FilterBar';
+import type { WidgetProps } from './registry';
+
+function resolveWidgetFilters(
+  dashboardFilters: FilterDefinition[] | undefined,
+  config: Record<string, unknown>,
+): FilterDefinition[] {
+  if (!dashboardFilters || dashboardFilters.length === 0) {
+    return [];
+  }
+
+  const rawFilterIds = config.filterIds;
+  const filterIds = Array.isArray(rawFilterIds)
+    ? rawFilterIds.filter((value): value is string => typeof value === 'string')
+    : undefined;
+
+  if (filterIds === undefined) {
+    return dashboardFilters;
+  }
+
+  if (filterIds.length === 0) {
+    return [];
+  }
+
+  const selectedIds = new Set(filterIds);
+  return dashboardFilters.filter((filter) => selectedIds.has(filter.id));
+}
+
+export function FilterBarWidget({
+  config,
+  dashboardFilters,
+  datasets,
+  filterOptions,
+}: WidgetProps) {
+  return createElement(FilterBar, {
+    filters: resolveWidgetFilters(dashboardFilters, config),
+    datasets,
+    filterOptions,
+    className: 'ss-widget-filter-bar',
+  });
+}

--- a/packages/runtime/src/widgets/registry.ts
+++ b/packages/runtime/src/widgets/registry.ts
@@ -3,7 +3,9 @@
  * Chart packages register their components here; the runtime looks them up by type string.
  */
 import type { ComponentType } from 'react';
+import type { DatasetDefinition, FilterDefinition } from '@supersubset/schema';
 import type { FilterValue } from '../filters/FilterEngine';
+import { FilterBarWidget } from './FilterBarWidget';
 
 /**
  * Props passed to every widget component by the runtime.
@@ -30,6 +32,12 @@ export interface WidgetProps {
   error?: Error | null;
   /** Active filters that apply to this widget */
   activeFilters?: FilterValue[];
+  /** Authored dashboard filters available to built-in control widgets */
+  dashboardFilters?: FilterDefinition[];
+  /** Inline dataset metadata referenced by control widgets */
+  datasets?: DatasetDefinition[];
+  /** Static option values for authored filters */
+  filterOptions?: Record<string, string[]>;
   /** Callback for widget interactions (click, hover, etc.) */
   onEvent?: (event: WidgetEvent) => void;
 }
@@ -42,22 +50,28 @@ export interface WidgetEvent {
 
 export type WidgetComponent = ComponentType<WidgetProps>;
 
+export function getBuiltInWidgetEntries(): Array<[string, WidgetComponent]> {
+  return [['filter-bar', FilterBarWidget]];
+}
+
 /**
  * Widget registry — maps widget type strings to React components.
  */
 export class WidgetRegistry {
   private widgets = new Map<string, WidgetComponent>();
 
+  constructor(private readonly builtInWidgets = new Map<string, WidgetComponent>()) {}
+
   register(type: string, component: WidgetComponent): void {
     this.widgets.set(type, component);
   }
 
   get(type: string): WidgetComponent | undefined {
-    return this.widgets.get(type);
+    return this.widgets.get(type) ?? this.builtInWidgets.get(type);
   }
 
   has(type: string): boolean {
-    return this.widgets.has(type);
+    return this.widgets.has(type) || this.builtInWidgets.has(type);
   }
 
   getRegisteredTypes(): string[] {
@@ -72,10 +86,8 @@ export class WidgetRegistry {
 /**
  * Create a new WidgetRegistry, optionally pre-populated with widgets.
  */
-export function createWidgetRegistry(
-  entries?: Array<[string, WidgetComponent]>
-): WidgetRegistry {
-  const registry = new WidgetRegistry();
+export function createWidgetRegistry(entries?: Array<[string, WidgetComponent]>): WidgetRegistry {
+  const registry = new WidgetRegistry(new Map(getBuiltInWidgetEntries()));
   if (entries) {
     for (const [type, component] of entries) {
       registry.register(type, component);

--- a/packages/runtime/test/filter-bar-widget.test.tsx
+++ b/packages/runtime/test/filter-bar-widget.test.tsx
@@ -1,0 +1,180 @@
+import { createElement } from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { DashboardDefinition } from '@supersubset/schema';
+import { SupersubsetRenderer } from '../src/components/SupersubsetRenderer';
+import { createWidgetRegistry, type WidgetProps } from '../src/widgets/registry';
+
+function SummaryWidget({ title }: WidgetProps) {
+  return createElement('div', null, title ?? 'Summary');
+}
+
+const baseFilters: NonNullable<DashboardDefinition['filters']> = [
+  {
+    id: 'region',
+    title: 'Region',
+    type: 'select',
+    fieldRef: 'orders.region',
+    datasetRef: 'orders',
+    operator: 'equals',
+    scope: { type: 'global' },
+  },
+  {
+    id: 'status',
+    title: 'Status',
+    type: 'select',
+    fieldRef: 'orders.status',
+    datasetRef: 'orders',
+    operator: 'equals',
+    scope: { type: 'widgets', widgetIds: ['summary-1'] },
+  },
+];
+
+const baseDataModel: DashboardDefinition['dataModel'] = {
+  type: 'inline',
+  datasets: [
+    {
+      id: 'orders',
+      label: 'Orders',
+      fields: [
+        { id: 'region', label: 'Region', dataType: 'string' },
+        { id: 'status', label: 'Status', dataType: 'string' },
+      ],
+    },
+  ],
+};
+
+const baseFilterOptions = {
+  region: ['East', 'West'],
+  status: ['Open', 'Closed'],
+};
+
+const noFallbackDashboard: DashboardDefinition = {
+  schemaVersion: '0.2.0',
+  id: 'no-fallback-dashboard',
+  title: 'No Fallback Dashboard',
+  filters: baseFilters,
+  dataModel: baseDataModel,
+  pages: [
+    {
+      id: 'overview',
+      title: 'Overview',
+      rootNodeId: 'root',
+      layout: {
+        root: { id: 'root', type: 'root', children: ['grid'], meta: {} },
+        grid: { id: 'grid', type: 'grid', children: ['summary-node'], parentId: 'root', meta: {} },
+        'summary-node': {
+          id: 'summary-node',
+          type: 'widget',
+          children: [],
+          parentId: 'grid',
+          meta: { widgetRef: 'summary-1', width: 12 },
+        },
+      },
+      widgets: [
+        {
+          id: 'summary-1',
+          type: 'summary-widget',
+          title: 'Summary',
+          config: {},
+        },
+      ],
+    },
+  ],
+};
+
+const subsetDashboard: DashboardDefinition = {
+  schemaVersion: '0.2.0',
+  id: 'subset-dashboard',
+  title: 'Subset Dashboard',
+  filters: baseFilters,
+  dataModel: baseDataModel,
+  pages: [
+    {
+      id: 'overview',
+      title: 'Overview',
+      rootNodeId: 'root',
+      layout: {
+        root: { id: 'root', type: 'root', children: ['grid'], meta: {} },
+        grid: {
+          id: 'grid',
+          type: 'grid',
+          children: ['filters-region-node', 'filters-all-node'],
+          parentId: 'root',
+          meta: {},
+        },
+        'filters-region-node': {
+          id: 'filters-region-node',
+          type: 'widget',
+          children: [],
+          parentId: 'grid',
+          meta: { widgetRef: 'filters-region', width: 12 },
+        },
+        'filters-all-node': {
+          id: 'filters-all-node',
+          type: 'widget',
+          children: [],
+          parentId: 'grid',
+          meta: { widgetRef: 'filters-all', width: 12 },
+        },
+      },
+      widgets: [
+        {
+          id: 'filters-region',
+          type: 'filter-bar',
+          title: 'Region Filters',
+          config: { filterIds: ['region', 'missing-filter-id'] },
+        },
+        {
+          id: 'filters-all',
+          type: 'filter-bar',
+          title: 'All Filters',
+          config: {},
+        },
+      ],
+    },
+  ],
+};
+
+describe('filter-bar runtime widget', () => {
+  it('does not render a shell-level filter bar when filters exist but no filter-bar widget is placed', () => {
+    const registry = createWidgetRegistry([['summary-widget', SummaryWidget]]);
+    const { container } = render(
+      createElement(SupersubsetRenderer, {
+        definition: noFallbackDashboard,
+        registry,
+        filterOptions: baseFilterOptions,
+      }),
+    );
+
+    expect(screen.getByText('Summary')).toBeTruthy();
+    expect(container.querySelector('.ss-filter-bar')).toBeNull();
+  });
+
+  it('renders placed filter-bar widgets with per-widget subsets that share one filter store', () => {
+    const { container } = render(
+      createElement(SupersubsetRenderer, {
+        definition: subsetDashboard,
+        registry: createWidgetRegistry(),
+        filterOptions: baseFilterOptions,
+      }),
+    );
+
+    const bars = Array.from(container.querySelectorAll('.ss-filter-bar')) as HTMLElement[];
+
+    expect(bars).toHaveLength(2);
+    expect(container.querySelector('.ss-widget-unregistered')).toBeNull();
+    expect(within(bars[0]).getByLabelText('Region')).toBeTruthy();
+    expect(within(bars[0]).queryByLabelText('Status')).toBeNull();
+    expect(within(bars[1]).getByLabelText('Region')).toBeTruthy();
+    expect(within(bars[1]).getByLabelText('Status')).toBeTruthy();
+
+    const regionSelectA = within(bars[0]).getByLabelText('Region') as HTMLSelectElement;
+    const regionSelectB = within(bars[1]).getByLabelText('Region') as HTMLSelectElement;
+
+    fireEvent.change(regionSelectA, { target: { value: 'West' } });
+
+    expect(regionSelectA.value).toBe('West');
+    expect(regionSelectB.value).toBe('West');
+  });
+});

--- a/packages/runtime/test/filter-bar.test.tsx
+++ b/packages/runtime/test/filter-bar.test.tsx
@@ -148,10 +148,11 @@ describe('FilterBar', () => {
     const { container } = renderFilterBar([selectFilter]);
     const label = container.querySelector('.ss-filter-label');
     const select = container.querySelector('.ss-filter-select');
+    const selectId = select?.getAttribute('id');
     expect(label).toBeTruthy();
     expect(label?.textContent).toBe('Status');
-    expect(label?.getAttribute('for')).toBe('ss-filter-f-status-primary');
-    expect(select?.getAttribute('id')).toBe('ss-filter-f-status-primary');
+    expect(label?.getAttribute('for')).toBe(selectId);
+    expect(selectId).toContain('ss-filter-f-status-primary');
     expect(select?.getAttribute('name')).toBe('f-status');
   });
 
@@ -169,7 +170,7 @@ describe('FilterBar', () => {
   it('adds names to date inputs for form and accessibility tooling', () => {
     const { container } = renderFilterBar([dateFilter]);
     const preset = container.querySelector('.ss-filter-date-preset');
-    expect(preset?.getAttribute('id')).toBe('ss-filter-f-date-primary');
+    expect(preset?.getAttribute('id')).toContain('ss-filter-f-date-primary');
     expect(preset?.getAttribute('name')).toBe('f-date-preset');
   });
 });

--- a/packages/runtime/test/registry.test.ts
+++ b/packages/runtime/test/registry.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { WidgetRegistry, createWidgetRegistry } from '../src/widgets/registry';
+import {
+  WidgetRegistry,
+  createWidgetRegistry,
+  getBuiltInWidgetEntries,
+} from '../src/widgets/registry';
 import type { WidgetProps } from '../src/widgets/registry';
 
 // Simple mock widgets for testing
@@ -50,9 +54,11 @@ describe('WidgetRegistry', () => {
 });
 
 describe('createWidgetRegistry', () => {
-  it('creates an empty registry', () => {
+  it('preserves an empty explicit registry while exposing built-in widgets', () => {
     const registry = createWidgetRegistry();
     expect(registry.getRegisteredTypes()).toEqual([]);
+    expect(registry.has('filter-bar')).toBe(true);
+    expect(registry.get('filter-bar')).toBeDefined();
   });
 
   it('creates a pre-populated registry', () => {
@@ -63,5 +69,16 @@ describe('createWidgetRegistry', () => {
     expect(registry.has('line-chart')).toBe(true);
     expect(registry.has('bar-chart')).toBe(true);
     expect(registry.getRegisteredTypes()).toHaveLength(2);
+  });
+
+  it('lets explicit registrations override built-in widgets', () => {
+    const registry = createWidgetRegistry([['filter-bar', MockBar]]);
+
+    expect(registry.get('filter-bar')).toBe(MockBar);
+    expect(registry.getRegisteredTypes()).toEqual(['filter-bar']);
+  });
+
+  it('exports the built-in widget helper entries', () => {
+    expect(getBuiltInWidgetEntries().map(([type]) => type)).toContain('filter-bar');
   });
 });


### PR DESCRIPTION
## Summary

Closes #99.

This changes dashboard filters from an implicit shell-level bar to explicit, placeable `filter-bar` widgets.

- add built-in runtime support for `filter-bar` widgets and remove the old shell fallback bar
- allow multiple filter-bar widgets to share filter state while showing different authored-filter subsets via `config.filterIds`
- add designer-side `Shown Filters` authoring for `FilterBarBlock` and align filter control types with runtime-supported values
- update the dev-app demo fixture and focused browser regressions for the widget-only contract
- update filter docs to explain placement, subset bars, and the difference between filter scope and filter-bar composition

## Validation

Focused feature validation passed:
- `pnpm --filter @supersubset/runtime exec vitest run test/filter-bar.test.tsx test/filter-bar-widget.test.tsx test/registry.test.ts`
- `pnpm --filter @supersubset/designer exec vitest run test/config.test.ts test/integration.test.ts test/adapter-comprehensive.test.ts test/feature-panels-2.test.tsx`
- `pnpm --filter @supersubset/runtime typecheck`
- `pnpm --filter @supersubset/designer typecheck`
- `pnpm --filter @supersubset/runtime lint`
- `pnpm --filter @supersubset/designer lint`
- `pnpm --filter @supersubset/dev-app exec vitest run src/demo-dashboard.test.ts`
- `pnpm --filter @supersubset/docs build`
- `SUPERSUBSET_DEV_APP_PORT=3010 SUPERSUBSET_EXAMPLE_NEXTJS_PORT=3011 SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT=3012 pnpm exec playwright test --config playwright.e2e.config.ts e2e/interactions/dashboard-filter.spec.ts --project chromium`

Workspace-wide validation passed after refreshing stale local workspace links with `pnpm install`:
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

## Notes

- Local parallel-safe ports used during validation:
  - `SUPERSUBSET_DEV_APP_PORT=3010`
  - `SUPERSUBSET_EXAMPLE_NEXTJS_PORT=3011`
  - `SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT=3012`
- Targeted Snyk scans could not complete from this environment because the local auth/API path failed.
