### PR TITLE
fix: remove legacy filter option masking from examples

### DIFF
--- a/e2e/workflows/host-integration.spec.ts
+++ b/e2e/workflows/host-integration.spec.ts
@@ -120,4 +120,39 @@ test.describe('Host Integration Workflow', () => {
     expect(requestUrls.some((url) => /superset|lightdash|rill/i.test(url))).toBe(false);
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });
+
+  test('Vite host shows an explicit unavailable state when Region is authored with field-backed options', async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto(VITE_SQLITE_EXAMPLE_ORIGIN);
+
+    await expect(page.getByText('Vite + SQLite host example')).toBeVisible();
+    await page.getByRole('button', { name: 'Designer' }).click();
+    await expect(page.getByTestId('designer-filters-toggle')).toBeVisible();
+
+    await page.getByTestId('designer-filters-toggle').click();
+    await expect(page.getByTestId('filter-builder-panel')).toBeVisible();
+    await page.getByTestId('filter-option-source-kind-filter-region').selectOption('field');
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('slide-over-panel')).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Viewer' }).click();
+
+    const regionFilter = page.getByLabel('Region');
+    await expect(regionFilter).toBeDisabled();
+    await expect(regionFilter.locator('option')).toHaveCount(1);
+    await expect(regionFilter.locator('option').first()).toHaveText(
+      'Field-backed options require host support',
+    );
+
+    expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
+  });
 });

--- a/examples/nextjs-ecommerce/components/WorkbenchHost.tsx
+++ b/examples/nextjs-ecommerce/components/WorkbenchHost.tsx
@@ -27,7 +27,6 @@ import {
 } from '../lib/workbench-client';
 import { WORKBENCH_LOGIN_EMAIL, WORKBENCH_LOGIN_PASSWORD } from '../lib/workbench-auth';
 import { workbenchStarterDashboard } from '../lib/workbench-dashboard';
-import { workbenchFilterOptions } from '../lib/workbench-shared';
 
 export function WorkbenchHost() {
   const [email, setEmail] = useState(WORKBENCH_LOGIN_EMAIL);
@@ -522,7 +521,6 @@ export function WorkbenchHost() {
                 theme={resolvedTheme as unknown as Record<string, unknown>}
                 cssVariables={cssVariables}
                 queryAdapter={queryAdapter}
-                filterOptions={workbenchFilterOptions}
                 onFilterChange={setFilterState}
               />
             </div>

--- a/examples/nextjs-ecommerce/lib/workbench-dashboard.ts
+++ b/examples/nextjs-ecommerce/lib/workbench-dashboard.ts
@@ -1,5 +1,8 @@
 import type { DashboardDefinition } from '@supersubset/schema';
-import { WORKBENCH_DATASET_ID, workbenchFilterOptions } from './workbench-shared';
+import { WORKBENCH_DATASET_ID } from './workbench-shared';
+
+const REGION_OPTIONS = ['APAC', 'Europe', 'Latin America', 'North America'];
+const CARRIER_OPTIONS = ['Atlas Air', 'Horizon Freight', 'Meridian Cargo'];
 
 export const workbenchStarterDashboard: DashboardDefinition = {
   schemaVersion: '0.2.0',
@@ -18,7 +21,7 @@ export const workbenchStarterDashboard: DashboardDefinition = {
       optionSource: {
         kind: 'static',
         completeness: 'complete',
-        options: workbenchFilterOptions['filter-region'].map((value) => ({ value })),
+        options: REGION_OPTIONS.map((value) => ({ value })),
       },
       scope: { type: 'global' },
     },
@@ -32,7 +35,7 @@ export const workbenchStarterDashboard: DashboardDefinition = {
       optionSource: {
         kind: 'static',
         completeness: 'complete',
-        options: workbenchFilterOptions['filter-carrier'].map((value) => ({ value })),
+        options: CARRIER_OPTIONS.map((value) => ({ value })),
       },
       scope: { type: 'global' },
     },

--- a/examples/vite-sqlite/src/App.tsx
+++ b/examples/vite-sqlite/src/App.tsx
@@ -7,10 +7,10 @@ import type { DashboardDefinition } from '@supersubset/schema';
 import { defaultDashboard } from './dashboard';
 import {
   compileSqliteLogicalQuery,
+  ensureSqliteReady,
   executeSqliteLogicalQuery,
   fetchDesignerPreviewData,
   formatSqliteQueryLogEntry,
-  loadSqliteFilterOptions,
 } from './sqlite';
 import './styles.css';
 
@@ -48,7 +48,7 @@ export default function App() {
     return defaultDashboard;
   });
   const [filterState, setFilterState] = useState<FilterState>({ values: {} });
-  const [filterOptions, setFilterOptions] = useState<Record<string, string[]> | null>(null);
+  const [sqliteReady, setSqliteReady] = useState(false);
   const [queryLog, setQueryLog] = useState<string[]>([]);
   const [viewerStatus, setViewerStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
@@ -61,10 +61,10 @@ export default function App() {
   useEffect(() => {
     let active = true;
     setError(null);
-    loadSqliteFilterOptions()
-      .then((result) => {
+    ensureSqliteReady()
+      .then(() => {
         if (!active) return;
-        setFilterOptions(result);
+        setSqliteReady(true);
       })
       .catch((err: unknown) => {
         if (!active) return;
@@ -77,7 +77,7 @@ export default function App() {
   }, []);
 
   useLayoutEffect(() => {
-    if (!filterOptions || mode !== 'viewer') {
+    if (!sqliteReady || mode !== 'viewer') {
       if (mode !== 'viewer') {
         setViewerStatus('idle');
       }
@@ -92,7 +92,7 @@ export default function App() {
     setQueryLog([]);
     setViewerStatus('loading');
     setError(null);
-  }, [dashboard, filterOptions, filterState.values, mode]);
+  }, [dashboard, filterState.values, mode, sqliteReady]);
 
   const resolvedTheme = useMemo(
     () =>
@@ -135,7 +135,7 @@ export default function App() {
   }, []);
 
   const queryAdapter = useMemo<QueryAdapter | undefined>(() => {
-    if (!filterOptions || mode !== 'viewer') {
+    if (!sqliteReady || mode !== 'viewer') {
       return undefined;
     }
 
@@ -167,7 +167,7 @@ export default function App() {
         }
       },
     };
-  }, [filterOptions, mode]);
+  }, [mode, sqliteReady]);
 
   return (
     <div className={mode === 'designer' ? 'shell shell--designer' : 'shell'}>
@@ -212,9 +212,7 @@ export default function App() {
         </div>
       </section>
 
-      {status === 'error' ? (
-        <div className="error-panel">SQLite bootstrap failed: {error}</div>
-      ) : null}
+      {error ? <div className="error-panel">SQLite bootstrap failed: {error}</div> : null}
 
       <main className="workspace">
         <section className="canvas-area">
@@ -232,17 +230,16 @@ export default function App() {
             </Suspense>
           ) : (
             <div className="viewer-shell">
-              {filterOptions == null || viewerStatus === 'loading' ? (
+              {!sqliteReady || viewerStatus === 'loading' ? (
                 <div className="loading-panel">Running SQLite queries…</div>
               ) : null}
-              {filterOptions ? (
+              {sqliteReady ? (
                 <SupersubsetRenderer
                   definition={dashboard}
                   registry={registry}
                   theme={resolvedTheme as unknown as Record<string, unknown>}
                   cssVariables={cssVariables}
                   queryAdapter={queryAdapter}
-                  filterOptions={filterOptions}
                   onFilterChange={setFilterState}
                 />
               ) : null}

--- a/examples/vite-sqlite/src/sqlite.ts
+++ b/examples/vite-sqlite/src/sqlite.ts
@@ -635,6 +635,10 @@ export async function executeSqliteLogicalQuery(
   };
 }
 
+export async function ensureSqliteReady(): Promise<void> {
+  await getDatabase();
+}
+
 export async function loadSqliteFilterOptions(): Promise<Record<string, string[]>> {
   const db = await getDatabase();
 


### PR DESCRIPTION
## Summary

- remove legacy `filterOptions` injection from the first-party Vite and Next.js example viewers where the shipped dashboards already author static option sources in config
- keep the example dashboards working from authored config while making field-backed authored filters surface the explicit unavailable state instead of silently using deprecated sidecar data
- add host-integration coverage proving the Vite example no longer masks the unresolved field-backed runtime contract

## Issue

- closes #128

## Validation

- `cd /Users/kenxono/apps/supersubset-issue-128-example-host-filteroptions && corepack pnpm --filter @supersubset/example-vite-sqlite... build`
- `cd /Users/kenxono/apps/supersubset-issue-128-example-host-filteroptions && corepack pnpm --filter @supersubset/example-nextjs-ecommerce... build`
- `cd /Users/kenxono/apps/supersubset-issue-128-example-host-filteroptions && PLAYWRIGHT_HTML_OPEN=never SUPERSUBSET_DEV_APP_PORT=3250 SUPERSUBSET_EXAMPLE_NEXTJS_PORT=3251 SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT=3252 corepack pnpm exec playwright test -c playwright.e2e.config.ts e2e/workflows/host-integration.spec.ts e2e/workflows/host-workbench.spec.ts --project=chromium --reporter=line --grep "Vite host shows an explicit unavailable state|logs in, loads datasets, and re-queries a query-backed alerts tile in viewer mode"`

Observed result: `2 passed`.