### PR TITLE
Docs: harden market-readiness testing guidance

### DIFF
--- a/.github/skills/bi-visualization-quality/SKILL.md
+++ b/.github/skills/bi-visualization-quality/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: bi-visualization-quality
+description: 'Evaluate BI dashboards and charts for task-to-chart fit, readability, truthful encodings, filter discoverability, and decision-ready layout quality. Use when testing or reviewing dashboards for market readiness, not just technical correctness.'
+---
+
+# BI Visualization Quality
+
+## When to Use
+
+- Testing whether a dashboard is merely functional versus decision-ready
+- Reviewing chart choices, labels, colors, and layout hierarchy in host apps or screenshots
+- Auditing whether interactivity and filters are discoverable and meaningful to end users
+- Deciding what visual assertions belong in browser tests, screenshot checks, or manual QA
+- Performing release-readiness review for BI-facing workflows
+
+## Purpose
+
+This skill closes a gap that technical testing alone misses: a BI package can pass type checks, unit tests, and even browser workflows while still producing dashboards that are misleading, unreadable, hard to operate, or poor at answering user questions.
+
+Use this skill alongside `.github/skills/testing-strategy/SKILL.md` and `.github/skills/browser-testing/SKILL.md` when the outcome must be credible to a real analyst, operator, or dashboard consumer.
+
+## Core Review Questions
+
+Ask these before calling a dashboard or chart acceptable:
+
+1. Does the chart type fit the analytical task?
+2. Are the most important comparisons easy to see without explanation?
+3. Are labels, legends, number formats, and units clear enough for fast interpretation?
+4. Are color, size, ordering, and layout helping comprehension rather than adding noise?
+5. Are filters and interactions obvious enough that a new user can operate them correctly?
+6. Would a reasonable user draw the right conclusion from this view, or could the presentation mislead them?
+
+## Chart Selection Heuristics
+
+Choose the simplest visual form that matches the task.
+
+- Use bars for comparing categories with one or a few measures.
+- Use lines for time series or ordered sequences where trend matters.
+- Use tables when precise lookup or dense comparison matters more than shape.
+- Use scatter plots for relationships or clustering, not for simple category comparison.
+- Use heatmaps for matrix-style intensity patterns, not as a default substitute for bars.
+- Use KPI cards for single headline metrics, ideally with context such as delta, prior value, or target.
+- Use pie or donut only for small part-to-whole cases with few categories and clear magnitude differences.
+
+## Misleading Pattern Checks
+
+Flag these as release concerns unless strongly justified:
+
+- pie or donut with too many slices
+- lines with too many series to read cleanly
+- truncated axes that exaggerate differences without obvious signaling
+- unlabeled or ambiguous units, currencies, or time windows
+- inconsistent category ordering across related views
+- color meaning that changes from chart to chart without warning
+- stacked views that hide the key comparison the user actually needs
+- decorative complexity that competes with the data
+
+## Readability Rules
+
+- Titles should explain what the view is showing, not just restate the chart type.
+- Axis titles, legend labels, and number formats should remove ambiguity about units and grain.
+- Avoid dense label collisions; long labels should wrap, truncate safely, or be moved to a table.
+- Use ordering intentionally. Alphabetical order is rarely the best analytical order.
+- Show enough context for KPI values to be meaningful.
+- Prefer fewer panels with clear hierarchy over many equally loud panels.
+
+## Color And Emphasis
+
+- Use color to encode meaning or emphasis, not decoration.
+- Keep category colors stable across related views when the same categories recur.
+- Reserve strong accent colors for genuinely important states or outliers.
+- Ensure contrast is sufficient for labels, legends, and interactive controls.
+- Do not rely on color alone to communicate status or selection.
+
+## Dashboard Composition
+
+- Place the highest-value view first in the reading order.
+- Group related filters together and make their scope legible.
+- Keep supporting detail visually secondary to the main decision view.
+- Avoid making users scan unrelated panels to interpret one chart.
+- If multiple views must be compared, align scales and ordering where possible.
+
+## Interaction And Filter Quality
+
+- Filters should be discoverable without reading documentation.
+- Filter labels should reflect business meaning, not raw field ids.
+- A filter change should produce an obvious visible outcome or clear loading feedback.
+- Cross-filter and drill actions should be predictable; hidden affordances are not enough.
+- If a dashboard depends on host-owned query refresh, tests should prove both the host query mutation and the visible dashboard update.
+
+## Validation Expectations
+
+Use this skill to strengthen evidence, not replace it.
+
+- Pair visual-quality concerns with the cheapest executable proof possible.
+- Add screenshot or browser checks for overlaps, hierarchy, and affordance issues.
+- Add semantic assertions for query logs, row counts, KPI values, legends, or visible series changes when interactivity is involved.
+- Record manual review findings in `docs/testing/qa-checklist.md` or a QA history entry when the issue is release-relevant.
+
+## Anti-Patterns
+
+- declaring success because the chart rendered at all
+- testing only control state when the user cares about the changed analysis result
+- using screenshots as the only evidence for data-meaning correctness
+- accepting technically valid dashboards that are confusing on first use
+- treating design quality as subjective when the defect is actually interpretability or discoverability
+
+## See Also
+
+- `.github/skills/testing-strategy/SKILL.md`
+- `.github/skills/browser-testing/SKILL.md`
+- `docs/testing/verification-strategy.md`
+- `docs/testing/qa-checklist.md`

--- a/.github/skills/browser-testing/SKILL.md
+++ b/.github/skills/browser-testing/SKILL.md
@@ -14,8 +14,10 @@ description: 'Run browser tests against Supersubset using Chrome MCP. Use when v
 - Validating Probe mode against pasted metadata or controlled live discovery/query backends
 - Verifying renderer output against saved definitions
 - Checking filter propagation across widgets
+- Verifying that host-owned query refresh actually changes visible dashboard output
 - Detecting console errors and rendering regressions
 - Responsive mode testing
+- Running release-oriented blocker discovery sweeps in real host examples
 
 ## Chrome MCP Setup
 
@@ -69,6 +71,15 @@ The workspace has Chrome MCP configured in `.vscode/mcp.json`:
 3. Mount renderer in separate route/component tree
 4. Verify no hidden backend dependency
 
+### Plan F — Market-Critical BI Sweep
+
+1. Use the strongest host or authoring surface for the workflow under test
+2. Reproduce the end-user journey that changes analytical meaning
+3. Verify any host query or request payload mutation when the host owns data refresh
+4. Verify the visible dashboard outcome changed in a way a user can perceive
+5. Capture console, network, screenshot, and query-log evidence
+6. Record whether the result is a blocker, a regression gap, or a pass
+
 ### Probe Workflows
 
 1. Use `e2e/workflows/probe-metadata-paste.spec.ts` for deterministic paste-JSON onboarding coverage
@@ -96,6 +107,14 @@ The workspace has Chrome MCP configured in `.vscode/mcp.json`:
 8. Compare screenshots and DOM state to expected outcomes
 9. Report results with evidence, including the leased local origin that was tested
 
+For BI workflows, do not stop at screenshots or control values when a stronger proof exists. Prefer evidence like:
+
+- query log changed from the previous value set
+- row count or table contents changed
+- KPI value or delta changed
+- legend, series, or mark count changed in the rendered chart
+- network request payload reflects the expected filter or interaction state
+
 ## Verification Checklist
 
 - [ ] No console errors during test
@@ -103,10 +122,13 @@ The workspace has Chrome MCP configured in `.vscode/mcp.json`:
 - [ ] Drag-and-drop produces correct layout changes
 - [ ] Property edits reflect immediately in preview
 - [ ] Filter changes propagate to all bound widgets
+- [ ] When the host owns query refresh, filter changes mutate the expected query or request payload
+- [ ] Filter or interaction changes produce an obvious analytical outcome, not only a control-state update
 - [ ] Export/import produces semantically identical schema
 - [ ] Responsive resize works without layout breaks
 
 ## See Also
 
 - `.github/skills/testing-strategy/SKILL.md`
+- `.github/skills/bi-visualization-quality/SKILL.md`
 - `docs/testing/verification-strategy.md`

--- a/.github/skills/testing-strategy/SKILL.md
+++ b/.github/skills/testing-strategy/SKILL.md
@@ -27,6 +27,8 @@ Instead, it answers four questions first:
 
 Use this skill before writing or expanding tests. Then route into the narrower skill or document that owns the implementation details.
 
+For BI-facing work, use this skill together with `.github/skills/bi-visualization-quality/SKILL.md`. Technical correctness is not enough if the resulting dashboard is misleading, unreadable, or hard to operate.
+
 ## AI Tester Agent Design Principles
 
 Adapted to Supersubset, a strong tester agent should behave like this:
@@ -38,6 +40,7 @@ Adapted to Supersubset, a strong tester agent should behave like this:
 - choose the narrowest layer that can falsify the current hypothesis, then climb only when more confidence is needed
 - treat evaluation as an explicit loop: pick a check, run it, interpret it, then either stop or add the next layer
 - hand product bugs back to the owning domain once the failure is reproduced clearly
+- test the analytical outcome, not just the control state; if a filter changed, prove the query, rows, KPI, or chart changed in a way a user can perceive
 
 This follows the same principle we use elsewhere in the repo: simple, inspectable workflows beat elaborate autonomous wandering.
 
@@ -100,6 +103,7 @@ These are the authority for human-review expectations, screenshot checkpoints, a
 - If the risk is a user journey, authoring interaction, persistence flow, or browser-only regression, use Playwright.
 - If the risk is mostly visual hierarchy, overlap, spacing, or state affordance, add a targeted screenshot assertion or screenshot review artifact instead of only a full-page smoke test.
 - If the risk is documentation fidelity, use the docs screenshot harness rather than general E2E tests.
+- If the risk is a market-critical BI workflow, require semantic proof as high in the stack as needed: query-log change, visible row-count change, KPI/value change, chart-series change, or another user-visible analytical outcome.
 
 ### Push Tests Down
 
@@ -123,6 +127,23 @@ Example:
 - field role inference belongs in `packages/data-model/test/`
 - a field picker showing the inferred result belongs in a designer or workflow test
 - the full dashboard journey should only assert that the user-facing outcome still works
+
+For dashboards and host examples, do not stop at proving that a dropdown, toggle, or click handler changed internal state. Prove that the dashboard meaning changed in the way the user expected.
+
+## Market-Critical Discovery Priorities
+
+When hardening toward release, hunt for blockers in this order:
+
+1. host-owned filtering and query refresh
+2. authoring to publish/import to viewer round-trip
+3. import/export robustness and schema survivability
+4. cross-filter, drill, and page-management flows
+5. probe and live-backend onboarding behavior
+6. multi-instance isolation, theming, and responsive integrity
+7. large-dashboard performance and memory stability
+8. docs-following first-use onboarding
+
+Treat a human-found miss as a tracer bullet, not as proof that only one workflow is weak.
 
 ## Live Backend Probe Validation
 
@@ -196,6 +217,12 @@ Repo-specific notes:
 - the root suite currently targets Chromium and Firefox
 - the dev app origin is controlled by `SUPERSUBSET_DEV_APP_PORT` and defaults to `http://localhost:3000`
 
+For release-oriented BI validation, prefer the strongest host-owned test bed that can prove the behavior:
+
+- `examples/vite-sqlite` for deterministic query-log and rendered-data assertions
+- `examples/nextjs-ecommerce` workbench for auth and host query contract assertions
+- `packages/dev-app` for rich authoring and reproduction of designer-side behavior
+
 ## Evidence Expectations
 
 Before calling testing work done, leave evidence at the right layer:
@@ -210,6 +237,7 @@ For human-found bugs:
 - reproduce the bug cheaply
 - add the regression at the lowest adequate layer
 - add a higher-level test only if the user-facing risk still needs explicit proof
+- if the bug is critical or high severity and survives initial triage, open an issue immediately and treat it as a release blocker until fixed and regressed
 
 ## Anti-Patterns
 
@@ -223,6 +251,7 @@ For human-found bugs:
 ## See Also
 
 - `.github/skills/browser-testing/SKILL.md`
+- `.github/skills/bi-visualization-quality/SKILL.md`
 - `.github/skills/branch-ci-promotion/SKILL.md`
 - `docs/testing/verification-strategy.md`
 - `docs/testing/qa-checklist.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ When modifying files in specific packages, read the corresponding instruction fi
 For domain-specific knowledge, read the relevant skill file:
 
 - **Schema design**: `.github/skills/schema-design/SKILL.md`
+- **BI visualization quality**: `.github/skills/bi-visualization-quality/SKILL.md`
 - **ECharts widgets**: `.github/skills/echarts-widgets/SKILL.md`
 - **Designer shell design**: `.github/skills/designer-design/SKILL.md`
 - **Puck integration**: `.github/skills/puck-integration/SKILL.md`

--- a/docs/testing/history/README.md
+++ b/docs/testing/history/README.md
@@ -2,8 +2,9 @@
 
 QA audit logs ordered by date. Each file records what was tested, bugs found, bugs fixed, and remaining gaps — so future agents can pick up where the last round left off.
 
-| File                               | Date       | Scope                                            |
-| ---------------------------------- | ---------- | ------------------------------------------------ |
-| [qa-pre-audit.md](qa-pre-audit.md) | 2026-04-11 | Initial 31-bug sweep across all packages         |
-| [qa-round-1.md](qa-round-1.md)     | 2026-04-16 | Chart rendering, example apps, QA skill creation |
-| [qa-round-2.md](qa-round-2.md)     | 2026-04-16 | Lint, a11y, undo/redo, edge cases, performance   |
+| File                                                             | Date       | Scope                                                                        |
+| ---------------------------------------------------------------- | ---------- | ---------------------------------------------------------------------------- |
+| [qa-pre-audit.md](qa-pre-audit.md)                               | 2026-04-11 | Initial 31-bug sweep across all packages                                     |
+| [qa-round-1.md](qa-round-1.md)                                   | 2026-04-16 | Chart rendering, example apps, QA skill creation                             |
+| [qa-round-2.md](qa-round-2.md)                                   | 2026-04-16 | Lint, a11y, undo/redo, edge cases, performance                               |
+| [qa-round-3-market-readiness.md](qa-round-3-market-readiness.md) | 2026-05-02 | Market-readiness campaign plan, blocker hunt, and parallel PR dispatch model |

--- a/docs/testing/history/qa-round-3-market-readiness.md
+++ b/docs/testing/history/qa-round-3-market-readiness.md
@@ -1,0 +1,380 @@
+# QA Round 3 — Market Readiness Campaign Kickoff
+
+**Date**: 2026-05-02  
+**Role**: Orchestrator  
+**Branch**: `issue/market-readiness-orchestrator`
+
+## Purpose
+
+This entry is the repo-tracked source of truth for the market-readiness campaign.
+
+The triggering signal was a human-found dropdown/filter configuration miss. The campaign does not assume that issue is the only blocker. It treats that miss as a tracer bullet for a broader release-blocker hunt across the highest-risk Supersubset workflows.
+
+## Release Standard
+
+Supersubset is not ready for market until:
+
+- all campaign-found critical and high severity issues are fixed, reviewed by a human, and merged into `develop`
+- medium severity issues are triaged with owners and explicit follow-up
+- release-gate evidence is refreshed with focused browser proof plus full repo validation
+
+## Campaign Scope
+
+The campaign targets the workflows most likely to hide release-stopping defects:
+
+1. Host-owned filtering and query refresh in real host examples
+2. Authoring to publish/import to viewer round-trip
+3. Import/export robustness and schema survivability
+4. Cross-filter, drill, and page-management flows
+5. Probe and live-backend onboarding behavior
+6. Multi-instance isolation, theming, and responsive integrity
+7. Large-dashboard performance and memory stability
+8. Docs-following first-use onboarding from a clean shell
+
+The authored filter incident remains the first tracer bullet, not the only target.
+
+## Test Beds
+
+- `examples/vite-sqlite` is the primary deterministic BI environment
+- `examples/nextjs-ecommerce` workbench is the auth/query contract environment
+- `packages/dev-app` is the rich authoring and reproduction surface
+
+## Execution Phases
+
+### Phase 0 — Orchestrator setup
+
+- create isolated worktrees from fresh `origin/develop`
+- reserve explicit local port tuples for browser validation
+- keep hot files single-writer
+- use this file as the canonical cross-tool plan artifact
+
+### Phase 1 — Testing skill hardening
+
+- update `.github/skills/testing-strategy/SKILL.md`
+- update `.github/skills/browser-testing/SKILL.md`
+- require semantic BI assertions, not just control-state or screenshot proof
+
+### Phase 2 — BI visualization quality guidance
+
+- add a new BI visualization quality skill grounded in Data-to-Viz, Claus Wilke, and Tableau guidance
+- thread it into testing strategy, browser testing, and release-check docs
+
+### Phase 3 — History and browser-plan refresh
+
+- update testing history and add any new browser-plan artifacts needed for repeatable release checks
+
+### Phase 4 — Blocker discovery sweep
+
+- run a market-critical sweep across the primary test beds
+- collect browser evidence, query-log evidence, and console/network evidence
+- convert reproduced blockers into issues immediately
+
+### Phase 5 — Observability augmentation
+
+- add stable test ids, query-log hooks, explicit fixtures, and reset/versioning helpers only where needed to prove failures clearly
+- preserve the host-owned contract unless the product contract itself is proven wrong
+
+### Phase 6 — Coverage closure
+
+- tighten low-level tests where coverage stops at state, serialization, or smoke presence
+- add or extend Playwright workflows for every release-critical class exposed by discovery
+
+### Phase 7 — Parallel blocker dispatch
+
+- every reproduced critical/high blocker that survives initial triage gets a GitHub issue
+- the orchestrator dispatches bounded subagents in parallel, each with its own worktree, branch, file scope, leased ports, and acceptance criteria
+- each subagent is expected to return a PR-ready branch targeting `develop`
+- human review and merge remain mandatory
+
+### Phase 8 — Reconciliation
+
+- rebase and sequence branches that overlap on shared `e2e/**` files or other hot surfaces
+- rerun the narrowest affected checks after each merge-order change
+
+### Phase 9 — Final release gate
+
+- rerun focused package and browser checks
+- rerun `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm test:e2e`
+- refresh HC-9 style evidence before declaring readiness
+
+## Parallel Blocker Dispatch Matrix
+
+### Authored filter design or serialization defect
+
+- agent: `designer`
+- branch: `issue/filter-authoring-gap-designer`
+- worktree: `../supersubset-issue-filter-authoring-designer`
+- may modify: `packages/designer/**`, `packages/dev-app/**`, `packages/designer/test/**`
+- must not modify: `packages/runtime/**`, `e2e/**`, `examples/**`, root hot files
+
+### Runtime filter propagation or callback contract defect
+
+- agent: `runtime`
+- branch: `issue/filter-runtime-contract`
+- worktree: `../supersubset-issue-filter-runtime`
+- may modify: `packages/runtime/**`, `packages/runtime/test/**`, minimal `packages/dev-app/**` if required for repro
+- must not modify: `packages/designer/**`, `e2e/**`, `examples/**`, root hot files
+
+### Deterministic BI host defect in Vite SQLite
+
+- agent: `testing`
+- branch: `issue/filter-host-vite-sqlite`
+- worktree: `../supersubset-issue-filter-vite-sqlite`
+- may modify: `examples/vite-sqlite/**`, `e2e/workflows/**`, `e2e/interactions/**`, `docs/testing/browser-test-plans/**`
+- must not modify: `packages/designer/**`, `packages/runtime/**`, root hot files
+
+### Auth/query contract defect in Next.js workbench
+
+- agent: `testing`
+- branch: `issue/filter-host-nextjs-workbench`
+- worktree: `../supersubset-issue-filter-nextjs-workbench`
+- may modify: `examples/nextjs-ecommerce/**`, `e2e/workflows/**`, `docs/testing/browser-test-plans/**`
+- must not modify: `packages/designer/**`, `packages/runtime/**`, root hot files
+
+### Coverage hole without a proven product defect
+
+- agent: `testing`
+- branch: `issue/filter-e2e-gap`
+- worktree: `../supersubset-issue-filter-e2e`
+- may modify: `e2e/**`, `docs/testing/**`, `screenshots/**`
+- must not modify: `packages/**`, `examples/**`, root hot files
+
+### Testing playbook or BI-quality guidance gap
+
+- agent: orchestrator or bounded docs-only subagent
+- branch: `issue/testing-playbook-hardening`
+- worktree: `../supersubset-issue-testing-playbook`
+- may modify: `.github/skills/**`, `docs/testing/**`, `docs/status/checkpoints/**`
+- must not modify: `packages/**`, `examples/**`, `e2e/**` except for doc-only references
+
+## Exact Blocker Brief Templates
+
+### Template: Authored filter design or serialization defect
+
+- agent: `designer`
+- scope: fix authored filter creation, editing, filter-bar configuration, or designer-side round-trip defects
+- expected outputs: PR-ready branch, focused designer tests, concise before/after behavior note
+- non-goals: runtime contract redesign, host-query logic changes, unrelated broad `e2e/**` work
+- acceptance: filter definitions and `FilterBarBlock` config survive create/edit/publish/import with regression coverage
+
+### Template: Runtime filter propagation or callback contract defect
+
+- agent: `runtime`
+- scope: fix defects where authored filters, `onFilterChange`, `activeFilters`, or runtime controls violate the documented contract
+- expected outputs: PR-ready branch, focused runtime validation, explicit note about contract preservation or change
+- non-goals: designer authoring fixes, example-specific business logic rewrites, broad Playwright work
+- acceptance: runtime emits the right filter state and preserves the host-owned model unless escalation was explicitly approved
+
+### Template: Vite SQLite host query or render defect
+
+- agent: `testing`
+- scope: reproduce in `examples/vite-sqlite/**`, add only the observability hooks required, and tighten the smallest relevant workflow test
+- expected outputs: PR-ready branch, targeted Playwright evidence, query-log before/after proof
+- non-goals: speculative runtime or designer refactors, unrelated workbench changes
+- acceptance: host action changes SQLite query inputs and visible dashboard output deterministically
+
+### Template: Next.js workbench auth or query contract defect
+
+- agent: `testing`
+- scope: reproduce in `examples/nextjs-ecommerce/**`, fix the smallest auth/session/query path needed, and tighten the narrowest workflow
+- expected outputs: PR-ready branch, targeted Playwright evidence showing payload/query mutation plus visible viewer change
+- non-goals: broad designer/runtime rewrites, SQLite example edits
+- acceptance: workbench stays auth-correct, query-correct, and visually correct through the failing journey
+
+### Template: Coverage hole with no product defect proven yet
+
+- agent: `testing`
+- scope: modify `e2e/**`, `docs/testing/**`, and `screenshots/**` only
+- expected outputs: PR-ready branch, strengthened workflow or browser plan, proof that the new check owns the previously unguarded behavior
+- non-goals: speculative product fixes or package changes
+- acceptance: the missing release-critical behavior is now covered by a repeatable check
+
+### Template: Testing playbook or BI-visualization guidance gap
+
+- agent: orchestrator or docs-only bounded subagent
+- scope: modify `.github/skills/**`, `docs/testing/**`, and checkpoint docs only
+- expected outputs: PR-ready branch, linked skill/docs updates, concise summary of the new required evidence
+- non-goals: product code changes, broad E2E rewrites beyond reference updates
+- acceptance: the missing rule is explicit, linked, and reflected in release-gate docs
+
+## Merge-Order Table
+
+- `issue/testing-playbook-hardening` with any other branch: parallel-safe
+- `issue/filter-authoring-gap-designer` with `issue/filter-runtime-contract`: parallel-safe unless both touch `packages/dev-app/**`
+- `issue/filter-authoring-gap-designer` with `issue/filter-e2e-gap`: merge designer first if new test hooks are required
+- `issue/filter-runtime-contract` with `issue/filter-e2e-gap`: merge runtime first when E2E asserts new runtime behavior
+- `issue/filter-host-vite-sqlite` with `issue/filter-host-nextjs-workbench`: parallel-safe if `e2e/**` files do not overlap
+- `issue/filter-host-vite-sqlite` with `issue/filter-e2e-gap`: usually merge host branch first if generic E2E depends on its hooks
+- `issue/filter-host-nextjs-workbench` with `issue/filter-e2e-gap`: same sequencing rule as above
+- any overlapping `e2e/workflows/**` edits: treat as sequential
+- any unexpected root hot-file or `packages/schema/src/**` touch: stop parallel execution and escalate to orchestrator
+- after sequential merges on shared E2E surfaces, rerun the narrowest impacted specs before the full release gate
+
+## Immediate Next Step
+
+Implementation begins by using this file, not tool memory, as the canonical campaign plan.
+
+The first active work should be:
+
+1. update the testing skills and QA/checkpoint docs to reflect semantic BI assertions
+2. run the discovery sweep on the real host examples and dev-app authoring surface
+3. open GitHub issues for any reproduced critical/high blockers
+4. dispatch parallel subagents where blockers survive initial triage
+
+## Initial Findings — 2026-05-02
+
+### PASS — Vite SQLite host example proves semantic filter behavior
+
+- environment: `http://localhost:3112`
+- check: changed `Region` from `All` to `APAC`
+- result: SQL statements changed from unfiltered queries to `WHERE region = ? -- ["APAC"]`
+- visible outcome: KPI values changed from `$37,780.00 / 24 / $1,574.17` to `$11,535.00 / 8 / $1,441.88`
+- visible outcome: table rows collapsed to APAC-only records
+- conclusion: the host-owned filter contract is sound in the deterministic BI example
+
+### PASS — Next.js real host workbench proves auth + query contract behavior
+
+- environment: `http://localhost:3111/workbench`
+- check: logged in with demo credentials, switched to viewer, changed `Region` from `All` to `APAC`
+- result: host query log changed from empty filters to `{"fieldId":"region","operator":"eq","value":"APAC"}` across all published widgets
+- visible outcome: KPI values changed from `$403.9K / 2.5K / 91.06%` to `$108.6K / 646 / 93.78%`
+- visible outcome: table rows collapsed to APAC lanes only
+- conclusion: the production-like host example also honors the filter contract
+
+## Focused Executable Validations — 2026-05-02
+
+### PASS — Host integration workflow
+
+- command: `SUPERSUBSET_DEV_APP_PORT=3110 SUPERSUBSET_EXAMPLE_NEXTJS_PORT=3111 SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT=3112 pnpm --dir /Users/kenxono/apps/supersubset-issue-market-readiness-orchestrator exec playwright test e2e/workflows/host-integration.spec.ts --config=playwright.e2e.config.ts`
+- result: `2 passed`
+- scope proven: runtime-only Next host mount/theming path and Vite SQLite import/persist/reload path
+
+### PASS — Next.js workbench workflow
+
+- command: `SUPERSUBSET_DEV_APP_PORT=3110 SUPERSUBSET_EXAMPLE_NEXTJS_PORT=3111 SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT=3112 pnpm --dir /Users/kenxono/apps/supersubset-issue-market-readiness-orchestrator exec playwright test e2e/workflows/host-workbench.spec.ts --config=playwright.e2e.config.ts`
+- result: `1 passed`
+- scope proven: login, dataset loading, publish, viewer-mode re-query, and host-owned payload mutation
+
+### PASS — Probe onboarding workflow
+
+- command: `SUPERSUBSET_DEV_APP_PORT=3110 SUPERSUBSET_EXAMPLE_NEXTJS_PORT=3111 SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT=3112 pnpm --dir /Users/kenxono/apps/supersubset-issue-market-readiness-orchestrator exec playwright test e2e/workflows/probe-metadata-paste.spec.ts --project=chromium`
+- result: `1 passed`
+- scope proven: metadata paste onboarding reaches the probe designer with deterministic discovery status
+
+### PASS — Import/export workflow
+
+- command: `SUPERSUBSET_DEV_APP_PORT=3110 SUPERSUBSET_EXAMPLE_NEXTJS_PORT=3111 SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT=3112 pnpm --dir /Users/kenxono/apps/supersubset-issue-market-readiness-orchestrator exec playwright test e2e/workflows/import-export-cycle.spec.ts --project=chromium`
+- result: `5 passed`
+- scope proven: import/export cycle remains healthy in the leased-port orchestrator environment
+
+### PASS — Persistence regression workflow
+
+- command: `SUPERSUBSET_DEV_APP_PORT=3110 SUPERSUBSET_EXAMPLE_NEXTJS_PORT=3111 SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT=3112 pnpm --dir /Users/kenxono/apps/supersubset-issue-market-readiness-orchestrator exec playwright test e2e/workflows/persistence-regression.spec.ts --project=chromium`
+- result: `2 passed`
+- scope proven: persisted state workflows remain intact in the leased-port orchestrator environment
+
+### PASS — Full Chromium Playwright suite on orchestrator branch
+
+- command: `SUPERSUBSET_DEV_APP_PORT=3110 SUPERSUBSET_EXAMPLE_NEXTJS_PORT=3111 SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT=3112 pnpm --dir /Users/kenxono/apps/supersubset-issue-market-readiness-orchestrator exec playwright test --project=chromium`
+- result: `43 passed`
+- campaign read: broad browser regression health is currently strong, but this full-suite pass coexists with known story/demo gaps such as issues `#104` and `#106`, which confirms that the remaining risk is concentrated in missing semantic/assertion coverage and first-party demo fidelity rather than general browser instability
+
+### GAP — Existing dashboard-filter workflow missed issue #104
+
+- command: `SUPERSUBSET_DEV_APP_PORT=3110 SUPERSUBSET_EXAMPLE_NEXTJS_PORT=3111 SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT=3112 pnpm --dir /Users/kenxono/apps/supersubset-issue-market-readiness-orchestrator exec playwright test e2e/interactions/dashboard-filter.spec.ts --config=playwright.e2e.config.ts`
+- result: `3 passed`
+- important context: this suite passed on the orchestrator branch while the dev-app live dashboard still exhibited issue `#104`
+- conclusion: the current interaction coverage proves control-state sharing and registry integrity, but not the visible analytical outcome a human expects
+- campaign impact: semantic BI assertions are required in this class of workflow, not only control-state assertions
+
+### HIGH — Dev app live dashboard makes authored filters appear broken
+
+- environment: `http://localhost:3110`
+- check: stayed in `Viewer` with the default `Live dashboard` scenario and changed `Region` from `All` to `North`
+- result: filter controls updated, mirrored filter bar updated, and `Clear filters` appeared
+- visible outcome: KPI values and the orders table did not change
+- localization: `packages/dev-app/src/main.tsx` injects static `DEMO_DATA` and only logs `onFilterChange`
+- triage: this is not a core runtime-contract failure because both real host examples pass; it is a first-party demo and release-readiness blocker because a human can reasonably conclude that authored dropdown filters do not work
+
+### HIGH — Leased-port E2E config bug blocks parallel-worktree workflow validation
+
+- localization: `playwright.e2e.config.ts`
+- reproduction: focused workflows such as `designer-page-management` and `filter-cascade` fail immediately with `ERR_CONNECTION_REFUSED` at `http://localhost:3006/` even while the correct worktree services are running on leased ports
+- cause: the E2E config hardcodes `baseURL` to `http://localhost:3006`
+- triage: this is a testing-infrastructure blocker for the parallel-agent environment, not a product-runtime defect
+
+### MEDIUM/HIGH — Multi-page dev-app demo misrepresents shared filters and chart navigation
+
+- environment: `http://localhost:3110`, `Viewer` -> `One dashboard, two pages`
+- reproduced behavior: both `Overview` and `Region Detail` showed `0` `.ss-filter-bar` elements even though the scenario copy claims shared filters
+- reproduced behavior: the overview rendered five widgets, but the last two widget slots were empty/inert from a user perspective and clicking the first empty chart slot did not navigate to the detail page
+- localization: `packages/dev-app/src/navigation-demo.ts` declares global filters and a click-to-page interaction, but the user-facing demo does not currently expose that behavior in an exercisable way
+- triage: this is currently a first-party demo/story mismatch; underlying runtime health is not yet disproven by this finding
+
+## Issue Dispatches
+
+### Issue #104 — Dev app live dashboard filters update controls but not rendered data
+
+- issue: `https://github.com/wandir-tech/supersubset/issues/104`
+- severity: high
+- status: fixed in PR `#107`, merged into `develop`
+- dedicated fix branch: `issue/104-dev-app-live-dashboard-filters`
+- dedicated fix worktree: `/Users/kenxono/apps/supersubset-issue-104-dev-app-filters`
+- assigned mode: bounded parallel implementation for PR-ready human review
+- subagent outcome: testing subagent reported a PR-ready fix branch that makes the dev-app live viewer recompute demo KPI, trend, region, and table payloads from current filter values and adds regression coverage in `e2e/interactions/dashboard-filter.spec.ts`
+- PR: `https://github.com/wandir-tech/supersubset/pull/107`
+
+### Issue #105 — `playwright.e2e.config.ts` hardcodes localhost:3006 and breaks leased-port worktree runs
+
+- issue: `https://github.com/wandir-tech/supersubset/issues/105`
+- severity: high for testing infrastructure
+- status: fixed in PR `#108`, merged into `develop`
+- dedicated fix branch: `issue/105-playwright-e2e-leased-ports`
+- dedicated fix worktree: `/Users/kenxono/apps/supersubset-issue-105-playwright-e2e`
+- assigned mode: bounded parallel implementation for PR-ready human review
+- subagent outcome: testing subagent reported a PR-ready fix in `playwright.e2e.config.ts` that resolves the dev-app origin from env vars and/or `tmp/devenv-state.json`, validated via leased-port smoke runs
+- PR: `https://github.com/wandir-tech/supersubset/pull/108`
+
+### Issue #106 — Multi-page dev-app demo claims shared filters and chart navigation, but renders no filter bar and inert chart slots
+
+- issue: `https://github.com/wandir-tech/supersubset/issues/106`
+- severity: medium/high
+- status: fixed in PR `#109`, merged into `develop`
+- dedicated fix branch: `issue/106-page-demo-fidelity`
+- dedicated fix worktree: `/Users/kenxono/apps/supersubset-issue-106-page-demo`
+- assigned mode: bounded parallel implementation for PR-ready human review
+- subagent outcome: page-demo definitions now render shared filter bars on both pages, scenario copy matches the exercisable behavior, and browser coverage proves filter state persists across page switches
+- PR: `https://github.com/wandir-tech/supersubset/pull/109`
+
+## Update — 2026-05-02 after merged blocker branches
+
+### PASS — Current `develop` workflow sweep after PRs #107, #108, and #109
+
+- command: `pnpm exec playwright test e2e/workflows --project=chromium`
+- result: `33 passed`
+- scope proven: current `develop` keeps the workflow matrix green after the live-dashboard, leased-port, and page-demo fixes landed
+
+### PASS — Current `develop` interaction and first-party happy-path sweep
+
+- command: `pnpm exec playwright test e2e/smoke.spec.ts e2e/plan-a-designer-happy-path.spec.ts e2e/interactions/dashboard-filter.spec.ts --project=chromium`
+- result: `12 passed`
+- scope proven: smoke coverage, the core designer path, and the semantic dashboard-filter regression remain healthy on the merged base
+
+### PASS — Current `develop` visual snapshot sweep
+
+- command: `pnpm exec playwright test e2e/visual/chart-header-layout.spec.ts --project=chromium`
+- result: `1 passed`
+- scope proven: the remaining visual snapshot check still matches its baseline on the merged base
+
+## Current Campaign Read
+
+- host-owned filter/query behavior: proven in both real host examples
+- authoring/publish/import/viewer round-trip: currently backed by passing focused Playwright workflows in the host examples
+- probe onboarding: currently backed by a passing focused workflow in the leased-port orchestrator environment
+- import/export and persistence: currently backed by passing focused workflows in the leased-port orchestrator environment
+- designer filter configuration surface: present and supports dropdown control authoring in the dev app
+- first-party live demo readiness: repaired on `develop` by issue `#104` / PR `#107`
+- test-infrastructure readiness: repaired on `develop` by issue `#105` / PR `#108`
+- page-demo story health: repaired on `develop` by issue `#106` / PR `#109`
+- current browser-suite health: current `develop` passed `33` workflow tests, `12` smoke/interaction/happy-path tests, and `1` visual snapshot test in Chromium after the blocker merges
+- next discovery class: docs-following onboarding, repo-wide release-gate commands, and deeper performance or memory validation now that the first-party blocker set is merged

--- a/docs/testing/history/qa-round-3-market-readiness.md
+++ b/docs/testing/history/qa-round-3-market-readiness.md
@@ -366,6 +366,18 @@ The first active work should be:
 - result: `1 passed`
 - scope proven: the remaining visual snapshot check still matches its baseline on the merged base
 
+### PASS — Current `develop` repo-wide release gate
+
+- command: `pnpm lint`
+- result: passed across the workspace packages and examples
+- command: `pnpm typecheck`
+- result: passed across the workspace packages and examples
+- command: `pnpm test`
+- result: passed across the workspace package test suites
+- command: `pnpm test:e2e`
+- result: `92 passed`
+- scope proven: the merged base currently clears the full repo release gate, not only the targeted browser slices used during blocker triage
+
 ## Current Campaign Read
 
 - host-owned filter/query behavior: proven in both real host examples
@@ -377,4 +389,5 @@ The first active work should be:
 - test-infrastructure readiness: repaired on `develop` by issue `#105` / PR `#108`
 - page-demo story health: repaired on `develop` by issue `#106` / PR `#109`
 - current browser-suite health: current `develop` passed `33` workflow tests, `12` smoke/interaction/happy-path tests, and `1` visual snapshot test in Chromium after the blocker merges
-- next discovery class: docs-following onboarding, repo-wide release-gate commands, and deeper performance or memory validation now that the first-party blocker set is merged
+- current repo-wide release gate: `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm test:e2e` all pass on current `develop`
+- next discovery class: docs-following onboarding and deeper performance or memory validation now that the first-party blocker set and repo-wide gates are green

--- a/docs/testing/qa-checklist.md
+++ b/docs/testing/qa-checklist.md
@@ -26,6 +26,10 @@
 - [ ] Long legend labels wrap or scroll without colliding with chart titles
 - [ ] Color palette is consistent across chart types
 - [ ] Icons are clear and properly sized
+- [ ] The chosen chart type matches the analytical task instead of merely rendering the data
+- [ ] Pie/donut usage is limited to small, legible part-to-whole cases
+- [ ] Truncated axes, if used, are clearly signaled and not visually misleading
+- [ ] Multi-series line charts remain readable and do not collapse into spaghetti
 
 ## Keyboard Navigation
 
@@ -64,6 +68,9 @@
 - [ ] Loading spinners are visible and centered
 - [ ] Error states don't break the layout
 - [ ] Tooltips appear within viewport bounds
+- [ ] Titles, legends, labels, and units are understandable without insider field knowledge
+- [ ] Filters are grouped and labeled in a way a first-time user can operate correctly
+- [ ] Filter changes create an obvious analytical outcome, not just a changed control value
 
 ## State & Persistence Workflows
 
@@ -74,6 +81,7 @@
 - [ ] Page selection recovers safely when an imported dashboard changes the page set
 - [ ] Page delete confirmation names the targeted page and fallback selection is predictable
 - [ ] Undo/redo history resets or advances intentionally after import/publish actions
+- [ ] Host-owned viewers re-query or recompute correctly after user-facing filter changes
 
 ## Automated Regression Expectations
 
@@ -81,3 +89,4 @@
 - [ ] Visual regressions for canvas charts use targeted screenshot baselines
 - [ ] Workflow tests fail on unexpected console errors or warnings
 - [ ] Import/export tests assert semantic equivalence, not only that a dialog opens
+- [ ] Market-critical host workflows assert query-log, payload, row-count, KPI, or equivalent semantic outcomes when applicable

--- a/docs/testing/verification-strategy.md
+++ b/docs/testing/verification-strategy.md
@@ -16,53 +16,57 @@ Not:
 Write all code → Hope it works → Test at end → Find drift → Rework
 ```
 
+For BI-facing features, add one more rule: do not stop at proving that a control changed state when the real user expectation is a changed analytical result.
+
 ---
 
 ## Test Layers and Ownership
 
 ### Layer 1: Unit Tests (every task, every agent)
 
-| What | When | Where | Tool |
-|------|------|-------|------|
-| Schema validation | With every type change | `packages/schema/test/` | Vitest |
-| Serialization round-trips | With every serializer change | `packages/schema/test/` | Vitest |
-| Widget config validation | With every widget | `packages/charts-echarts/test/` | Vitest |
-| Adapter normalization | With every adapter | `packages/adapter-*/test/` | Vitest |
-| Filter state transitions | With filter engine | `packages/runtime/test/` | Vitest |
-| Registry lookup | With widget registry | `packages/runtime/test/` | Vitest |
+| What                      | When                         | Where                           | Tool   |
+| ------------------------- | ---------------------------- | ------------------------------- | ------ |
+| Schema validation         | With every type change       | `packages/schema/test/`         | Vitest |
+| Serialization round-trips | With every serializer change | `packages/schema/test/`         | Vitest |
+| Widget config validation  | With every widget            | `packages/charts-echarts/test/` | Vitest |
+| Adapter normalization     | With every adapter           | `packages/adapter-*/test/`      | Vitest |
+| Filter state transitions  | With filter engine           | `packages/runtime/test/`        | Vitest |
+| Registry lookup           | With widget registry         | `packages/runtime/test/`        | Vitest |
 
 **Rule**: No task is marked complete without passing unit tests in the affected package.
 
 ### Layer 2: Playwright E2E Tests (incremental, per-feature)
 
-| What | When Written | Where | Runs |
-|------|-------------|-------|------|
-| Renderer renders fixture dashboard | Task 1.16 (dev app scaffold) | `e2e/renderer/` | CI + pre-commit |
-| Each chart type renders | Tasks 1.11–1.14 (each chart) | `e2e/charts/` | CI |
-| Designer loads empty state | Task 2.1 (editor shell) | `e2e/designer/` | CI |
-| Drag-and-drop adds widget | Task 2.2 (first block) | `e2e/designer/` | CI |
-| Property edit updates widget | Task 2.5 (property panels) | `e2e/designer/` | CI |
-| Import/export round-trip | Task 2.10 (import/export) | `e2e/designer/` | CI |
-| Cross-filter propagates | Task 4.2 (cross-filtering) | `e2e/interactions/` | CI |
-| Host mount works | Task 5.5 (host examples) | `e2e/integration/` | CI |
+| What                               | When Written                 | Where               | Runs            |
+| ---------------------------------- | ---------------------------- | ------------------- | --------------- |
+| Renderer renders fixture dashboard | Task 1.16 (dev app scaffold) | `e2e/renderer/`     | CI + pre-commit |
+| Each chart type renders            | Tasks 1.11–1.14 (each chart) | `e2e/charts/`       | CI              |
+| Designer loads empty state         | Task 2.1 (editor shell)      | `e2e/designer/`     | CI              |
+| Drag-and-drop adds widget          | Task 2.2 (first block)       | `e2e/designer/`     | CI              |
+| Property edit updates widget       | Task 2.5 (property panels)   | `e2e/designer/`     | CI              |
+| Import/export round-trip           | Task 2.10 (import/export)    | `e2e/designer/`     | CI              |
+| Cross-filter propagates            | Task 4.2 (cross-filtering)   | `e2e/interactions/` | CI              |
+| Host mount works                   | Task 5.5 (host examples)     | `e2e/integration/`  | CI              |
 
 **Rule**: Every UI-visible feature ships WITH its Playwright test, not after.
+
+**BI release rule**: If a filter, interaction, or host refresh is central to the feature, the Playwright test must assert a user-visible analytical outcome such as changed rows, KPI values, chart content, or host query payloads.
 
 ### Layer 3: Chrome MCP Verification (milestone screenshots)
 
 Chrome MCP is for **human-reviewable visual verification** at key moments:
 
-| When | What to Capture | Screenshot Naming |
-|------|----------------|-------------------|
-| First chart renders in dev-app | All 4 chart types side-by-side | `screenshots/phase-1/charts-first-render.png` |
-| Designer shell loads | Empty editor state | `screenshots/phase-2/designer-empty.png` |
-| First widget drag-and-drop | Before/after drag | `screenshots/phase-2/drag-drop-{before,after}.png` |
-| Property panel edits widget | Before/after edit | `screenshots/phase-2/property-edit-{before,after}.png` |
-| Full 4-widget dashboard | Complete designer state | `screenshots/phase-2/full-dashboard.png` |
-| JSON export → reimport | Side-by-side comparison | `screenshots/phase-2/round-trip-{original,reimported}.png` |
-| Cross-filter in action | Before/after filter click | `screenshots/phase-4/cross-filter-{before,after}.png` |
-| Responsive modes | Desktop/tablet/mobile | `screenshots/phase-5/responsive-{desktop,tablet,mobile}.png` |
-| Dark theme | Full dashboard in dark mode | `screenshots/phase-5/theme-dark.png` |
+| When                           | What to Capture                | Screenshot Naming                                            |
+| ------------------------------ | ------------------------------ | ------------------------------------------------------------ |
+| First chart renders in dev-app | All 4 chart types side-by-side | `screenshots/phase-1/charts-first-render.png`                |
+| Designer shell loads           | Empty editor state             | `screenshots/phase-2/designer-empty.png`                     |
+| First widget drag-and-drop     | Before/after drag              | `screenshots/phase-2/drag-drop-{before,after}.png`           |
+| Property panel edits widget    | Before/after edit              | `screenshots/phase-2/property-edit-{before,after}.png`       |
+| Full 4-widget dashboard        | Complete designer state        | `screenshots/phase-2/full-dashboard.png`                     |
+| JSON export → reimport         | Side-by-side comparison        | `screenshots/phase-2/round-trip-{original,reimported}.png`   |
+| Cross-filter in action         | Before/after filter click      | `screenshots/phase-4/cross-filter-{before,after}.png`        |
+| Responsive modes               | Desktop/tablet/mobile          | `screenshots/phase-5/responsive-{desktop,tablet,mobile}.png` |
+| Dark theme                     | Full dashboard in dark mode    | `screenshots/phase-5/theme-dark.png`                         |
 
 **Rule**: Screenshots are stored in `screenshots/` and committed to git. The human checkpoint review explicitly references which screenshots to inspect.
 
@@ -70,14 +74,31 @@ Chrome MCP is for **human-reviewable visual verification** at key moments:
 
 These are the "complete workflow" Playwright tests that exercise full user journeys:
 
-| Test | Covers | When Built |
-|------|--------|-----------|
-| `e2e/workflows/designer-to-renderer.spec.ts` | Create dashboard in designer → save → load in renderer → verify all widgets | After Phase 2 |
-| `e2e/workflows/designer-page-management.spec.ts` | Responsive designer shell + page add/rename/delete flows | After page-management controls land |
-| `e2e/workflows/import-export-cycle.spec.ts` | Create → export JSON → export YAML → import JSON → import YAML → compare | After Task 2.10 |
-| `e2e/workflows/metadata-to-dashboard.spec.ts` | Load Prisma model → browse fields → bind to chart → render | After Phase 3 |
-| `e2e/workflows/filter-cascade.spec.ts` | Add 3 filters → apply → verify all widgets update → clear → verify reset | After Phase 4 |
-| `e2e/workflows/host-integration.spec.ts` | Mount in host → save via callback → remount renderer → verify | After Phase 5 |
+| Test                                             | Covers                                                                      | When Built                          |
+| ------------------------------------------------ | --------------------------------------------------------------------------- | ----------------------------------- |
+| `e2e/workflows/designer-to-renderer.spec.ts`     | Create dashboard in designer → save → load in renderer → verify all widgets | After Phase 2                       |
+| `e2e/workflows/designer-page-management.spec.ts` | Responsive designer shell + page add/rename/delete flows                    | After page-management controls land |
+| `e2e/workflows/import-export-cycle.spec.ts`      | Create → export JSON → export YAML → import JSON → import YAML → compare    | After Task 2.10                     |
+| `e2e/workflows/metadata-to-dashboard.spec.ts`    | Load Prisma model → browse fields → bind to chart → render                  | After Phase 3                       |
+| `e2e/workflows/filter-cascade.spec.ts`           | Add 3 filters → apply → verify all widgets update → clear → verify reset    | After Phase 4                       |
+| `e2e/workflows/host-integration.spec.ts`         | Mount in host → save via callback → remount renderer → verify               | After Phase 5                       |
+
+Release hardening should add or strengthen workflows whenever a human finds a gap in one of these journeys. Human-found misses are evidence that the workflow matrix is incomplete, not just that one test needs a tweak.
+
+## Market-Critical Discovery Order
+
+When preparing for release or hardening a branch after human-found misses, investigate in this order:
+
+1. host-owned filtering and query refresh
+2. authoring → publish/import → viewer round-trip
+3. import/export robustness and schema survivability
+4. cross-filter, drill, and page-management behavior
+5. probe and live-backend onboarding
+6. multi-instance isolation, theming, and responsive integrity
+7. large-dashboard performance and memory stability
+8. docs-following first-use onboarding
+
+Use the real host examples whenever they provide stronger proof than the dev-app alone.
 
 ---
 
@@ -137,6 +158,7 @@ e2e/
 Screenshots are not just captured — they are **explicitly reviewed** at human checkpoints.
 
 ### Storage
+
 ```
 screenshots/
 ├── phase-1/          # Renderer and chart screenshots
@@ -147,12 +169,15 @@ screenshots/
 ```
 
 ### Automated Comparison
+
 - Playwright `toHaveScreenshot()` for pixel-diff regression
 - Baseline screenshots committed to `screenshots/baselines/`
 - Any diff > 1% threshold fails the test and requires human review
 
 ### Human Review Points
+
 At every human checkpoint, the review includes:
+
 1. Open `screenshots/phase-N/` in a file browser
 2. Visually inspect each screenshot for layout correctness
 3. Compare before/after pairs
@@ -167,34 +192,34 @@ This is the critical part. Tests are **not deferred**. Each development task has
 
 ### Phase 1
 
-| Dev Task | Test Task (same sprint) | Test File |
-|----------|------------------------|-----------|
-| 1.6 Runtime shell | Renderer mounts empty | `e2e/renderer/basic-render.spec.ts` |
-| 1.10 ECharts wrapper | Chart renders with fixture data | `e2e/renderer/chart-types.spec.ts` |
-| 1.11 Line chart | Line chart specific assertions | `e2e/renderer/chart-types.spec.ts` |
-| 1.12 Bar chart | Bar chart assertions | same file |
-| 1.13 Table | Table column/row assertions | same file |
-| 1.14 KPI card | KPI value/label assertions | same file |
-| 1.16 Dev app | Full dev app loads, no errors | `e2e/renderer/basic-render.spec.ts` |
+| Dev Task             | Test Task (same sprint)         | Test File                           |
+| -------------------- | ------------------------------- | ----------------------------------- |
+| 1.6 Runtime shell    | Renderer mounts empty           | `e2e/renderer/basic-render.spec.ts` |
+| 1.10 ECharts wrapper | Chart renders with fixture data | `e2e/renderer/chart-types.spec.ts`  |
+| 1.11 Line chart      | Line chart specific assertions  | `e2e/renderer/chart-types.spec.ts`  |
+| 1.12 Bar chart       | Bar chart assertions            | same file                           |
+| 1.13 Table           | Table column/row assertions     | same file                           |
+| 1.14 KPI card        | KPI value/label assertions      | same file                           |
+| 1.16 Dev app         | Full dev app loads, no errors   | `e2e/renderer/basic-render.spec.ts` |
 
 ### Phase 2
 
-| Dev Task | Test Task (same sprint) | Test File |
-|----------|------------------------|-----------|
-| 2.1 Puck shell | Designer loads empty | `e2e/designer/editor-load.spec.ts` |
-| 2.2 Chart blocks | Drag chart to canvas | `e2e/designer/drag-drop.spec.ts` |
-| 2.5 Property panel | Edit prop → widget updates | `e2e/designer/property-edit.spec.ts` |
-| 2.6 Data model browser | Field picker shows fields | `e2e/designer/field-binding.spec.ts` |
-| 2.9 Schema adapter | Puck data → canonical → back | unit test + `e2e/designer/code-view.spec.ts` |
-| 2.10 Import/export | Round-trip JSON/YAML | `e2e/designer/import-export.spec.ts` |
-| 2.12 Live preview | Preview matches editor | `e2e/designer/editor-load.spec.ts` |
-| 2.13 Undo/redo | Ctrl+Z works across edits | `e2e/designer/undo-redo.spec.ts` |
+| Dev Task               | Test Task (same sprint)      | Test File                                    |
+| ---------------------- | ---------------------------- | -------------------------------------------- |
+| 2.1 Puck shell         | Designer loads empty         | `e2e/designer/editor-load.spec.ts`           |
+| 2.2 Chart blocks       | Drag chart to canvas         | `e2e/designer/drag-drop.spec.ts`             |
+| 2.5 Property panel     | Edit prop → widget updates   | `e2e/designer/property-edit.spec.ts`         |
+| 2.6 Data model browser | Field picker shows fields    | `e2e/designer/field-binding.spec.ts`         |
+| 2.9 Schema adapter     | Puck data → canonical → back | unit test + `e2e/designer/code-view.spec.ts` |
+| 2.10 Import/export     | Round-trip JSON/YAML         | `e2e/designer/import-export.spec.ts`         |
+| 2.12 Live preview      | Preview matches editor       | `e2e/designer/editor-load.spec.ts`           |
+| 2.13 Undo/redo         | Ctrl+Z works across edits    | `e2e/designer/undo-redo.spec.ts`             |
 
 ### Phase 4
 
-| Dev Task | Test Task (same sprint) | Test File |
-|----------|------------------------|-----------|
-| 4.1 Dashboard filters | Filter widget filters data | `e2e/interactions/dashboard-filter.spec.ts` |
-| 4.2 Cross-filtering | Click bar → table updates | `e2e/interactions/cross-filter.spec.ts` |
-| 4.4 Drill-to-detail | Click → drill action fires | `e2e/interactions/drill-action.spec.ts` |
+| Dev Task              | Test Task (same sprint)    | Test File                                    |
+| --------------------- | -------------------------- | -------------------------------------------- |
+| 4.1 Dashboard filters | Filter widget filters data | `e2e/interactions/dashboard-filter.spec.ts`  |
+| 4.2 Cross-filtering   | Click bar → table updates  | `e2e/interactions/cross-filter.spec.ts`      |
+| 4.4 Drill-to-detail   | Click → drill action fires | `e2e/interactions/drill-action.spec.ts`      |
 | 4.6 State persistence | Reload → filters preserved | `e2e/interactions/state-persistence.spec.ts` |


### PR DESCRIPTION
## Summary
- add BI visualization quality guidance and wire it into the testing skills
- harden browser and testing strategy docs around semantic BI outcomes and blocker discovery ordering
- record the market-readiness campaign, merged blocker fixes, and current-develop validation results

## Validation
- pnpm exec prettier --check .github/skills/browser-testing/SKILL.md .github/skills/testing-strategy/SKILL.md .github/skills/bi-visualization-quality/SKILL.md CLAUDE.md docs/testing/history/README.md docs/testing/history/qa-round-3-market-readiness.md docs/testing/qa-checklist.md docs/testing/verification-strategy.md
- git diff --check

Context refreshed in the campaign note also records the current merged-base browser sweep:
- pnpm exec playwright test e2e/workflows --project=chromium
- pnpm exec playwright test e2e/smoke.spec.ts e2e/plan-a-designer-happy-path.spec.ts e2e/interactions/dashboard-filter.spec.ts --project=chromium
- pnpm exec playwright test e2e/visual/chart-header-layout.spec.ts --project=chromium