### PR TITLE
fix: honor field-backed filter precedence

### DIFF
--- a/packages/runtime/src/components/FilterBar.tsx
+++ b/packages/runtime/src/components/FilterBar.tsx
@@ -587,10 +587,6 @@ function resolveFilterOptions(
       : { options: [], unavailableMessage: 'No options configured' };
   }
 
-  if (legacyOptions && legacyOptions.length > 0) {
-    return { options: legacyOptions.map((option) => ({ value: option, label: option })) };
-  }
-
   if (filter.optionSource?.kind === 'field') {
     const fieldOptions = getFieldOptions(filter, datasets);
     if (fieldOptions.length > 0) {
@@ -602,6 +598,10 @@ function resolveFilterOptions(
       options: [],
       unavailableMessage: 'Field-backed options require host support',
     };
+  }
+
+  if (legacyOptions && legacyOptions.length > 0) {
+    return { options: legacyOptions.map((option) => ({ value: option, label: option })) };
   }
 
   return { options: [], unavailableMessage: 'Options unavailable' };

--- a/packages/runtime/test/filter-bar.test.tsx
+++ b/packages/runtime/test/filter-bar.test.tsx
@@ -160,6 +160,32 @@ describe('FilterBar', () => {
     expect(optionLabels).toEqual(['Options unavailable']);
   });
 
+  it('does not fall back to legacy filterOptions for field-backed select filters', () => {
+    const { container } = renderFilterBar(
+      [
+        {
+          ...selectFilter,
+          optionSource: {
+            kind: 'field',
+            strategy: 'search',
+            minSearchChars: 2,
+          },
+        },
+      ],
+      {
+        filterOptions: { 'f-status': ['open', 'closed'] },
+      },
+    );
+
+    const select = container.querySelector('.ss-filter-select') as HTMLSelectElement;
+    const optionLabels = Array.from(select.querySelectorAll('option')).map(
+      (option) => option.textContent,
+    );
+
+    expect(select.disabled).toBe(true);
+    expect(optionLabels).toEqual(['Field-backed options require host support']);
+  });
+
   it('renders a multi-select control for multi-select filters', () => {
     const { container } = renderFilterBar([multiSelectFilter]);
 


### PR DESCRIPTION
## Summary

- align `FilterBar` option resolution with ADR-009 precedence: static first, then field-backed authored filters, then legacy `filterOptions`, then explicit unavailable state
- stop field-backed authored filters from silently downgrading to the deprecated host-side fallback when no runtime resolver exists yet
- add focused runtime regression coverage for the precedence change

## Issue

- closes #129

## Validation

- `cd /Users/kenxono/apps/supersubset-issue-129-field-option-precedence && corepack pnpm --dir packages/runtime test -- filter-bar.test.tsx`

Observed result: `20 passed`.