### PR TITLE
refactor: dedupe alert-rule helpers and severity types across packages

### DIFF
--- a/packages/charts-echarts/src/charts/AlertsWidget.tsx
+++ b/packages/charts-echarts/src/charts/AlertsWidget.tsx
@@ -1,6 +1,5 @@
 import type { WidgetProps } from '@supersubset/runtime';
-
-type AlertSeverity = 'info' | 'success' | 'warning' | 'danger';
+import { isAlertRuleSeverity, type AlertRuleSeverity } from '@supersubset/schema';
 
 const LAYOUT_STYLES: Record<'stack' | 'wrap' | 'inline', React.CSSProperties> = {
   stack: {
@@ -23,7 +22,7 @@ const LAYOUT_STYLES: Record<'stack' | 'wrap' | 'inline', React.CSSProperties> = 
 };
 
 const FALLBACK_SEVERITY_STYLES: Record<
-  AlertSeverity,
+  AlertRuleSeverity,
   { accent: string; background: string; border: string }
 > = {
   info: {
@@ -70,7 +69,9 @@ export function AlertsWidget({
   const maxItems = toPositiveInteger(config.maxItems);
   const emptyState = config.emptyState === 'hide' ? 'hide' : 'placeholder';
   const showTimestamp = config.showTimestamp !== false && config.showTimestamp !== 'false';
-  const defaultSeverity = isAlertSeverity(config.defaultSeverity) ? config.defaultSeverity : 'info';
+  const defaultSeverity = isAlertRuleSeverity(config.defaultSeverity)
+    ? config.defaultSeverity
+    : 'info';
   const visibleRows = maxItems ? rows.slice(0, maxItems) : rows;
   const borderColor = getThemeColor(theme, 'border', '#d9d9d9');
   const isDataUnavailable = datasetRef !== undefined && data === undefined && !loading && !error;
@@ -140,7 +141,7 @@ export function AlertsWidget({
         <div style={LAYOUT_STYLES[layout]}>
           {visibleRows.map((row, index) => {
             const severityValue = row[severityField];
-            const severity = isAlertSeverity(severityValue) ? severityValue : defaultSeverity;
+            const severity = isAlertRuleSeverity(severityValue) ? severityValue : defaultSeverity;
             const severityStyle = resolveSeverityStyle(theme, severity);
             const alertTitle =
               typeof row[titleField] === 'string' && row[titleField].trim().length > 0
@@ -261,7 +262,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function getThemeColor(
   theme: Record<string, unknown> | undefined,
-  token: AlertSeverity | 'border',
+  token: AlertRuleSeverity | 'border',
   fallback: string,
 ): string {
   if (!isRecord(theme)) {
@@ -277,7 +278,10 @@ function getThemeColor(
   return typeof color === 'string' && color.trim().length > 0 ? color : fallback;
 }
 
-function resolveSeverityStyle(theme: Record<string, unknown> | undefined, severity: AlertSeverity) {
+function resolveSeverityStyle(
+  theme: Record<string, unknown> | undefined,
+  severity: AlertRuleSeverity,
+) {
   const fallback = FALLBACK_SEVERITY_STYLES[severity];
   const accent = getThemeColor(theme, severity, fallback.accent);
 
@@ -298,10 +302,6 @@ function toPositiveInteger(value: unknown): number | null {
     return null;
   }
   return Math.floor(parsed);
-}
-
-function isAlertSeverity(value: unknown): value is AlertSeverity {
-  return value === 'info' || value === 'success' || value === 'warning' || value === 'danger';
 }
 
 function withAlpha(color: string, alpha: number): string | null {

--- a/packages/designer/src/adapters/alert-rule-helpers.ts
+++ b/packages/designer/src/adapters/alert-rule-helpers.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared helpers for translating designer-side alert rule fields
+ * (`ruleMetricField`, `ruleAggregation`, `ruleOperator`, `ruleThreshold`,
+ * `ruleTitle`, `ruleMessage`, `ruleSeverity`) into the canonical
+ * `alertRule` config and its in-progress `alertRuleDraft` shape.
+ *
+ * Both ChartPreview (live preview) and puck-canonical (save path) read
+ * the same designer field set, so the translation lives in one place.
+ */
+
+export const ALERT_RULE_DESIGNER_KEYS = [
+  'alertMode',
+  'ruleMetricField',
+  'ruleAggregation',
+  'ruleOperator',
+  'ruleThreshold',
+  'ruleTitle',
+  'ruleMessage',
+  'ruleSeverity',
+] as const;
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function finiteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+export function buildStructuredAlertRuleConfig(
+  source: Record<string, unknown>,
+): Record<string, unknown> | null {
+  if (source.alertMode !== 'structured') {
+    return null;
+  }
+
+  const metricFieldRef = nonEmptyString(source.ruleMetricField);
+  const aggregation = nonEmptyString(source.ruleAggregation);
+  const operator = nonEmptyString(source.ruleOperator);
+  const threshold = finiteNumber(source.ruleThreshold);
+  const title = nonEmptyString(source.ruleTitle);
+  const message = nonEmptyString(source.ruleMessage);
+  const severity = nonEmptyString(source.ruleSeverity) ?? undefined;
+
+  if (!metricFieldRef || !aggregation || !operator || threshold == null || !title || !message) {
+    return null;
+  }
+
+  return {
+    mode: 'structured',
+    metricFieldRef,
+    aggregation,
+    operator,
+    threshold,
+    alert: {
+      title,
+      message,
+      ...(severity ? { severity } : {}),
+    },
+  };
+}
+
+export function buildStructuredAlertRuleDraft(
+  source: Record<string, unknown>,
+): Record<string, unknown> | null {
+  if (source.alertMode !== 'structured') {
+    return null;
+  }
+
+  const draft: Record<string, unknown> = { mode: 'structured' };
+
+  const metricFieldRef = nonEmptyString(source.ruleMetricField);
+  if (metricFieldRef) draft.metricFieldRef = metricFieldRef;
+
+  const aggregation = nonEmptyString(source.ruleAggregation);
+  if (aggregation) draft.aggregation = aggregation;
+
+  const operator = nonEmptyString(source.ruleOperator);
+  if (operator) draft.operator = operator;
+
+  const threshold = finiteNumber(source.ruleThreshold);
+  if (threshold != null) draft.threshold = threshold;
+
+  const alert: Record<string, unknown> = {};
+
+  const title = nonEmptyString(source.ruleTitle);
+  if (title) alert.title = title;
+
+  const message = nonEmptyString(source.ruleMessage);
+  if (message) alert.message = message;
+
+  const severity = nonEmptyString(source.ruleSeverity);
+  if (severity) alert.severity = severity;
+
+  if (Object.keys(alert).length > 0) {
+    draft.alert = alert;
+  }
+
+  return draft;
+}

--- a/packages/designer/src/adapters/puck-canonical.ts
+++ b/packages/designer/src/adapters/puck-canonical.ts
@@ -17,6 +17,11 @@ import { PUCK_NAME_TO_WIDGET_TYPE, WIDGET_TYPE_TO_PUCK_NAME } from '../blocks/ch
 import { CONTENT_PUCK_NAME_TO_TYPE } from '../blocks/content';
 import { CONTROL_PUCK_NAME_TO_TYPE } from '../blocks/controls';
 import { LAYOUT_PUCK_NAME_TO_TYPE } from '../blocks/layout';
+import {
+  ALERT_RULE_DESIGNER_KEYS,
+  buildStructuredAlertRuleConfig,
+  buildStructuredAlertRuleDraft,
+} from './alert-rule-helpers';
 
 // All component type maps merged
 const puckNameToType: Record<string, string> = {
@@ -448,17 +453,6 @@ const NUMERIC_CONFIG_KEYS = new Set([
 
 const PUCK_STRING_NUMERIC_CONFIG_KEYS = new Set(['xAxisLabelRotate', 'areaOpacity', 'opacity']);
 
-const ALERT_RULE_DESIGNER_KEYS = [
-  'alertMode',
-  'ruleMetricField',
-  'ruleAggregation',
-  'ruleOperator',
-  'ruleThreshold',
-  'ruleTitle',
-  'ruleMessage',
-  'ruleSeverity',
-] as const;
-
 function normalizeBooleanRadioValue(value: unknown): unknown {
   if (value === 'true') return true;
   if (value === 'false') return false;
@@ -642,108 +636,6 @@ function buildWidgetDefinition(
   }
 
   return widget;
-}
-
-function buildStructuredAlertRuleConfig(
-  config: Record<string, unknown>,
-): Record<string, unknown> | null {
-  if (config.alertMode !== 'structured') {
-    return null;
-  }
-
-  const metricFieldRef =
-    typeof config.ruleMetricField === 'string' && config.ruleMetricField.trim().length > 0
-      ? config.ruleMetricField
-      : null;
-  const aggregation =
-    typeof config.ruleAggregation === 'string' && config.ruleAggregation.trim().length > 0
-      ? config.ruleAggregation
-      : null;
-  const operator =
-    typeof config.ruleOperator === 'string' && config.ruleOperator.trim().length > 0
-      ? config.ruleOperator
-      : null;
-  const threshold =
-    typeof config.ruleThreshold === 'number' && Number.isFinite(config.ruleThreshold)
-      ? config.ruleThreshold
-      : null;
-  const title =
-    typeof config.ruleTitle === 'string' && config.ruleTitle.trim().length > 0
-      ? config.ruleTitle
-      : null;
-  const message =
-    typeof config.ruleMessage === 'string' && config.ruleMessage.trim().length > 0
-      ? config.ruleMessage
-      : null;
-  const severity =
-    typeof config.ruleSeverity === 'string' && config.ruleSeverity.trim().length > 0
-      ? config.ruleSeverity
-      : undefined;
-
-  if (!metricFieldRef || !aggregation || !operator || threshold == null || !title || !message) {
-    return null;
-  }
-
-  return {
-    mode: 'structured',
-    metricFieldRef,
-    aggregation,
-    operator,
-    threshold,
-    alert: {
-      title,
-      message,
-      ...(severity ? { severity } : {}),
-    },
-  };
-}
-
-function buildStructuredAlertRuleDraft(
-  config: Record<string, unknown>,
-): Record<string, unknown> | null {
-  if (config.alertMode !== 'structured') {
-    return null;
-  }
-
-  const draft: Record<string, unknown> = {
-    mode: 'structured',
-  };
-
-  if (typeof config.ruleMetricField === 'string' && config.ruleMetricField.trim().length > 0) {
-    draft.metricFieldRef = config.ruleMetricField;
-  }
-
-  if (typeof config.ruleAggregation === 'string' && config.ruleAggregation.trim().length > 0) {
-    draft.aggregation = config.ruleAggregation;
-  }
-
-  if (typeof config.ruleOperator === 'string' && config.ruleOperator.trim().length > 0) {
-    draft.operator = config.ruleOperator;
-  }
-
-  if (typeof config.ruleThreshold === 'number' && Number.isFinite(config.ruleThreshold)) {
-    draft.threshold = config.ruleThreshold;
-  }
-
-  const alert: Record<string, unknown> = {};
-
-  if (typeof config.ruleTitle === 'string' && config.ruleTitle.trim().length > 0) {
-    alert.title = config.ruleTitle;
-  }
-
-  if (typeof config.ruleMessage === 'string' && config.ruleMessage.trim().length > 0) {
-    alert.message = config.ruleMessage;
-  }
-
-  if (typeof config.ruleSeverity === 'string' && config.ruleSeverity.trim().length > 0) {
-    alert.severity = config.ruleSeverity;
-  }
-
-  if (Object.keys(alert).length > 0) {
-    draft.alert = alert;
-  }
-
-  return draft;
 }
 
 function buildContentMeta(

--- a/packages/designer/src/preview/ChartPreview.tsx
+++ b/packages/designer/src/preview/ChartPreview.tsx
@@ -9,6 +9,11 @@
  */
 import React, { useMemo, useState, useEffect, type ComponentType } from 'react';
 import type { WidgetProps } from '@supersubset/runtime';
+import { normalizeAlertRuleSeverity, type AlertRuleSeverity } from '@supersubset/schema';
+import {
+  buildStructuredAlertRuleConfig,
+  buildStructuredAlertRuleDraft,
+} from '../adapters/alert-rule-helpers';
 import { getSampleData } from '../data/sample-data';
 import { usePreviewData, type PreviewDataRequest } from '../context/PreviewDataContext';
 
@@ -117,7 +122,6 @@ function normalizePuckProps(puckProps: Record<string, unknown>): Record<string, 
   );
 }
 
-type AlertSeverity = 'info' | 'success' | 'warning' | 'danger';
 type AlertLayout = 'stack' | 'wrap' | 'inline';
 
 const ALERT_LAYOUT_STYLES: Record<AlertLayout, React.CSSProperties> = {
@@ -141,7 +145,7 @@ const ALERT_LAYOUT_STYLES: Record<AlertLayout, React.CSSProperties> = {
 };
 
 const ALERT_SEVERITY_STYLES: Record<
-  AlertSeverity,
+  AlertRuleSeverity,
   { accent: string; background: string; border: string }
 > = {
   info: {
@@ -165,14 +169,6 @@ const ALERT_SEVERITY_STYLES: Record<
     border: '#fecaca',
   },
 };
-
-function normalizeAlertSeverity(value: unknown, fallback: AlertSeverity = 'info'): AlertSeverity {
-  if (value === 'info' || value === 'success' || value === 'warning' || value === 'danger') {
-    return value;
-  }
-
-  return fallback;
-}
 
 function readAlertText(row: Record<string, unknown>, fieldName: unknown): string {
   if (typeof fieldName !== 'string' || fieldName.length === 0) {
@@ -203,7 +199,7 @@ function AlertsPreview({ title, data, config, fallbackIcon }: AlertsPreviewProps
     typeof config.maxItems === 'number' && config.maxItems > 0 ? config.maxItems : data.length;
   const emptyState = config.emptyState === 'hide' ? 'hide' : 'placeholder';
   const showTimestamp = config.showTimestamp !== false;
-  const defaultSeverity = normalizeAlertSeverity(config.defaultSeverity, 'info');
+  const defaultSeverity = normalizeAlertRuleSeverity(config.defaultSeverity, 'info');
   const structuredAlertRule = readStructuredAlertRulePreview(config);
   const isStructuredAlertMode = config.alertMode === 'structured' || !!structuredAlertRule;
   const previewAlerts = structuredAlertRule
@@ -271,7 +267,7 @@ function AlertsPreview({ title, data, config, fallbackIcon }: AlertsPreviewProps
       ) : (
         <div style={ALERT_LAYOUT_STYLES[layout]}>
           {visibleAlerts.map((row, index) => {
-            const severity = normalizeAlertSeverity(row[severityField], defaultSeverity);
+            const severity = normalizeAlertRuleSeverity(row[severityField], defaultSeverity);
             const severityStyle = ALERT_SEVERITY_STYLES[severity];
             const alertTitle = readAlertText(row, titleField) || `Alert ${index + 1}`;
             const alertMessage = readAlertText(row, messageField) || 'No alert message configured.';
@@ -564,143 +560,6 @@ function buildWidgetConfig(
   if (s(normalizedPuckProps.format)) config.format = normalizedPuckProps.format;
 
   return config;
-}
-
-function buildStructuredAlertRuleConfig(
-  normalizedPuckProps: Record<string, unknown>,
-): Record<string, unknown> | null {
-  if (normalizedPuckProps.alertMode !== 'structured') {
-    return null;
-  }
-
-  const metricFieldRef =
-    typeof normalizedPuckProps.ruleMetricField === 'string' &&
-    normalizedPuckProps.ruleMetricField.trim().length > 0
-      ? normalizedPuckProps.ruleMetricField
-      : null;
-  const aggregation =
-    typeof normalizedPuckProps.ruleAggregation === 'string' &&
-    normalizedPuckProps.ruleAggregation.trim().length > 0
-      ? normalizedPuckProps.ruleAggregation
-      : null;
-  const operator =
-    typeof normalizedPuckProps.ruleOperator === 'string' &&
-    normalizedPuckProps.ruleOperator.trim().length > 0
-      ? normalizedPuckProps.ruleOperator
-      : null;
-  const threshold =
-    normalizedPuckProps.ruleThreshold != null && normalizedPuckProps.ruleThreshold !== ''
-      ? Number(normalizedPuckProps.ruleThreshold)
-      : null;
-  const title =
-    typeof normalizedPuckProps.ruleTitle === 'string' &&
-    normalizedPuckProps.ruleTitle.trim().length > 0
-      ? normalizedPuckProps.ruleTitle
-      : null;
-  const message =
-    typeof normalizedPuckProps.ruleMessage === 'string' &&
-    normalizedPuckProps.ruleMessage.trim().length > 0
-      ? normalizedPuckProps.ruleMessage
-      : null;
-  const severity =
-    typeof normalizedPuckProps.ruleSeverity === 'string' &&
-    normalizedPuckProps.ruleSeverity.trim().length > 0
-      ? normalizedPuckProps.ruleSeverity
-      : undefined;
-
-  if (
-    !metricFieldRef ||
-    !aggregation ||
-    !operator ||
-    threshold == null ||
-    !Number.isFinite(threshold) ||
-    !title ||
-    !message
-  ) {
-    return null;
-  }
-
-  return {
-    mode: 'structured',
-    metricFieldRef,
-    aggregation,
-    operator,
-    threshold,
-    alert: {
-      title,
-      message,
-      ...(severity ? { severity } : {}),
-    },
-  };
-}
-
-function buildStructuredAlertRuleDraft(
-  normalizedPuckProps: Record<string, unknown>,
-): Record<string, unknown> | null {
-  if (normalizedPuckProps.alertMode !== 'structured') {
-    return null;
-  }
-
-  const draft: Record<string, unknown> = {
-    mode: 'structured',
-  };
-
-  if (
-    typeof normalizedPuckProps.ruleMetricField === 'string' &&
-    normalizedPuckProps.ruleMetricField.trim().length > 0
-  ) {
-    draft.metricFieldRef = normalizedPuckProps.ruleMetricField;
-  }
-
-  if (
-    typeof normalizedPuckProps.ruleAggregation === 'string' &&
-    normalizedPuckProps.ruleAggregation.trim().length > 0
-  ) {
-    draft.aggregation = normalizedPuckProps.ruleAggregation;
-  }
-
-  if (
-    typeof normalizedPuckProps.ruleOperator === 'string' &&
-    normalizedPuckProps.ruleOperator.trim().length > 0
-  ) {
-    draft.operator = normalizedPuckProps.ruleOperator;
-  }
-
-  if (normalizedPuckProps.ruleThreshold != null && normalizedPuckProps.ruleThreshold !== '') {
-    const threshold = Number(normalizedPuckProps.ruleThreshold);
-    if (Number.isFinite(threshold)) {
-      draft.threshold = threshold;
-    }
-  }
-
-  const alert: Record<string, unknown> = {};
-
-  if (
-    typeof normalizedPuckProps.ruleTitle === 'string' &&
-    normalizedPuckProps.ruleTitle.trim().length > 0
-  ) {
-    alert.title = normalizedPuckProps.ruleTitle;
-  }
-
-  if (
-    typeof normalizedPuckProps.ruleMessage === 'string' &&
-    normalizedPuckProps.ruleMessage.trim().length > 0
-  ) {
-    alert.message = normalizedPuckProps.ruleMessage;
-  }
-
-  if (
-    typeof normalizedPuckProps.ruleSeverity === 'string' &&
-    normalizedPuckProps.ruleSeverity.trim().length > 0
-  ) {
-    alert.severity = normalizedPuckProps.ruleSeverity;
-  }
-
-  if (Object.keys(alert).length > 0) {
-    draft.alert = alert;
-  }
-
-  return draft;
 }
 
 function readStructuredAlertRulePreview(

--- a/packages/schema/src/types/dashboard.ts
+++ b/packages/schema/src/types/dashboard.ts
@@ -163,6 +163,17 @@ export interface FieldBinding {
 
 export type AlertRuleSeverity = 'info' | 'success' | 'warning' | 'danger';
 
+export function isAlertRuleSeverity(value: unknown): value is AlertRuleSeverity {
+  return value === 'info' || value === 'success' || value === 'warning' || value === 'danger';
+}
+
+export function normalizeAlertRuleSeverity(
+  value: unknown,
+  fallback: AlertRuleSeverity = 'info',
+): AlertRuleSeverity {
+  return isAlertRuleSeverity(value) ? value : fallback;
+}
+
 export type StructuredAlertRuleAggregation =
   | 'sum'
   | 'avg'


### PR DESCRIPTION
Hoist AlertRuleSeverity from schema as the single source of truth, and collapse the structured-alert-rule builders that PR #119/120 left duplicated across the designer preview and the puck-canonical adapter.

- packages/schema: export isAlertRuleSeverity / normalizeAlertRuleSeverity alongside the canonical AlertRuleSeverity type
- packages/charts-echarts: replace local AlertSeverity + isAlertSeverity with the schema exports
- packages/designer: replace local normalizeAlertSeverity copy with the schema export; move buildStructuredAlertRuleConfig / buildStructuredAlertRuleDraft / ALERT_RULE_DESIGNER_KEYS into adapters/alert-rule-helpers.ts so ChartPreview and puck-canonical share one implementation

No behavior change. Net -241 lines.