### PR TITLE
fix: restore treemap preview variants

### DIFF
--- a/packages/charts-echarts/src/base/shared-options.ts
+++ b/packages/charts-echarts/src/base/shared-options.ts
@@ -28,36 +28,100 @@
 
 const PALETTES: Record<string, string[]> = {
   supersetColors: [
-    '#1FA8C9', '#454E7C', '#5AC189', '#FF7F44', '#666666',
-    '#E04355', '#FCC700', '#A868B7', '#3CCCCB', '#A38F79',
+    '#1FA8C9',
+    '#454E7C',
+    '#5AC189',
+    '#FF7F44',
+    '#666666',
+    '#E04355',
+    '#FCC700',
+    '#A868B7',
+    '#3CCCCB',
+    '#A38F79',
   ],
   d3Category10: [
-    '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
-    '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf',
+    '#1f77b4',
+    '#ff7f0e',
+    '#2ca02c',
+    '#d62728',
+    '#9467bd',
+    '#8c564b',
+    '#e377c2',
+    '#7f7f7f',
+    '#bcbd22',
+    '#17becf',
   ],
   google10: [
-    '#3366CC', '#DC3912', '#FF9900', '#109618', '#990099',
-    '#0099C6', '#DD4477', '#66AA00', '#B82E2E', '#316395',
+    '#3366CC',
+    '#DC3912',
+    '#FF9900',
+    '#109618',
+    '#990099',
+    '#0099C6',
+    '#DD4477',
+    '#66AA00',
+    '#B82E2E',
+    '#316395',
   ],
   tableau10: [
-    '#4E79A7', '#F28E2B', '#E15759', '#76B7B2', '#59A14F',
-    '#EDC948', '#B07AA1', '#FF9DA7', '#9C755F', '#BAB0AC',
+    '#4E79A7',
+    '#F28E2B',
+    '#E15759',
+    '#76B7B2',
+    '#59A14F',
+    '#EDC948',
+    '#B07AA1',
+    '#FF9DA7',
+    '#9C755F',
+    '#BAB0AC',
   ],
   pastel: [
-    '#AEC7E8', '#FFBB78', '#98DF8A', '#FF9896', '#C5B0D5',
-    '#C49C94', '#F7B6D2', '#C7C7C7', '#DBDB8D', '#9EDAE5',
+    '#AEC7E8',
+    '#FFBB78',
+    '#98DF8A',
+    '#FF9896',
+    '#C5B0D5',
+    '#C49C94',
+    '#F7B6D2',
+    '#C7C7C7',
+    '#DBDB8D',
+    '#9EDAE5',
   ],
   dark: [
-    '#1B9E77', '#D95F02', '#7570B3', '#E7298A', '#66A61E',
-    '#E6AB02', '#A6761D', '#666666', '#1D91C0', '#AE017E',
+    '#1B9E77',
+    '#D95F02',
+    '#7570B3',
+    '#E7298A',
+    '#66A61E',
+    '#E6AB02',
+    '#A6761D',
+    '#666666',
+    '#1D91C0',
+    '#AE017E',
   ],
   warm: [
-    '#FE4A49', '#FED766', '#F77F00', '#E36414', '#9A031E',
-    '#D00000', '#DC2F02', '#E85D04', '#FAA307', '#FFBA08',
+    '#FE4A49',
+    '#FED766',
+    '#F77F00',
+    '#E36414',
+    '#9A031E',
+    '#D00000',
+    '#DC2F02',
+    '#E85D04',
+    '#FAA307',
+    '#FFBA08',
   ],
   cool: [
-    '#264653', '#2A9D8F', '#E9C46A', '#F4A261', '#E76F51',
-    '#023E8A', '#0077B6', '#0096C7', '#00B4D8', '#48CAE4',
+    '#264653',
+    '#2A9D8F',
+    '#E9C46A',
+    '#F4A261',
+    '#E76F51',
+    '#023E8A',
+    '#0077B6',
+    '#0096C7',
+    '#00B4D8',
+    '#48CAE4',
   ],
 };
 
@@ -96,16 +160,32 @@ export interface SharedConfig {
   zoomable?: boolean;
 }
 
+function toOptionalBoolean(value: unknown): boolean | undefined {
+  if (value === true || value === false) {
+    return value;
+  }
+
+  if (value === 'true') {
+    return true;
+  }
+
+  if (value === 'false') {
+    return false;
+  }
+
+  return undefined;
+}
+
 /**
  * Extract shared config from generic WidgetProps config record.
  */
 export function extractSharedConfig(config: Record<string, unknown>): SharedConfig {
   return {
     colorScheme: config.colorScheme as string | undefined,
-    showLegend: config.showLegend as boolean | undefined,
+    showLegend: toOptionalBoolean(config.showLegend),
     legendPosition: config.legendPosition as SharedConfig['legendPosition'],
     legendType: config.legendType as SharedConfig['legendType'],
-    showValues: config.showValues as boolean | undefined,
+    showValues: toOptionalBoolean(config.showValues),
     numberFormat: config.numberFormat as string | undefined,
     tooltipTrigger: config.tooltipTrigger as SharedConfig['tooltipTrigger'],
     xAxisTitle: config.xAxisTitle as string | undefined,
@@ -113,8 +193,8 @@ export function extractSharedConfig(config: Record<string, unknown>): SharedConf
     xAxisLabelRotate: config.xAxisLabelRotate as number | undefined,
     yAxisMin: config.yAxisMin as number | null | undefined,
     yAxisMax: config.yAxisMax as number | null | undefined,
-    logAxis: config.logAxis as boolean | undefined,
-    zoomable: config.zoomable as boolean | undefined,
+    logAxis: toOptionalBoolean(config.logAxis),
+    zoomable: toOptionalBoolean(config.zoomable),
   };
 }
 
@@ -192,7 +272,7 @@ export function buildLegendOption(
  */
 export function buildTooltipOption(
   shared: SharedConfig,
-  defaultTrigger: 'axis' | 'item' = 'axis'
+  defaultTrigger: 'axis' | 'item' = 'axis',
 ): Record<string, unknown> | undefined {
   const trigger = shared.tooltipTrigger ?? defaultTrigger;
   if (trigger === 'none') return { show: false };
@@ -205,7 +285,7 @@ export function buildTooltipOption(
  */
 export function buildGridOption(
   shared: SharedConfig,
-  layout?: { hasTitle?: boolean; hasLegend?: boolean }
+  layout?: { hasTitle?: boolean; hasLegend?: boolean },
 ): Record<string, unknown> {
   const grid: Record<string, unknown> = {
     left: '3%',
@@ -232,9 +312,7 @@ export function buildGridOption(
 
   // Extra bottom space for data zoom
   if (shared.zoomable) {
-    grid.bottom = typeof grid.bottom === 'number'
-      ? (grid.bottom as number) + 40
-      : '12%';
+    grid.bottom = typeof grid.bottom === 'number' ? (grid.bottom as number) + 40 : '12%';
   }
 
   return grid;
@@ -246,7 +324,7 @@ export function buildGridOption(
 export function buildCategoryAxisOption(
   shared: SharedConfig,
   categoryData: string[],
-  axis: 'x' | 'y' = 'x'
+  axis: 'x' | 'y' = 'x',
 ): Record<string, unknown> {
   const axisOpt: Record<string, unknown> = {
     type: 'category',
@@ -268,7 +346,7 @@ export function buildCategoryAxisOption(
  */
 export function buildValueAxisOption(
   shared: SharedConfig,
-  axis: 'x' | 'y' = 'y'
+  axis: 'x' | 'y' = 'y',
 ): Record<string, unknown> {
   const axisOpt: Record<string, unknown> = {
     type: shared.logAxis && axis === 'y' ? 'log' : 'value',
@@ -293,7 +371,7 @@ export function buildValueAxisOption(
  * Build data zoom option for slider-based zoom.
  */
 export function buildDataZoomOption(
-  shared: SharedConfig
+  shared: SharedConfig,
 ): Array<Record<string, unknown>> | undefined {
   if (!shared.zoomable) return undefined;
   return [
@@ -305,9 +383,7 @@ export function buildDataZoomOption(
 /**
  * Build label option for showing values on data points.
  */
-export function buildLabelOption(
-  shared: SharedConfig
-): Record<string, unknown> | undefined {
+export function buildLabelOption(shared: SharedConfig): Record<string, unknown> | undefined {
   if (!shared.showValues) return undefined;
   const label: Record<string, unknown> = {
     show: true,
@@ -315,9 +391,12 @@ export function buildLabelOption(
   };
   if (shared.numberFormat) {
     label.formatter = (params: { value: unknown }) => {
-      const v = typeof params.value === 'number' ? params.value
-        : Array.isArray(params.value) ? Number(params.value[1] ?? 0)
-        : Number(params.value ?? 0);
+      const v =
+        typeof params.value === 'number'
+          ? params.value
+          : Array.isArray(params.value)
+            ? Number(params.value[1] ?? 0)
+            : Number(params.value ?? 0);
       return formatNumber(v, shared.numberFormat!);
     };
   }

--- a/packages/charts-echarts/src/charts/TreemapWidget.tsx
+++ b/packages/charts-echarts/src/charts/TreemapWidget.tsx
@@ -32,6 +32,10 @@ export function TreemapWidget({ config, data, columns, title, height, theme }: W
     const borderWidth = (config.borderWidth as number) ?? 0;
     const shared = extractSharedConfig(config);
     const fmt = shared.numberFormat;
+    const labelFormatter = (params: { name: string; value: number }) => {
+      const formattedValue = fmt ? formatNumber(params.value, fmt) : String(params.value);
+      return `${params.name}\n${formattedValue}`;
+    };
 
     let treeData: Array<{
       name: string;
@@ -95,10 +99,7 @@ export function TreemapWidget({ config, data, columns, title, height, theme }: W
           upperLabel: { show: showUpperLabel },
           label: {
             show: shared.showValues !== false,
-            formatter: fmt
-              ? (params: { name: string; value: number }) =>
-                  `${params.name}\n${formatNumber(params.value, fmt)}`
-              : '{b}',
+            formatter: labelFormatter,
           },
           breadcrumb: { show: true },
           ...(maxDepth > 0 ? { leafDepth: maxDepth } : {}),

--- a/packages/charts-echarts/test/per-chart-properties.test.tsx
+++ b/packages/charts-echarts/test/per-chart-properties.test.tsx
@@ -1025,6 +1025,70 @@ describe('TreemapWidget — per-chart properties', () => {
     expect(upper.show).toBe(false);
   });
 
+  it('showValues=true formats treemap labels with raw values when no number format is set', () => {
+    render(
+      <TreemapWidget
+        {...makeProps({
+          config: { nameField: 'name', valueField: 'value', showValues: true },
+          data: sampleTreemapData,
+        })}
+      />,
+    );
+
+    const label = getSeries().label as {
+      show: boolean;
+      formatter: (params: { name: string; value: number }) => string;
+    };
+    expect(label.show).toBe(true);
+    expect(label.formatter({ name: 'A', value: 100 })).toBe('A\n100');
+  });
+
+  it('showValues="true" from the designer still enables treemap labels', () => {
+    render(
+      <TreemapWidget
+        {...makeProps({
+          config: { nameField: 'name', valueField: 'value', showValues: 'true' },
+          data: sampleTreemapData,
+        })}
+      />,
+    );
+
+    const label = getSeries().label as {
+      show: boolean;
+      formatter: (params: { name: string; value: number }) => string;
+    };
+    expect(label.show).toBe(true);
+    expect(label.formatter({ name: 'A', value: 100 })).toBe('A\n100');
+  });
+
+  it('showValues=false hides treemap labels', () => {
+    render(
+      <TreemapWidget
+        {...makeProps({
+          config: { nameField: 'name', valueField: 'value', showValues: false },
+          data: sampleTreemapData,
+        })}
+      />,
+    );
+
+    const label = getSeries().label as Record<string, unknown>;
+    expect(label.show).toBe(false);
+  });
+
+  it('showValues="false" from the designer hides treemap labels', () => {
+    render(
+      <TreemapWidget
+        {...makeProps({
+          config: { nameField: 'name', valueField: 'value', showValues: 'false' },
+          data: sampleTreemapData,
+        })}
+      />,
+    );
+
+    const label = getSeries().label as Record<string, unknown>;
+    expect(label.show).toBe(false);
+  });
+
   it('maxDepth limits tree depth', () => {
     render(
       <TreemapWidget

--- a/packages/designer/src/preview/ChartPreview.tsx
+++ b/packages/designer/src/preview/ChartPreview.tsx
@@ -334,6 +334,7 @@ function buildWidgetConfig(
   if (s(puckProps.aggregation)) config.aggregation = puckProps.aggregation;
   if (s(puckProps.nameField)) config.nameField = puckProps.nameField;
   if (s(puckProps.parentField)) config.parentField = puckProps.parentField;
+  else if (widgetType === 'treemap') delete config.parentField;
   if (s(puckProps.sourceField)) config.sourceField = puckProps.sourceField;
   if (s(puckProps.targetField)) config.targetField = puckProps.targetField;
   if (s(puckProps.barField)) config.barFields = [puckProps.barField as string];

--- a/packages/designer/test/chart-preview-properties.test.tsx
+++ b/packages/designer/test/chart-preview-properties.test.tsx
@@ -15,26 +15,42 @@ import { render } from '@testing-library/react';
 const mockChartWidget = vi.fn((props: Record<string, unknown>) =>
   React.createElement('div', {
     'data-testid': `chart-${props.widgetType}`,
-  })
+  }),
 );
 
 vi.mock('@supersubset/charts-echarts', () => ({
-  LineChartWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'line-chart' }),
-  BarChartWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'bar-chart' }),
-  PieChartWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'pie-chart' }),
-  ScatterChartWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'scatter-chart' }),
-  AreaChartWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'area-chart' }),
-  ComboChartWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'combo-chart' }),
-  HeatmapWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'heatmap' }),
-  RadarChartWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'radar-chart' }),
-  FunnelChartWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'funnel-chart' }),
-  TreemapWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'treemap' }),
-  SankeyWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'sankey' }),
-  WaterfallWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'waterfall' }),
-  BoxPlotWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'box-plot' }),
-  GaugeWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'gauge' }),
-  TableWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'table' }),
-  KPICardWidget: (props: Record<string, unknown>) => mockChartWidget({ ...props, widgetType: 'kpi-card' }),
+  LineChartWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'line-chart' }),
+  BarChartWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'bar-chart' }),
+  PieChartWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'pie-chart' }),
+  ScatterChartWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'scatter-chart' }),
+  AreaChartWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'area-chart' }),
+  ComboChartWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'combo-chart' }),
+  HeatmapWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'heatmap' }),
+  RadarChartWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'radar-chart' }),
+  FunnelChartWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'funnel-chart' }),
+  TreemapWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'treemap' }),
+  SankeyWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'sankey' }),
+  WaterfallWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'waterfall' }),
+  BoxPlotWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'box-plot' }),
+  GaugeWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'gauge' }),
+  TableWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'table' }),
+  KPICardWidget: (props: Record<string, unknown>) =>
+    mockChartWidget({ ...props, widgetType: 'kpi-card' }),
 }));
 
 vi.mock('@supersubset/runtime', () => ({}));
@@ -50,11 +66,13 @@ function renderPreview(widgetType: string, puckProps: Record<string, unknown>) {
       widgetType,
       puckProps: { title: 'Test', ...puckProps },
       fallbackIcon: '📊',
-    })
+    }),
   );
   expect(mockChartWidget).toHaveBeenCalled();
-  return mockChartWidget.mock.calls[mockChartWidget.mock.calls.length - 1][0]
-    .config as Record<string, unknown>;
+  return mockChartWidget.mock.calls[mockChartWidget.mock.calls.length - 1][0].config as Record<
+    string,
+    unknown
+  >;
 }
 
 /** Capture both config and data from the rendered widget */
@@ -65,7 +83,7 @@ function renderPreviewFull(widgetType: string, puckProps: Record<string, unknown
       widgetType,
       puckProps: { title: 'Test', ...puckProps },
       fallbackIcon: '📊',
-    })
+    }),
   );
   expect(mockChartWidget).toHaveBeenCalled();
   const props = mockChartWidget.mock.calls[mockChartWidget.mock.calls.length - 1][0];
@@ -434,13 +452,19 @@ describe('ChartPreview — field-change data remapping', () => {
     });
 
     it('remaps both x and y simultaneously', () => {
-      const { data } = renderPreviewFull('line-chart', { xAxisField: 'region', yAxisField: 'sales' });
+      const { data } = renderPreviewFull('line-chart', {
+        xAxisField: 'region',
+        yAxisField: 'sales',
+      });
       expect(data[0]).toHaveProperty('region');
       expect(data[0]).toHaveProperty('sales');
     });
 
     it('keeps original keys when fields match defaults', () => {
-      const { data } = renderPreviewFull('line-chart', { xAxisField: 'month', yAxisField: 'revenue' });
+      const { data } = renderPreviewFull('line-chart', {
+        xAxisField: 'month',
+        yAxisField: 'revenue',
+      });
       expect(data[0]).toHaveProperty('month');
       expect(data[0]).toHaveProperty('revenue');
     });
@@ -475,7 +499,10 @@ describe('ChartPreview — field-change data remapping', () => {
 
   describe('scatter-chart', () => {
     it('remaps xAxisField and yAxisField', () => {
-      const { data } = renderPreviewFull('scatter-chart', { xAxisField: 'quantity', yAxisField: 'amount' });
+      const { data } = renderPreviewFull('scatter-chart', {
+        xAxisField: 'quantity',
+        yAxisField: 'amount',
+      });
       expect(data[0]).toHaveProperty('quantity');
       expect(data[0]).toHaveProperty('amount');
     });
@@ -489,7 +516,10 @@ describe('ChartPreview — field-change data remapping', () => {
 
   describe('combo-chart', () => {
     it('remaps barField and lineField', () => {
-      const { config, data } = renderPreviewFull('combo-chart', { barField: 'revenue', lineField: 'margin' });
+      const { config, data } = renderPreviewFull('combo-chart', {
+        barField: 'revenue',
+        lineField: 'margin',
+      });
       expect(config.barFields).toEqual(['revenue']);
       expect(config.lineFields).toEqual(['margin']);
       expect(data[0]).toHaveProperty('revenue');
@@ -499,7 +529,11 @@ describe('ChartPreview — field-change data remapping', () => {
 
   describe('heatmap', () => {
     it('remaps all three fields', () => {
-      const { data } = renderPreviewFull('heatmap', { xAxisField: 'hour', yAxisField: 'day', valueField: 'sales' });
+      const { data } = renderPreviewFull('heatmap', {
+        xAxisField: 'hour',
+        yAxisField: 'day',
+        valueField: 'sales',
+      });
       expect(data[0]).toHaveProperty('hour');
       expect(data[0]).toHaveProperty('day');
       expect(data[0]).toHaveProperty('sales');
@@ -508,7 +542,10 @@ describe('ChartPreview — field-change data remapping', () => {
 
   describe('funnel-chart', () => {
     it('remaps categoryField and valueField', () => {
-      const { config, data } = renderPreviewFull('funnel-chart', { categoryField: 'phase', valueField: 'count' });
+      const { config, data } = renderPreviewFull('funnel-chart', {
+        categoryField: 'phase',
+        valueField: 'count',
+      });
       expect(config.nameField).toBe('phase');
       expect(data[0]).toHaveProperty('phase');
       expect(data[0]).toHaveProperty('count');
@@ -517,7 +554,10 @@ describe('ChartPreview — field-change data remapping', () => {
 
   describe('treemap', () => {
     it('remaps nameField and valueField', () => {
-      const { config, data } = renderPreviewFull('treemap', { nameField: 'category', valueField: 'amount' });
+      const { config, data } = renderPreviewFull('treemap', {
+        nameField: 'category',
+        valueField: 'amount',
+      });
       expect(config.nameField).toBe('category');
       expect(data[0]).toHaveProperty('category');
       expect(data[0]).toHaveProperty('amount');
@@ -526,7 +566,11 @@ describe('ChartPreview — field-change data remapping', () => {
 
   describe('sankey', () => {
     it('remaps all three fields', () => {
-      const { config, data } = renderPreviewFull('sankey', { sourceField: 'origin', targetField: 'destination', valueField: 'visits' });
+      const { config, data } = renderPreviewFull('sankey', {
+        sourceField: 'origin',
+        targetField: 'destination',
+        valueField: 'visits',
+      });
       expect(config.sourceField).toBe('origin');
       expect(config.targetField).toBe('destination');
       expect(data[0]).toHaveProperty('origin');
@@ -537,7 +581,10 @@ describe('ChartPreview — field-change data remapping', () => {
 
   describe('waterfall', () => {
     it('remaps categoryField and valueField', () => {
-      const { config, data } = renderPreviewFull('waterfall', { categoryField: 'item', valueField: 'amount' });
+      const { config, data } = renderPreviewFull('waterfall', {
+        categoryField: 'item',
+        valueField: 'amount',
+      });
       expect(config.categoryField).toBe('item');
       expect(data[0]).toHaveProperty('item');
       expect(data[0]).toHaveProperty('amount');
@@ -546,7 +593,10 @@ describe('ChartPreview — field-change data remapping', () => {
 
   describe('kpi-card', () => {
     it('remaps valueField and comparisonField', () => {
-      const { config, data } = renderPreviewFull('kpi-card', { valueField: 'revenue', comparisonField: 'prevRevenue' });
+      const { config, data } = renderPreviewFull('kpi-card', {
+        valueField: 'revenue',
+        comparisonField: 'prevRevenue',
+      });
       expect(config.valueField).toBe('revenue');
       expect(config.comparisonField).toBe('prevRevenue');
       expect(data[0]).toHaveProperty('revenue');
@@ -597,6 +647,11 @@ describe('ChartPreview — field config mappings', () => {
   it('maps parentField to config (treemap)', () => {
     const c = renderPreview('treemap', { parentField: 'group' });
     expect(c.parentField).toBe('group');
+  });
+
+  it('clears the default treemap parentField when the widget is authored flat', () => {
+    const c = renderPreview('treemap', { parentField: '' });
+    expect(c.parentField).toBeUndefined();
   });
 
   it('maps sourceField to config (sankey)', () => {


### PR DESCRIPTION
## Summary
- format treemap labels with raw values when show-values is enabled without a number format
- normalize string booleans from designer config so show-values false stays false
- clear the preview-only treemap parent field default when a widget is authored as a flat treemap, restoring visible docs capture variants

## Validation
- pnpm --filter @supersubset/designer exec vitest run test/chart-preview-properties.test.tsx --testNamePattern treemap
- pnpm --filter @supersubset/charts-echarts exec vitest run test/per-chart-properties.test.tsx --testNamePattern treemap
- pnpm --filter @supersubset/docs exec playwright test capture/property-variants.spec.ts --grep treemap

Closes #90