### PR TITLE
Fix leased-port support in Playwright E2E config

### DIFF
--- a/playwright.e2e.config.ts
+++ b/playwright.e2e.config.ts
@@ -1,4 +1,38 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
 import { defineConfig, devices } from '@playwright/test';
+
+const DEFAULT_DEV_APP_PORT = '3006';
+const DEVENV_STATE_PATH = path.resolve(process.cwd(), 'tmp/devenv-state.json');
+
+function resolveDevAppPort(): string {
+  if (process.env.SUPERSUBSET_DEV_APP_PORT) {
+    return process.env.SUPERSUBSET_DEV_APP_PORT;
+  }
+
+  if (!existsSync(DEVENV_STATE_PATH)) {
+    return DEFAULT_DEV_APP_PORT;
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(DEVENV_STATE_PATH, 'utf8')) as {
+      ports?: { devApp?: number };
+    };
+
+    if (parsed.ports?.devApp == null) {
+      return DEFAULT_DEV_APP_PORT;
+    }
+
+    return String(parsed.ports.devApp);
+  } catch {
+    return DEFAULT_DEV_APP_PORT;
+  }
+}
+
+const devAppPort = resolveDevAppPort();
+const devAppOrigin = `http://localhost:${devAppPort}`;
+
+process.env.SUPERSUBSET_DEV_APP_PORT = devAppPort;
 
 export default defineConfig({
   testDir: './e2e',
@@ -6,7 +40,7 @@ export default defineConfig({
   retries: 0,
   reporter: 'list',
   use: {
-    baseURL: 'http://localhost:3006',
+    baseURL: devAppOrigin,
     trace: 'off',
     screenshot: 'only-on-failure',
   },


### PR DESCRIPTION
## Summary
- resolve the E2E base URL from SUPERSUBSET_DEV_APP_PORT before falling back to the legacy default
- honor persisted DevEnv state when running focused workflows against already-running leased environments
- keep the change scoped to Playwright test infrastructure

## Testing
- SUPERSUBSET_DEV_APP_PORT=3110 pnpm --dir /Users/kenxono/apps/supersubset-issue-105-playwright-e2e exec playwright test e2e/smoke.spec.ts --config=playwright.e2e.config.ts --project=chromium

Closes #105