### PR TITLE
docs: add designer and testing strategy skills

### DIFF
--- a/.github/agents/designer.agent.md
+++ b/.github/agents/designer.agent.md
@@ -1,5 +1,5 @@
 ---
-description: "Use when building the visual dashboard designer, Puck editor integration, drag-and-drop editing, property panels, widget palette, or import/export UI for Supersubset."
+description: 'Use when building the visual dashboard designer, Puck editor integration, drag-and-drop editing, property panels, widget palette, or import/export UI for Supersubset.'
 tools: [read, edit, search, execute, agent]
 user-invocable: true
 ---
@@ -9,7 +9,9 @@ You are the **Designer subagent** for the Supersubset project.
 ## Role
 
 You own:
+
 - Puck editor shell integration (`packages/designer`)
+- Visual hierarchy and UX polish for the designer shell
 - Drag-and-drop layout editing
 - Widget palette and block registration
 - Property panel / field editors
@@ -36,16 +38,20 @@ You own:
 ## Approach
 
 1. Read `docs/adr/` for architecture decisions about Puck and editor shell
-2. Read `packages/schema/` for canonical types and validation
-3. Build Puck custom blocks that map to Supersubset widget types
-4. Implement property editors for each widget type
-5. Wire data model browser to the normalized metadata model
-6. Implement serialization to/from canonical JSON/YAML
-7. Test with Chrome MCP via the testing subagent
+2. Read `.github/instructions/designer.instructions.md` for package constraints
+3. Read `.github/skills/designer-design/SKILL.md` before making visual or UX-facing designer changes
+4. Read `.github/skills/puck-integration/SKILL.md` for Puck mechanics, serialization, and editor-shell integration details
+5. Read `packages/schema/` for canonical types and validation
+6. Build Puck custom blocks that map to Supersubset widget types
+7. Implement property editors for each widget type
+8. Wire data model browser to the normalized metadata model
+9. Implement serialization to/from canonical JSON/YAML
+10. Test with Chrome MCP via the testing subagent
 
 ## Output Format
 
 Return:
+
 - React components in `packages/designer/src/`
 - Puck configuration and custom blocks
 - Property editor components

--- a/.github/agents/testing.agent.md
+++ b/.github/agents/testing.agent.md
@@ -1,5 +1,5 @@
 ---
-description: 'Use when writing tests, browser automation, Chrome MCP validation, regression plans, fixture dashboards, QA checklists, or verifying Supersubset UI behavior.'
+description: 'Use when planning or writing tests, browser automation, live-backend probe validation, regression plans, fixture dashboards, QA checklists, or verifying Supersubset behavior.'
 tools: [read, edit, search, execute, web, agent, 'io.github.ChromeDevTools/chrome-devtools-mcp/*']
 user-invocable: true
 ---
@@ -10,9 +10,11 @@ You are the **Testing/QA subagent** for the Supersubset project.
 
 You own:
 
+- **Risk-based test routing** — choose the lowest-confidence, lowest-cost layer that can prove the behavior
 - **Playwright E2E test authoring** — deterministic automated tests that ship WITH features
 - **Chrome MCP visual verification** — screenshot capture and manual-style inspection at milestones
 - **Workflow tests** — end-to-end user journey tests in `e2e/workflows/`
+- **Live backend probe validation** — controlled browser checks for host-owned discovery/query endpoints
 - Test plan creation and maintenance (`docs/testing/`)
 - Screenshot review protocol and baseline management (`screenshots/`)
 - Regression test suites
@@ -90,12 +92,15 @@ You own:
 
 ## Approach
 
-1. Read test plans in `docs/testing/browser-test-plans/`
-2. Read the current QA checklist in `docs/testing/qa-checklist.md`
-3. Navigate to the dev app in Chrome using Chrome MCP
-4. Execute test plan steps, taking screenshots for verification
-5. Report pass/fail with evidence (screenshots, console output)
-6. Update test plans and QA checklist based on findings
+1. Read `.github/skills/testing-strategy/SKILL.md` to choose the right test layer before writing or expanding tests
+2. Read `docs/testing/verification-strategy.md` for the project-wide testing matrix
+3. Read the current QA checklist in `docs/testing/qa-checklist.md`
+4. Read test plans in `docs/testing/browser-test-plans/` when the task needs browser verification or milestone evidence
+5. Use `.github/skills/browser-testing/SKILL.md` when Chrome MCP or Playwright browser work is the chosen layer
+6. Navigate to the dev app in Chrome using Chrome MCP when visual or workflow evidence is required
+7. Execute the selected test plan or workflow, taking screenshots or traces only when they add evidence
+8. Report pass/fail with evidence (test results, screenshots, console output, traces)
+9. Update test plans and QA checklist based on findings
 
 ## Best Practices
 
@@ -105,6 +110,7 @@ You own:
 4. When a workflow depends on browser refresh or route switches, include those transitions explicitly in the test.
 5. Treat console warnings/errors during workflow tests as failures unless explicitly expected.
 6. Keep a "bug replay" mindset: if a user can find it quickly, the suite should reproduce it cheaply.
+7. For host-owned backend validation, keep contract checks narrow and live-backend browser checks explicit rather than burying them in generic smoke tests.
 
 ## Output Format
 

--- a/.github/skills/browser-testing/SKILL.md
+++ b/.github/skills/browser-testing/SKILL.md
@@ -11,6 +11,7 @@ description: 'Run browser tests against Supersubset using Chrome MCP. Use when v
 - Testing drag-and-drop widget interactions
 - Verifying property edits update rendered widgets
 - Testing JSON/YAML import/export round-trips
+- Validating Probe mode against pasted metadata or controlled live discovery/query backends
 - Verifying renderer output against saved definitions
 - Checking filter propagation across widgets
 - Detecting console errors and rendering regressions
@@ -68,16 +69,23 @@ The workspace has Chrome MCP configured in `.vscode/mcp.json`:
 3. Mount renderer in separate route/component tree
 4. Verify no hidden backend dependency
 
+### Probe Workflows
+
+1. Use `e2e/workflows/probe-metadata-paste.spec.ts` for deterministic paste-JSON onboarding coverage
+2. Use a sibling workflow in `e2e/workflows/` for live backend discovery/query/auth validation when the branch includes one
+3. Anchor live backend assertions to the probe contract documented in `docs/api/metadata-and-cli.md`
+
 ## Procedure
 
-1. If multiple agents or checkouts share the machine, lease ports first:
+1. Decide first whether browser automation is the right layer by reading `.github/skills/testing-strategy/SKILL.md`
+2. If multiple agents or checkouts share the machine, lease ports first:
    `mapfile -t LEASED_PORTS < <(node scripts/find-free-port.mjs --start 3110 --end 3199 --count 3)`
-2. Export explicit origins before starting servers or Playwright-backed flows:
+3. Export explicit origins before starting servers or Playwright-backed flows:
    `SUPERSUBSET_DEV_APP_PORT`, `SUPERSUBSET_EXAMPLE_NEXTJS_PORT`, `SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT`
-3. Start the target app or stack on the leased ports.
-4. Use Chrome MCP to navigate to the explicit app URL, not an assumed shared default.
-5. Take an initial screenshot for baseline.
-6. Execute test plan steps using Chrome MCP tools:
+4. Start the target app or stack on the leased ports, or reuse the configured Playwright web server
+5. Use Chrome MCP to navigate to the explicit app URL, not an assumed shared default
+6. Take an initial screenshot for baseline
+7. Execute test plan steps using Chrome MCP tools:
    - `chr_navigate_page` — navigate to URLs
    - `chr_click` — click elements
    - `chr_fill` — fill input fields
@@ -85,8 +93,8 @@ The workspace has Chrome MCP configured in `.vscode/mcp.json`:
    - `chr_take_snapshot` — capture DOM state
    - `chr_list_console_messages` — check for errors
    - `chr_evaluate_script` — run assertions in browser
-7. Compare screenshots and DOM state to expected outcomes.
-8. Report results with evidence, including the leased local origin that was tested.
+8. Compare screenshots and DOM state to expected outcomes
+9. Report results with evidence, including the leased local origin that was tested
 
 ## Verification Checklist
 
@@ -97,3 +105,8 @@ The workspace has Chrome MCP configured in `.vscode/mcp.json`:
 - [ ] Filter changes propagate to all bound widgets
 - [ ] Export/import produces semantically identical schema
 - [ ] Responsive resize works without layout breaks
+
+## See Also
+
+- `.github/skills/testing-strategy/SKILL.md`
+- `docs/testing/verification-strategy.md`

--- a/.github/skills/designer-design/SKILL.md
+++ b/.github/skills/designer-design/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: designer-design
+description: 'Shape the visual design of the Supersubset designer shell. Use when refining layout density, property panels, palette organization, empty states, preview chrome, selection states, or other UX polish inside packages/designer/. Covers host-owned theming, Puck-compatible shell design, accessibility, and visual QA.'
+---
+
+# Designer Design
+
+## When to Use
+
+- Refining the visual hierarchy of the designer shell
+- Designing or polishing property panels, toolbar chrome, palette organization, and empty states
+- Improving selection, hover, loading, validation, or disabled states in `packages/designer/`
+- Making the designer feel more intentional without changing the canonical schema contract
+- Reviewing proposed UI changes for theme alignment, accessibility, and embeddability
+
+## Overview
+
+Supersubset's designer should feel like a precise authoring tool, not a branded hosted product.
+Its job is to help dashboard authors understand structure, data bindings, and state changes quickly.
+
+The visual direction should therefore be:
+
+- editor-first: dense enough for real work, but never cramped
+- host-compatible: the host application owns branding and theme values
+- schema-aware: UI affordances must reflect what the canonical dashboard schema can actually express
+- Puck-compatible: shell decisions should work with Puck's layout, sidebar, and editing primitives rather than fighting them
+- operationally clear: selected, dirty, invalid, loading, empty, and disabled states should read immediately
+
+Use the upstream `design.md` spec as inspiration for reasoning style and section order, not as a new contract to introduce into this repo.
+
+## Local Sources of Truth
+
+These are the normative sources for designer visuals:
+
+- `packages/theme/src/index.ts`
+  - `ResolvedTheme`
+  - `DEFAULT_THEME`
+  - `themeToCssVariables()`
+- `.github/instructions/designer.instructions.md` for package constraints
+- `.github/skills/puck-integration/SKILL.md` for Puck mechanics and serialization boundaries
+- `packages/designer/src/config/puck-config.ts` as a positive example of shell styling that already consumes `var(--ss-*)`
+- `packages/designer/src/components/SupersubsetDesigner.tsx` as a positive example of designer-shell chrome and accessibility adaptation
+- `packages/designer/src/components/LivePreviewPane.tsx` as a cautionary example where hardcoded visual values should not be copied into new reusable shell work
+
+Do not introduce a repo-wide `DESIGN.md`, a second token system, or a new theme schema through this skill.
+
+## Colors
+
+The designer must consume host-owned theme values rather than inventing its own brand.
+
+- Prefer `var(--ss-color-*)` CSS variables for designer shell UI
+- Treat `DEFAULT_THEME` as a fallback, not a branding target
+- Use color to communicate state only when the meaning is unambiguous: selection, success, warning, danger, disabled
+- Keep chart coloration and shell coloration distinct; chart palette choices should not leak into editor chrome decisions
+
+Guidance:
+
+- Use neutral surfaces and borders to establish containment before reaching for accent color
+- Reserve the primary accent for the active selection, primary action, or the single most important focus state in a region
+- Make destructive and error states obvious, but do not let them dominate the canvas when the user is simply authoring
+
+## Typography
+
+The designer should inherit host typography through `--ss-font-family`, `--ss-font-size`, and related theme values.
+
+- Favor legibility and scanning speed over expressive display type
+- Use weight changes sparingly to separate titles, labels, metadata, and helper text
+- Keep data-binding labels, control labels, and validation text visually distinct
+- Avoid introducing a second font stack for editor chrome unless the host theme explicitly provides one
+
+## Layout and Spacing
+
+The designer is an operational workspace. It should feel structured, not decorative.
+
+- Use the existing spacing rhythm from the resolved theme and current shell patterns
+- Preserve clear separation between palette, canvas, preview, and property editing regions
+- Keep high-frequency controls close to the surface they act on
+- Avoid layouts that require wide cursor travel for common authoring loops
+- Prefer predictable alignment and containment over clever asymmetry
+
+For authoring surfaces, optimize for these loops:
+
+1. choose a block
+2. place it
+3. configure it
+4. verify state in preview
+5. continue editing without losing context
+
+## Elevation and Depth
+
+Use depth sparingly. The designer should communicate hierarchy mostly through containment, borders, contrast, and spacing.
+
+- Prefer border, background, and inset treatment before large shadows
+- Use stronger separation only for overlays, popovers, or temporary focus surfaces
+- Ensure selection states remain readable even when the host theme has low contrast accent colors
+
+## Shapes
+
+Shape language should stay consistent with the host theme and existing designer shell.
+
+- Reuse the host's corner radius direction where possible
+- Do not mix aggressively rounded and rigidly square shells within the same workflow
+- Keep handles, chips, pills, and buttons visually related so the editor reads as one system
+
+## Components
+
+When designing or reviewing components in the designer, evaluate them by job rather than by isolated styling.
+
+### Shell Chrome
+
+- Toolbar, mode switchers, page tabs, sidebar tabs, and header actions should signal navigation and scope clearly
+- Primary actions should be obvious without overpowering the canvas
+- Secondary actions should be discoverable but visually quieter
+
+### Palette and Structure Views
+
+- Categories should help authors predict where blocks live
+- Icons should support recognition, not carry the whole meaning alone
+- Drag handles, insertion affordances, and nesting structure must remain legible at authoring density
+
+### Property Panels
+
+- Group fields by author intent, not by implementation order
+- Put the highest-impact controls near the top
+- Differentiate destructive, advanced, and validation-heavy controls clearly
+- Long forms need sectioning, summaries, or progressive disclosure before they need more chrome
+
+### Preview and Empty States
+
+- The preview area should read as verification space, not final product chrome
+- Blank states must explain whether the user needs data, configuration, or layout work next
+- Loading and query states must distinguish between waiting, partial data, and hard failure
+
+### Interaction States
+
+For any meaningful UI change, consider all of these states where relevant:
+
+- default
+- hover
+- focus
+- selected
+- disabled
+- invalid
+- loading
+- empty
+- destructive confirmation
+
+## Validation and Visual QA
+
+Every meaningful designer-shell change should have an explicit proof surface before it is considered done.
+
+- Update or add a Storybook story for every user-facing component or stateful shell pattern that a human reviewer should inspect
+- Prefer focused stories that isolate one interaction or layout question over one oversized kitchen-sink story
+- Pair structural checks with visual checks: Storybook for component states, Playwright or Chrome MCP for end-to-end authoring flows
+- Use screenshots when a regression would be easier to spot visually than semantically
+- If a change affects spacing, selection affordances, empty states, or panel hierarchy, assume browser verification is required
+
+Minimum expectations by change type:
+
+- component or panel polish: Storybook story plus a quick visual review
+- canvas, palette, or property workflow changes: browser flow validation in the dev app
+- state-heavy UI changes: capture the relevant default, hover, focus, selected, loading, empty, or invalid states somewhere reviewable
+
+Good validation questions:
+
+- Can another reviewer tell what changed from the story or screenshot without reading the diff first?
+- Would a low-contrast host theme still preserve the intended hierarchy?
+- Does the selected state still stand apart from hover and focus?
+- Does the layout still read correctly at authoring density?
+
+## Design Brief Template
+
+Use this lightweight brief before a substantial designer-shell change:
+
+```md
+## Intent
+
+- What authoring problem is this change solving?
+
+## Surfaces
+
+- Which designer surfaces change?
+- Which existing components or files own them?
+
+## Theme Usage
+
+- Which `--ss-*` variables or resolved theme fields are used?
+- Are any hardcoded values still necessary? Why?
+
+## States
+
+- Which interaction states must be visible?
+- What is the primary state distinction the user needs to notice fastest?
+
+## Accessibility
+
+- How are labels, focus states, and contrast preserved?
+- Does the change improve or risk keyboard/screen-reader clarity?
+
+## Validation
+
+- Which Storybook story, test, or browser flow proves the change?
+- What screenshot or visual check would catch a regression?
+- Which state combinations must be visible in review artifacts?
+```
+
+## Do's and Don'ts
+
+- Do keep the designer visually subordinate to host branding and dashboard content
+- Do use `ResolvedTheme` and `var(--ss-*)` as the first stop for shell styling
+- Do make state transitions and authoring affordances obvious
+- Do keep visual groupings aligned with schema concepts and user tasks
+- Do use screenshot-driven validation for meaningful visual changes
+- Do leave a clear Storybook or browser-verification trail for reviewer-visible UI changes
+- Don't add a second visual token vocabulary inside `packages/designer/`
+- Don't hardcode persistent brand colors into reusable editor chrome when host theme variables exist
+- Don't let Puck implementation details dictate the user-facing information architecture when a clearer shell layer is possible
+- Don't create UI affordances for schema behaviors the canonical contract cannot serialize
+- Don't copy one-off hardcoded styling from older preview surfaces into new shared designer components
+
+## See Also
+
+- `.github/skills/puck-integration/SKILL.md`
+- `.github/skills/document-feature/SKILL.md`
+- `docs/testing/verification-strategy.md`
+- `.github/instructions/designer.instructions.md`

--- a/.github/skills/puck-integration/SKILL.md
+++ b/.github/skills/puck-integration/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: puck-integration
-description: "Integrate Puck visual editor as the shell for the Supersubset dashboard designer. Use when building drag-and-drop editing, custom Puck blocks, property editors, field registration, or designer-to-schema serialization. Covers Puck configuration, custom components, and host-app mounting."
+description: 'Integrate Puck visual editor as the shell for the Supersubset dashboard designer. Use when building drag-and-drop editing, custom Puck blocks, property editors, field registration, or designer-to-schema serialization. Covers Puck configuration, custom components, and host-app mounting.'
 ---
 
 # Puck Integration Skill
 
 ## When to Use
+
 - Setting up Puck as the editor shell
 - Creating custom Puck blocks for Supersubset widgets
 - Building property editors for widget configuration
@@ -16,6 +17,7 @@ description: "Integrate Puck visual editor as the shell for the Supersubset dash
 ## Puck Overview
 
 Puck is an open-source React visual editor that provides:
+
 - Drag-and-drop block editing
 - Category-organized component palette
 - Property editing panels
@@ -46,35 +48,42 @@ Host App
 ## Key Integration Points
 
 ### 1. Custom Block Definition
+
 Each Supersubset widget becomes a Puck component with:
+
 - `fields`: Property editor configuration
 - `defaultProps`: Sensible defaults
 - `render`: Preview component
 - `resolveData`: Async data resolution for live preview
 
 ### 2. Data Binding
+
 Puck's internal data model must roundtrip through:
+
 ```
 Puck Data ←→ Canonical Dashboard Schema (JSON/YAML)
 ```
+
 Implement adapters in `packages/designer/src/adapters/`:
+
 - `puckToCanonical(puckData)` → DashboardDefinition
 - `canonicalToPuck(dashboard)` → PuckData
 
 ### 3. Host App Integration
+
 ```tsx
 <SupersubsetDesigner
-  value={dashboardDefinition}          // controlled mode
-  onChange={handleChange}               // canonical schema out
-  metadata={analyticalModel}           // data model for field pickers
-  onSave={handleSave}                  // host persistence callback
-  theme={hostTheme}                    // theming bridge
+  value={dashboardDefinition} // controlled mode
+  onChange={handleChange} // canonical schema out
+  metadata={analyticalModel} // data model for field pickers
+  onSave={handleSave} // host persistence callback
+  theme={hostTheme} // theming bridge
 />
 ```
 
 ## Procedure
 
-1. Install Puck: `pnpm add @measured/puck` in `packages/designer`
+1. Install Puck: `pnpm add @puckeditor/core` in `packages/designer`
 2. Create component configs for each widget type
 3. Build custom field editors for data bindings
 4. Implement Puck ↔ canonical schema adapter
@@ -83,5 +92,11 @@ Implement adapters in `packages/designer/src/adapters/`:
 7. Test with Chrome MCP browser verification
 
 ## Key References
+
 - [Puck docs](https://puckeditor.com/docs)
 - [Puck GitHub](https://github.com/measuredco/puck)
+
+## See Also
+
+- `.github/skills/designer-design/SKILL.md` for visual hierarchy, theme usage, and authoring UX guidance
+- `.github/instructions/designer.instructions.md` for package-level constraints

--- a/.github/skills/testing-strategy/SKILL.md
+++ b/.github/skills/testing-strategy/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: testing-strategy
+description: 'Plan and route Supersubset tests across package tests, Playwright workflows, docs screenshot harnesses, and live-backend probe validation. Use when deciding what tests to add or run for a feature, bug, regression, or release gate.'
+---
+
+# Testing Strategy
+
+## When to Use
+
+- Deciding what test layer should cover a feature, bug, or regression
+- Choosing between package tests, Playwright workflows, browser verification, and screenshot capture
+- Planning evidence for a human checkpoint or release gate
+- Auditing whether a test change is too broad, too flaky, or too weak
+- Validating host-owned backends through Probe mode or other integration surfaces
+
+## Purpose
+
+This skill is the routing layer for Supersubset testing work.
+
+It does not replace the detailed testing docs or the browser-testing skill.
+Instead, it answers four questions first:
+
+1. What is the real risk?
+2. What is the cheapest test that can catch it reliably?
+3. Which local test surface owns that risk?
+4. What evidence is required before the task is done?
+
+Use this skill before writing or expanding tests. Then route into the narrower skill or document that owns the implementation details.
+
+## AI Tester Agent Design Principles
+
+Adapted to Supersubset, a strong tester agent should behave like this:
+
+- prefer the simplest workflow that can produce trustworthy evidence
+- state the risk being tested before choosing tools or files
+- collect ground truth from executable checks, browser output, traces, screenshots, and console logs rather than intuition
+- keep package boundaries clear: tests may change, product architecture should not be silently redesigned from the testing surface
+- choose the narrowest layer that can falsify the current hypothesis, then climb only when more confidence is needed
+- treat evaluation as an explicit loop: pick a check, run it, interpret it, then either stop or add the next layer
+- hand product bugs back to the owning domain once the failure is reproduced clearly
+
+This follows the same principle we use elsewhere in the repo: simple, inspectable workflows beat elaborate autonomous wandering.
+
+## Local Test Surfaces
+
+Supersubset already has several distinct testing surfaces. Route to the one that matches the risk.
+
+### Package Tests
+
+Use `packages/*/test/` or `packages/*/__tests__/` for narrow, deterministic checks.
+
+Examples already in the repo:
+
+- `packages/data-model/test/` for heuristics and normalized metadata rules
+- `packages/query-client/test/` for query orchestration and metadata caching
+- `packages/theme/test/` for resolved theme defaults and CSS variable bridging
+- `packages/designer/test/` for field editors and other focused designer logic
+- `packages/charts-echarts/test/` for widget rendering and theme-aware states
+- `packages/adapter-*/test/` for normalization behavior and edge cases
+
+Use these when the bug or feature is fundamentally about data transformation, serialization, configuration, state logic, or component behavior that does not require a full browser journey.
+
+### Playwright Workflow Tests
+
+Use `e2e/` when the risk only appears in the browser or across multiple packages.
+
+Current workflow examples include:
+
+- `e2e/workflows/probe-metadata-paste.spec.ts`
+- `e2e/workflows/designer-to-renderer.spec.ts`
+- `e2e/workflows/import-export-cycle.spec.ts`
+- `e2e/workflows/host-integration.spec.ts`
+- `e2e/interactions/dashboard-filter.spec.ts`
+- `e2e/visual/chart-header-layout.spec.ts`
+
+Use these when the issue is about real authoring flow, rendering flow, persistence flow, page switching, host integration, or UI regressions that only emerge in a browser.
+
+### Docs Screenshot Harness
+
+Use `pnpm docs:screenshots` and `packages/docs/playwright.config.ts` when the goal is documentation-grade screenshots or reviewer-facing visual artifacts.
+
+This harness is not the default place to prove core product behavior. It is for curated screenshots with stable framing and documentation-quality output.
+
+### Manual QA and Human Gates
+
+Use these docs when the task affects milestone confidence, not just one automated test:
+
+- `docs/testing/verification-strategy.md`
+- `docs/testing/qa-checklist.md`
+- `docs/testing/human-checkpoints.md`
+
+These are the authority for human-review expectations, screenshot checkpoints, and gate criteria.
+
+## Test Routing Heuristics
+
+### Start Low, Climb Only When Needed
+
+- If the risk is a pure transform, heuristic, serializer, mapper, or query-builder rule, start in package tests.
+- If the risk sits at a system boundary such as metadata ingestion, query execution, or transport envelopes, add a boundary-focused test before a browser test.
+- If the risk is a user journey, authoring interaction, persistence flow, or browser-only regression, use Playwright.
+- If the risk is mostly visual hierarchy, overlap, spacing, or state affordance, add a targeted screenshot assertion or screenshot review artifact instead of only a full-page smoke test.
+- If the risk is documentation fidelity, use the docs screenshot harness rather than general E2E tests.
+
+### Push Tests Down
+
+Follow the practical test pyramid, adapted for this repo:
+
+- many package tests
+- some boundary or workflow tests
+- few broad end-to-end journeys
+
+If a broad browser test fails and no lower-level test tells you why, add the missing lower-level test.
+
+### Avoid Duplicate Confidence
+
+Do not restate the same edge cases at every layer.
+
+- lower layers should cover logic breadth
+- higher layers should prove the integration point the lower layers could not prove
+
+Example:
+
+- field role inference belongs in `packages/data-model/test/`
+- a field picker showing the inferred result belongs in a designer or workflow test
+- the full dashboard journey should only assert that the user-facing outcome still works
+
+## Live Backend Probe Validation
+
+This repo is backend-agnostic, but it still needs a disciplined way to validate host-owned backends through Probe mode.
+
+Treat live backend testing as a staged workflow, not as a single giant E2E test.
+
+### Stage 1: Contract Confidence
+
+Read `docs/api/metadata-and-cli.md` first.
+
+The key contract types are:
+
+- `ProbeDatasetsResponse`
+- `ProbeQueryRequest`
+- `ProbeQueryResponse`
+- `ProbeErrorResponse`
+- `PROBE_PROTOCOL_VERSION`
+
+If the risk is the transport envelope or logical query shape, prefer narrow tests around the contract and adapters before a browser run.
+
+### Stage 2: Deterministic Probe Workflow
+
+Use or add a Playwright workflow in `e2e/workflows/` beside `probe-metadata-paste.spec.ts` for discovery/query/auth behavior.
+
+This is the right place to verify that Probe mode:
+
+- accepts a discovery URL or base URL
+- sends the expected auth header or credential mode
+- shows dataset count and metadata source summary
+- enables or disables preview appropriately
+- reaches the `Supersubset Probe Designer` state
+
+Prefer routing or request interception for this layer so the UI contract stays deterministic.
+
+### Stage 3: Controlled Live Backend Smoke
+
+Only use a real backend when it is local, team-owned, or a stable dedicated test target.
+
+- do not make routine tests depend on an uncontrolled third-party service
+- do not hide live-backend checks inside unrelated smoke suites
+- keep auth, base URL, and environment selection explicit
+- treat console errors, failed discovery, and broken preview queries as first-class failures
+
+If the current branch already has a dedicated live-backend probe workflow, use it before inventing a new one. If not, add it in `e2e/workflows/` rather than scattering probe validation across ad hoc files.
+
+### What a Good Live Backend Test Should Prove
+
+- the discovery endpoint responds with the documented probe contract or an explicitly supported compatibility shape
+- query preview can execute against the host backend when the flow requires it
+- auth is actually sent, not just entered into a form
+- the designer loads with the discovered datasets visible to the user
+- the failure mode is legible when discovery or preview is unavailable
+
+## Playwright Rules for Supersubset
+
+Use these rules whenever work routes into browser automation:
+
+- test user-visible behavior, not implementation details
+- keep each test isolated; never depend on prior test state
+- prefer `getByRole()`, `getByTestId()`, and other stable user-facing locators
+- avoid brittle CSS selectors or DOM-shape assertions unless there is no stable contract
+- use Playwright web-first assertions such as `toBeVisible()` and `toHaveText()`
+- stub or route dependencies you do not control
+- keep broad journeys short and focused on product-critical flows
+- treat unexpected console errors as failures
+
+Repo-specific notes:
+
+- `playwright.config.ts` already records traces on first retry and screenshots only on failure
+- the root suite currently targets Chromium and Firefox
+- the dev app origin is controlled by `SUPERSUBSET_DEV_APP_PORT` and defaults to `http://localhost:3000`
+
+## Evidence Expectations
+
+Before calling testing work done, leave evidence at the right layer:
+
+- changed or added test file(s)
+- the narrowest command(s) run to validate the affected surface
+- trace, screenshot, console output, or failing assertion details when the problem is browser-based
+- updated checklist, checkpoint brief, or screenshot artifact when the work affects a milestone gate
+
+For human-found bugs:
+
+- reproduce the bug cheaply
+- add the regression at the lowest adequate layer
+- add a higher-level test only if the user-facing risk still needs explicit proof
+
+## Anti-Patterns
+
+- adding only a broad workflow test when a package test would catch the root cause faster
+- relying on uncontrolled live services for routine CI confidence
+- asserting CSS classes or internal implementation names when the user cannot perceive them
+- treating a screenshot as enough evidence for data-contract correctness
+- adding manual QA notes without turning repeatable bugs into automated regressions
+- widening a flaky test instead of isolating the unstable dependency or state leak
+
+## See Also
+
+- `.github/skills/browser-testing/SKILL.md`
+- `.github/skills/branch-ci-promotion/SKILL.md`
+- `docs/testing/verification-strategy.md`
+- `docs/testing/qa-checklist.md`
+- `docs/testing/human-checkpoints.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,10 @@ See `.github/agents/` for specialized agent definitions:
 
 The **orchestrator agent** (`orchestrator.agent.md`) is the coordinator. It decomposes complex requests, delegates to specialized agents, parallelizes independent work, and verifies results. Use it for any task that spans multiple packages or domains. See `.github/skills/orchestration/SKILL.md` for the delegation methodology.
 
+For designer-shell visual work, pair the `designer` agent with `.github/skills/designer-design/SKILL.md`. Use `.github/skills/puck-integration/SKILL.md` for Puck mechanics and serialization.
+
+For testing work, pair the `testing` agent with `.github/skills/testing-strategy/SKILL.md` for layer selection and evidence expectations. Use `.github/skills/browser-testing/SKILL.md` for Chrome MCP and Playwright browser execution details.
+
 ### Planning, CI, and AI context skills
 
 | Skill                         | Use when                                                                                                  |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,8 +99,10 @@ For domain-specific knowledge, read the relevant skill file:
 
 - **Schema design**: `.github/skills/schema-design/SKILL.md`
 - **ECharts widgets**: `.github/skills/echarts-widgets/SKILL.md`
+- **Designer shell design**: `.github/skills/designer-design/SKILL.md`
 - **Puck integration**: `.github/skills/puck-integration/SKILL.md`
 - **Adapter development**: `.github/skills/adapter-development/SKILL.md`
+- **Testing strategy**: `.github/skills/testing-strategy/SKILL.md`
 - **Browser testing**: `.github/skills/browser-testing/SKILL.md`
 - **OSS archaeology**: `.github/skills/oss-archaeology/SKILL.md`
 - **Orchestration**: `.github/skills/orchestration/SKILL.md`

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -18,6 +18,8 @@
 8. **`.github/skills/parallel-agent-environments/SKILL.md`** — Parallel work: branch isolation, file-scope ownership, ports, merge sequencing
 9. **`.github/skills/github-cli/SKILL.md`** — Use `gh` for GitHub (issues, PRs, Actions, API); avoid slow browser-first flows
 10. **`.github/skills/release-runbook/SKILL.md`** — End-to-end release path: candidate validation, changesets, promotion, publish, downstream upgrade
+11. **`.github/skills/designer-design/SKILL.md`** — Designer-shell UX, theme usage, Storybook expectations, and visual QA guidance
+12. **`.github/skills/testing-strategy/SKILL.md`** — Test layer selection, live-backend probe validation, and evidence expectations
 
 ### Where Things Are
 


### PR DESCRIPTION
## Summary
- add the new designer-design skill and wire it into the designer agent flow
- add the new testing-strategy skill and wire it into the testing agent flow
- cross-link related skills and refresh AGENTS/bootstrap/CLAUDE discoverability

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test