### PR TITLE
Fix page demo shared-filter fidelity

### DIFF
--- a/e2e/workflows/filter-cascade.spec.ts
+++ b/e2e/workflows/filter-cascade.spec.ts
@@ -14,6 +14,13 @@ test.describe('Filter Cascade Workflow', () => {
     }
   });
 
+  async function openPagesWorkbook(page: import('@playwright/test').Page) {
+    const pagesScenarioButton = page.getByTestId('viewer-scenario-pages');
+    await expect(pagesScenarioButton).toBeVisible();
+    await pagesScenarioButton.click();
+    await expect(page.getByRole('button', { name: 'Overview' })).toBeVisible();
+  }
+
   test('dashboard renders with filter bar and all widgets', async ({ page }) => {
     // Verify the dashboard renders
     const dashboard = page.locator('[data-ss-dashboard]');
@@ -64,5 +71,33 @@ test.describe('Filter Cascade Workflow', () => {
       const dashboard = page.locator('[data-ss-dashboard]');
       await expect(dashboard).toBeVisible();
     }
+  });
+
+  test('page demo shows shared filters on both pages and preserves selected values', async ({
+    page,
+  }) => {
+    await openPagesWorkbook(page);
+
+    const overviewFilterBar = page.locator('.ss-filter-bar');
+    await expect(overviewFilterBar).toHaveCount(1);
+
+    const overviewRegionFilter = overviewFilterBar.getByLabel('Region');
+    const overviewCategoryFilter = overviewFilterBar.getByLabel('Category');
+
+    await expect(overviewRegionFilter).toBeVisible();
+    await expect(overviewCategoryFilter).toBeVisible();
+
+    await overviewRegionFilter.selectOption({ label: 'East' });
+    await expect(overviewRegionFilter).toHaveValue('East');
+
+    await page.getByRole('button', { name: 'Region Detail' }).click();
+
+    const detailFilterBar = page.locator('.ss-filter-bar');
+    await expect(detailFilterBar).toHaveCount(1);
+    await expect(detailFilterBar.getByLabel('Region')).toHaveValue('East');
+    await expect(detailFilterBar.getByLabel('Category')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Overview' }).click();
+    await expect(page.locator('.ss-filter-bar').getByLabel('Region')).toHaveValue('East');
   });
 });

--- a/packages/dev-app/src/main.tsx
+++ b/packages/dev-app/src/main.tsx
@@ -1049,9 +1049,9 @@ function App() {
                     What to try
                   </strong>
                   <span style={{ color: '#475569', lineHeight: 1.5 }}>
-                    In the page demo, click the region chart to navigate to another page. In the
-                    dashboard demo, use the host buttons to switch documents and notice the separate
-                    titles and themes.
+                    In the page demo, use the shared filter bar and page tabs to confirm one
+                    workbook state across multiple canvases. In the dashboard demo, use the host
+                    buttons to switch documents and notice the separate titles and themes.
                   </span>
                 </div>
               </div>

--- a/packages/dev-app/src/navigation-demo.test.ts
+++ b/packages/dev-app/src/navigation-demo.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  dashboardSwitchingDemo,
-  pageNavigationDemoDashboard,
-} from './navigation-demo';
+import { dashboardSwitchingDemo, pageNavigationDemoDashboard } from './navigation-demo';
 
 describe('navigation demo definitions', () => {
   it('uses pages for intra-dashboard navigation', () => {
@@ -19,6 +16,36 @@ describe('navigation demo definitions', () => {
         }),
       ]),
     );
+  });
+
+  it('places shared filter bars on both pages of the workbook demo', () => {
+    const [overviewPage, detailPage] = pageNavigationDemoDashboard.pages;
+    const overviewFilterBar = pageNavigationDemoDashboard.pages[0]?.widgets.find(
+      (widget) => widget.id === 'pages-filter-bar',
+    );
+    const detailFilterBar = pageNavigationDemoDashboard.pages[1]?.widgets.find(
+      (widget) => widget.id === 'pages-detail-filter-bar',
+    );
+
+    expect(overviewPage?.layout['pages-filter-row']?.children).toEqual(['pages-filter-bar-host']);
+    expect(overviewPage?.layout['pages-filter-bar-host']?.meta.widgetRef).toBe('pages-filter-bar');
+    expect(overviewFilterBar).toMatchObject({
+      type: 'filter-bar',
+      title: 'Shared Workbook Filters',
+      config: {},
+    });
+
+    expect(detailPage?.layout['page-detail-filter-row']?.children).toEqual([
+      'page-detail-filter-bar-host',
+    ]);
+    expect(detailPage?.layout['page-detail-filter-bar-host']?.meta.widgetRef).toBe(
+      'pages-detail-filter-bar',
+    );
+    expect(detailFilterBar).toMatchObject({
+      type: 'filter-bar',
+      title: 'Shared Workbook Filters',
+      config: {},
+    });
   });
 
   it('uses unique dashboard ids for the host-switching demo', () => {

--- a/packages/dev-app/src/navigation-demo.ts
+++ b/packages/dev-app/src/navigation-demo.ts
@@ -74,7 +74,13 @@ export const pageNavigationDemoDashboard: DashboardDefinition = {
         'pages-grid': {
           id: 'pages-grid',
           type: 'grid',
-          children: ['pages-header', 'pages-note-row', 'pages-kpi-row', 'pages-chart-row'],
+          children: [
+            'pages-header',
+            'pages-note-row',
+            'pages-filter-row',
+            'pages-kpi-row',
+            'pages-chart-row',
+          ],
           parentId: 'pages-root',
           meta: { columns: 12 },
         },
@@ -98,6 +104,20 @@ export const pageNavigationDemoDashboard: DashboardDefinition = {
           children: [],
           parentId: 'pages-note-row',
           meta: { widgetRef: 'pages-note', width: 12, height: 96 },
+        },
+        'pages-filter-row': {
+          id: 'pages-filter-row',
+          type: 'row',
+          children: ['pages-filter-bar-host'],
+          parentId: 'pages-grid',
+          meta: {},
+        },
+        'pages-filter-bar-host': {
+          id: 'pages-filter-bar-host',
+          type: 'widget',
+          children: [],
+          parentId: 'pages-filter-row',
+          meta: { widgetRef: 'pages-filter-bar', width: 12, height: 88 },
         },
         'pages-kpi-row': {
           id: 'pages-kpi-row',
@@ -149,14 +169,25 @@ export const pageNavigationDemoDashboard: DashboardDefinition = {
           title: '',
           config: {
             content:
-              'A page is another canvas inside the same dashboard document. These two pages share the same dashboard id, filters, interactions, theme, and saved state. Click **Sales by Region** to jump to the detail page.',
+              'A page is another canvas inside the same dashboard document. These two pages share the same dashboard id, filters, interactions, theme, and saved state. Use the shared filter bar and page tabs to see one workbook state carried across multiple canvases.',
           },
+        },
+        {
+          id: 'pages-filter-bar',
+          type: 'filter-bar',
+          title: 'Shared Workbook Filters',
+          config: {},
         },
         {
           id: 'pages-kpi-revenue',
           type: 'kpi-card',
           title: 'Revenue',
-          config: { valueField: 'revenue', comparisonField: 'prevRevenue', format: 'compact', prefix: '$' },
+          config: {
+            valueField: 'revenue',
+            comparisonField: 'prevRevenue',
+            format: 'compact',
+            prefix: '$',
+          },
         },
         {
           id: 'pages-kpi-orders',
@@ -183,11 +214,21 @@ export const pageNavigationDemoDashboard: DashboardDefinition = {
       title: 'Region Detail',
       rootNodeId: 'page-detail-root',
       layout: {
-        'page-detail-root': { id: 'page-detail-root', type: 'root', children: ['page-detail-grid'], meta: {} },
+        'page-detail-root': {
+          id: 'page-detail-root',
+          type: 'root',
+          children: ['page-detail-grid'],
+          meta: {},
+        },
         'page-detail-grid': {
           id: 'page-detail-grid',
           type: 'grid',
-          children: ['page-detail-header', 'page-detail-note-row', 'page-detail-table-row'],
+          children: [
+            'page-detail-header',
+            'page-detail-note-row',
+            'page-detail-filter-row',
+            'page-detail-table-row',
+          ],
           parentId: 'page-detail-root',
           meta: { columns: 12 },
         },
@@ -219,6 +260,20 @@ export const pageNavigationDemoDashboard: DashboardDefinition = {
           parentId: 'page-detail-note-row',
           meta: { widgetRef: 'pages-kpi-aov', width: 4, height: 96 },
         },
+        'page-detail-filter-row': {
+          id: 'page-detail-filter-row',
+          type: 'row',
+          children: ['page-detail-filter-bar-host'],
+          parentId: 'page-detail-grid',
+          meta: {},
+        },
+        'page-detail-filter-bar-host': {
+          id: 'page-detail-filter-bar-host',
+          type: 'widget',
+          children: [],
+          parentId: 'page-detail-filter-row',
+          meta: { widgetRef: 'pages-detail-filter-bar', width: 12, height: 88 },
+        },
         'page-detail-table-row': {
           id: 'page-detail-table-row',
           type: 'row',
@@ -241,8 +296,14 @@ export const pageNavigationDemoDashboard: DashboardDefinition = {
           title: '',
           config: {
             content:
-              'This is still the same dashboard. The filter bar, theme, and persisted state are shared with the overview page. Use pages when you want one analytical workbook with multiple canvases.',
+              'This is still the same dashboard. The shared filter bar, theme, and persisted state carry over from the overview page. Use pages when you want one analytical workbook with multiple canvases.',
           },
+        },
+        {
+          id: 'pages-detail-filter-bar',
+          type: 'filter-bar',
+          title: 'Shared Workbook Filters',
+          config: {},
         },
         {
           id: 'pages-kpi-aov',
@@ -370,7 +431,12 @@ const executiveDashboard: DashboardDefinition = {
           id: 'exec-kpi-revenue',
           type: 'kpi-card',
           title: 'Revenue',
-          config: { valueField: 'revenue', comparisonField: 'prevRevenue', format: 'compact', prefix: '$' },
+          config: {
+            valueField: 'revenue',
+            comparisonField: 'prevRevenue',
+            format: 'compact',
+            prefix: '$',
+          },
         },
         {
           id: 'exec-kpi-orders',


### PR DESCRIPTION
## Summary
- place shared filter-bar widgets on both pages of the workbook demo
- update the page-demo copy so it describes the behavior users can actually exercise
- add definition-level and browser regression coverage for shared filter state across pages

## Validation
- pnpm --filter @supersubset/dev-app test -- src/navigation-demo.test.ts
- pnpm --filter @supersubset/dev-app typecheck
- pnpm exec eslint packages/dev-app/src/main.tsx packages/dev-app/src/navigation-demo.ts packages/dev-app/src/navigation-demo.test.ts e2e/workflows/filter-cascade.spec.ts
- leased-port Playwright run: e2e/workflows/filter-cascade.spec.ts (chromium)

Closes #106