### PR TITLE
fix: support corepack in devenv launcher

### DIFF
--- a/scripts/devenv.mjs
+++ b/scripts/devenv.mjs
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
@@ -178,8 +178,26 @@ function buildEnv(ports) {
   };
 }
 
-function getPnpmCommand() {
-  return process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+function commandExists(command, args = ['--version']) {
+  const result = spawnSync(command, args, {
+    stdio: 'ignore',
+  });
+
+  return !result.error && result.status === 0;
+}
+
+function getPnpmInvocation() {
+  const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+  if (commandExists(pnpmCommand)) {
+    return { command: pnpmCommand, argsPrefix: [] };
+  }
+
+  const corepackCommand = process.platform === 'win32' ? 'corepack.cmd' : 'corepack';
+  if (commandExists(corepackCommand, ['pnpm', '--version'])) {
+    return { command: corepackCommand, argsPrefix: ['pnpm'] };
+  }
+
+  throw new Error('Could not find pnpm or corepack on PATH for DevEnv launcher');
 }
 
 function runTarget(targetName) {
@@ -192,7 +210,8 @@ function runTarget(targetName) {
   const ports = getPorts();
   process.stdout.write(`Starting ${target.label} at ${target.url(ports)}\n`);
 
-  const child = spawn(getPnpmCommand(), target.args, {
+  const pnpmInvocation = getPnpmInvocation();
+  const child = spawn(pnpmInvocation.command, [...pnpmInvocation.argsPrefix, ...target.args], {
     cwd: ROOT_DIR,
     env: buildEnv(ports),
     stdio: 'inherit',


### PR DESCRIPTION
## Summary

- resolve the DevEnv package-manager invocation dynamically instead of assuming a bare `pnpm` binary is on `PATH`
- fall back to `corepack pnpm` when `pnpm` is unavailable so worktree-local `scripts/devenv.mjs run <target>` works on Corepack-managed machines
- keep the launcher behavior unchanged when a normal `pnpm` executable is already present

## Issue

- closes #127

## Validation

- `cd /Users/kenxono/apps/supersubset-issue-127-devenv-corepack && corepack pnpm install --frozen-lockfile`
- `cd /Users/kenxono/apps/supersubset-issue-127-devenv-corepack && corepack pnpm -r build`
- `cd /Users/kenxono/apps/supersubset-issue-127-devenv-corepack && node scripts/devenv.mjs prepare --profile leased --start 3330 --end 3360`
- `cd /Users/kenxono/apps/supersubset-issue-127-devenv-corepack && node scripts/devenv.mjs run dev-app`

Observed result: the launcher reached the worktree-local dev app and started Vite instead of failing with `spawn pnpm ENOENT`.