### PR TITLE
Fix real chart click interactions

### DIFF
--- a/e2e/workflows/filter-cascade.spec.ts
+++ b/e2e/workflows/filter-cascade.spec.ts
@@ -21,6 +21,23 @@ test.describe('Filter Cascade Workflow', () => {
     await expect(page.getByRole('button', { name: 'Overview' })).toBeVisible();
   }
 
+  async function clickOverviewRegionDatum(page: import('@playwright/test').Page) {
+    const canvas = page.locator('[data-ss-node="pages-region-chart-host"] canvas').first();
+    await expect(canvas).toBeVisible();
+
+    const bounds = await canvas.boundingBox();
+    if (!bounds) {
+      throw new Error('Expected overview region chart canvas bounds');
+    }
+
+    await canvas.click({
+      position: {
+        x: bounds.width * 0.68,
+        y: bounds.height * 0.24,
+      },
+    });
+  }
+
   test('dashboard renders with filter bar and all widgets', async ({ page }) => {
     // Verify the dashboard renders
     const dashboard = page.locator('[data-ss-dashboard]');
@@ -99,6 +116,41 @@ test.describe('Filter Cascade Workflow', () => {
 
     await page.getByRole('button', { name: 'Overview' }).click();
     await expect(page.locator('.ss-filter-bar').getByLabel('Region')).toHaveValue('East');
+  });
+
+  test('real overview chart clicks navigate to the detail page', async ({ page }) => {
+    await openPagesWorkbook(page);
+
+    await page.evaluate(() => {
+      const debugWindow = window as Window & {
+        __SUPERSUBSET_WIDGET_EVENTS__?: Array<Record<string, unknown>>;
+      };
+      debugWindow.__SUPERSUBSET_WIDGET_EVENTS__ = [];
+    });
+
+    const dashboard = page.locator('[data-ss-dashboard]');
+    await expect(dashboard).toHaveAttribute('data-ss-page', 'page-overview');
+
+    await clickOverviewRegionDatum(page);
+
+    await expect(dashboard).toHaveAttribute('data-ss-page', 'page-detail');
+
+    const lastEvent = await page.evaluate(() => {
+      const debugWindow = window as Window & {
+        __SUPERSUBSET_WIDGET_EVENTS__?: Array<Record<string, unknown>>;
+      };
+      const events = debugWindow.__SUPERSUBSET_WIDGET_EVENTS__ ?? [];
+      return events[events.length - 1];
+    });
+
+    expect(lastEvent).toMatchObject({
+      type: 'click',
+      widgetId: 'pages-chart-region-sales',
+      payload: expect.objectContaining({
+        region: expect.any(String),
+        revenue: expect.any(Number),
+      }),
+    });
   });
 
   test('page-scoped category filter changes overview widgets without leaking into detail widgets', async ({

--- a/packages/charts-echarts/src/base/BaseChart.tsx
+++ b/packages/charts-echarts/src/base/BaseChart.tsx
@@ -62,7 +62,14 @@ export function BaseChart({
 }: BaseChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<echarts.ECharts | null>(null);
+  const lastHoveredParamsRef = useRef<unknown>(null);
+  const lastAxisPointerRef = useRef<ChartTestClickDetail | null>(null);
+  const lastChartClickAtRef = useRef(0);
   const echartsTheme = useMemo(() => toEChartsTheme(theme), [theme]);
+  const runtimeOption = useMemo(
+    () => withInteractionSafeTooltip(option, Boolean(onEvent && widgetId)),
+    [onEvent, option, widgetId],
+  );
 
   // Initialize chart
   useEffect(() => {
@@ -93,26 +100,91 @@ export function BaseChart({
   useEffect(() => {
     const chart = chartRef.current;
     if (!chart || isChartDisposed(chart)) return;
-    chart.setOption(option, { notMerge: true });
-  }, [option]);
+    chart.setOption(runtimeOption, { notMerge: true });
+  }, [runtimeOption]);
 
   useEffect(() => {
     const chart = chartRef.current;
-    if (!chart || !onEvent || !widgetId) return;
+    const container = containerRef.current;
+    if (!chart || !container || !onEvent || !widgetId) return;
+    const resolvePayload = (params: unknown) =>
+      buildClickPayload?.(params) ?? extractClickPayload(params);
 
-    const handleClick = (params: unknown) => {
+    const emitClick = (params: unknown) => {
+      lastChartClickAtRef.current = Date.now();
       onEvent({
         type: 'click',
         widgetId,
-        payload: buildClickPayload?.(params) ?? extractClickPayload(params),
+        payload: resolvePayload(params),
+      });
+    };
+
+    const handleClick = (params: unknown) => {
+      emitClick(params);
+    };
+
+    const handlePointerHover = (params: unknown) => {
+      lastHoveredParamsRef.current = params;
+    };
+
+    const clearPointerHover = () => {
+      lastHoveredParamsRef.current = null;
+      lastAxisPointerRef.current = null;
+    };
+
+    const handleAxisPointer = (params: unknown) => {
+      lastAxisPointerRef.current = extractAxisPointerDetail(params) ?? null;
+    };
+
+    const handleNativeClick = (event: Event) => {
+      queueMicrotask(() => {
+        if (Date.now() - lastChartClickAtRef.current < 32) {
+          return;
+        }
+
+        const hoveredParams = lastHoveredParamsRef.current;
+        if (hoveredParams && resolvePayload(hoveredParams) !== undefined) {
+          emitClick(hoveredParams);
+          return;
+        }
+
+        const pixelParams = buildPixelClickParams(chart, option, event as MouseEvent, container);
+        if (pixelParams) {
+          emitClick(pixelParams);
+          return;
+        }
+
+        const pointer = lastAxisPointerRef.current;
+        if (!pointer) {
+          return;
+        }
+
+        const params = buildSyntheticClickParams(
+          option,
+          pointer.seriesIndex ?? 0,
+          pointer.dataIndex ?? 0,
+        );
+        if (!params) {
+          return;
+        }
+
+        emitClick(params);
       });
     };
 
     chart.on('click', handleClick);
+    chart.on('mouseover', handlePointerHover);
+    chart.on('updateAxisPointer', handleAxisPointer);
+    container.addEventListener('click', handleNativeClick, true);
+    container.addEventListener('mouseleave', clearPointerHover);
     return () => {
       chart.off('click', handleClick);
+      chart.off('mouseover', handlePointerHover);
+      chart.off('updateAxisPointer', handleAxisPointer);
+      container.removeEventListener('click', handleNativeClick, true);
+      container.removeEventListener('mouseleave', clearPointerHover);
     };
-  }, [buildClickPayload, echartsTheme, onEvent, widgetId]);
+  }, [buildClickPayload, echartsTheme, onEvent, option, widgetId]);
 
   useEffect(() => {
     const chart = chartRef.current;
@@ -179,6 +251,157 @@ export function BaseChart({
 
 function isChartTestHookEnabled(debugWindow: ChartTestWindow | null | undefined): boolean {
   return debugWindow?.__SUPERSUBSET_ENABLE_CHART_TEST_HOOKS__ === true;
+}
+
+function withInteractionSafeTooltip(
+  option: echarts.EChartsCoreOption,
+  hasInteractionHandler: boolean,
+): echarts.EChartsCoreOption {
+  if (!hasInteractionHandler || !isRecord(option.tooltip)) {
+    return option;
+  }
+
+  if (option.tooltip.show === false || option.tooltip.triggerOn !== undefined) {
+    return option;
+  }
+
+  return {
+    ...option,
+    tooltip: {
+      ...option.tooltip,
+      triggerOn: 'mousemove',
+    },
+  };
+}
+
+function extractAxisPointerDetail(params: unknown): ChartTestClickDetail | undefined {
+  if (!isRecord(params)) {
+    return undefined;
+  }
+
+  const directMatch = extractSeriesDataIndex(params.seriesDataIndices);
+  if (directMatch) {
+    return directMatch;
+  }
+
+  if (!Array.isArray(params.axesInfo)) {
+    return undefined;
+  }
+
+  for (const axisInfo of params.axesInfo) {
+    if (!isRecord(axisInfo)) {
+      continue;
+    }
+
+    const nestedMatch = extractSeriesDataIndex(axisInfo.seriesDataIndices);
+    if (nestedMatch) {
+      return nestedMatch;
+    }
+  }
+
+  return undefined;
+}
+
+function extractSeriesDataIndex(value: unknown): ChartTestClickDetail | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  for (const candidate of value) {
+    if (!isRecord(candidate)) {
+      continue;
+    }
+
+    const seriesIndex = toFiniteNumber(candidate.seriesIndex);
+    const dataIndex = toFiniteNumber(candidate.dataIndex);
+    if (seriesIndex !== undefined && dataIndex !== undefined) {
+      return { seriesIndex, dataIndex };
+    }
+  }
+
+  return undefined;
+}
+
+function buildPixelClickParams(
+  chart: echarts.ECharts,
+  option: echarts.EChartsCoreOption,
+  event: MouseEvent,
+  container: HTMLDivElement,
+): Record<string, unknown> | undefined {
+  const rect = container.getBoundingClientRect();
+  const pixel: [number, number] = [event.clientX - rect.left, event.clientY - rect.top];
+  const maybeChart = chart as echarts.ECharts & {
+    containPixel?: (finder: Record<string, unknown>, value: [number, number]) => boolean;
+    convertFromPixel?: (finder: Record<string, unknown>, value: [number, number]) => unknown;
+  };
+
+  if (
+    typeof maybeChart.containPixel !== 'function' ||
+    !maybeChart.containPixel({ gridIndex: 0 }, pixel) ||
+    typeof maybeChart.convertFromPixel !== 'function'
+  ) {
+    return undefined;
+  }
+
+  const coord = maybeChart.convertFromPixel({ seriesIndex: 0 }, pixel);
+  if (!Array.isArray(coord) || coord.length < 2) {
+    return undefined;
+  }
+
+  const dataIndex = resolveCartesianDataIndex(option, coord);
+  if (dataIndex === undefined) {
+    return undefined;
+  }
+
+  return buildSyntheticClickParams(option, 0, dataIndex);
+}
+
+function resolveCartesianDataIndex(
+  option: echarts.EChartsCoreOption,
+  coord: unknown[],
+): number | undefined {
+  const xAxis = getPrimaryAxisOption(option.xAxis);
+  if (isCategoryAxisOption(xAxis)) {
+    return resolveCategoryIndex(xAxis.data, coord[0]);
+  }
+
+  const yAxis = getPrimaryAxisOption(option.yAxis);
+  if (isCategoryAxisOption(yAxis)) {
+    return resolveCategoryIndex(yAxis.data, coord[1]);
+  }
+
+  return undefined;
+}
+
+function getPrimaryAxisOption(axis: unknown): Record<string, unknown> | undefined {
+  if (Array.isArray(axis)) {
+    return axis.find(isRecord);
+  }
+
+  return isRecord(axis) ? axis : undefined;
+}
+
+function isCategoryAxisOption(
+  axis: unknown,
+): axis is Record<string, unknown> & { data: unknown[] } {
+  return isRecord(axis) && axis.type === 'category' && Array.isArray(axis.data);
+}
+
+function resolveCategoryIndex(categories: unknown[], value: unknown): number | undefined {
+  const numericValue = toFiniteNumber(value);
+  if (numericValue !== undefined) {
+    const rounded = Math.round(numericValue);
+    if (rounded >= 0 && rounded < categories.length) {
+      return rounded;
+    }
+  }
+
+  if (typeof value === 'string') {
+    const categoryIndex = categories.findIndex((candidate) => String(candidate) === value);
+    return categoryIndex >= 0 ? categoryIndex : undefined;
+  }
+
+  return undefined;
 }
 
 function extractClickPayload(params: unknown): Record<string, unknown> | undefined {
@@ -283,6 +506,19 @@ function isResolvedTheme(theme: unknown): theme is ResolvedTheme {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  return undefined;
 }
 
 // Re-export echarts for use/register calls in chart modules

--- a/packages/charts-echarts/test/base-chart-events.test.tsx
+++ b/packages/charts-echarts/test/base-chart-events.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 
 const { chartInstance, initMock } = vi.hoisted(() => {
   const instance = {
@@ -10,6 +10,8 @@ const { chartInstance, initMock } = vi.hoisted(() => {
     resize: vi.fn(),
     dispose: vi.fn(),
     isDisposed: vi.fn(() => false),
+    containPixel: vi.fn(() => false),
+    convertFromPixel: vi.fn(() => undefined),
   };
 
   return {
@@ -44,6 +46,10 @@ describe('BaseChart interaction events', () => {
     chartInstance.off.mockClear();
     chartInstance.setOption.mockClear();
     chartInstance.dispose.mockClear();
+    chartInstance.containPixel.mockReset();
+    chartInstance.containPixel.mockReturnValue(false);
+    chartInstance.convertFromPixel.mockReset();
+    chartInstance.convertFromPixel.mockReturnValue(undefined);
     chartInstance.isDisposed.mockReset();
     chartInstance.isDisposed.mockReturnValue(false);
     initMock.mockClear();
@@ -166,6 +172,225 @@ describe('BaseChart interaction events', () => {
       }),
       expect.objectContaining({ renderer: 'canvas' }),
     );
+  });
+
+  it('defaults interactive tooltips to hover-only when emitting widget click events', () => {
+    render(
+      React.createElement(BaseChart, {
+        option: {
+          tooltip: {
+            trigger: 'axis',
+          },
+        },
+        widgetId: 'chart-3',
+        onEvent: vi.fn(),
+      }),
+    );
+
+    expect(chartInstance.setOption).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tooltip: expect.objectContaining({
+          trigger: 'axis',
+          triggerOn: 'mousemove',
+        }),
+      }),
+      { notMerge: true },
+    );
+  });
+
+  it('preserves explicit tooltip triggerOn values for interactive charts', () => {
+    render(
+      React.createElement(BaseChart, {
+        option: {
+          tooltip: {
+            trigger: 'axis',
+            triggerOn: 'click',
+          },
+        },
+        widgetId: 'chart-4',
+        onEvent: vi.fn(),
+      }),
+    );
+
+    expect(chartInstance.setOption).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tooltip: expect.objectContaining({
+          trigger: 'axis',
+          triggerOn: 'click',
+        }),
+      }),
+      { notMerge: true },
+    );
+  });
+
+  it('falls back to the hovered datum when zrender receives the click first', async () => {
+    const onEvent = vi.fn();
+
+    const { container } = render(
+      React.createElement(BaseChart, {
+        option: {
+          series: [
+            {
+              data: [
+                {
+                  value: 6400,
+                  __ssPayload: {
+                    region: 'North',
+                    revenue: 6400,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        widgetId: 'chart-5',
+        onEvent,
+      }),
+    );
+
+    const mouseoverHandler = chartInstance.on.mock.calls.find(
+      ([eventName]) => eventName === 'mouseover',
+    )?.[1] as (params: unknown) => void;
+    const chartElement = container.querySelector('.ss-chart');
+    expect(chartElement).toBeTruthy();
+
+    mouseoverHandler({
+      data: {
+        __ssPayload: {
+          region: 'North',
+          revenue: 6400,
+        },
+      },
+    });
+    fireEvent.click(chartElement as Element);
+    await Promise.resolve();
+
+    expect(onEvent).toHaveBeenCalledWith({
+      type: 'click',
+      widgetId: 'chart-5',
+      payload: {
+        region: 'North',
+        revenue: 6400,
+      },
+    });
+  });
+
+  it('maps native chart clicks back to category data when echarts click payload is unavailable', async () => {
+    const onEvent = vi.fn();
+    chartInstance.containPixel.mockReturnValue(true);
+    chartInstance.convertFromPixel.mockReturnValue([6400, 'East']);
+
+    const { container } = render(
+      React.createElement(BaseChart, {
+        option: {
+          xAxis: { type: 'value' },
+          yAxis: { type: 'category', data: ['North', 'South', 'East', 'West'] },
+          series: [
+            {
+              data: [
+                { value: 6400, __ssPayload: { region: 'North', revenue: 6400 } },
+                { value: 5200, __ssPayload: { region: 'South', revenue: 5200 } },
+                { value: 3600, __ssPayload: { region: 'East', revenue: 3600 } },
+                { value: 4400, __ssPayload: { region: 'West', revenue: 4400 } },
+              ],
+            },
+          ],
+        },
+        widgetId: 'chart-7',
+        onEvent,
+      }),
+    );
+
+    const chartElement = container.querySelector('.ss-chart');
+    expect(chartElement).toBeTruthy();
+
+    vi.spyOn(chartElement as HTMLDivElement, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 400,
+      bottom: 300,
+      width: 400,
+      height: 300,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.click(chartElement as Element, { clientX: 200, clientY: 120 });
+    await Promise.resolve();
+
+    expect(onEvent).toHaveBeenCalledWith({
+      type: 'click',
+      widgetId: 'chart-7',
+      payload: {
+        region: 'East',
+        revenue: 3600,
+      },
+    });
+  });
+
+  it('does not emit duplicate events when echarts click fires for the same interaction', async () => {
+    const onEvent = vi.fn();
+
+    const { container } = render(
+      React.createElement(BaseChart, {
+        option: {
+          series: [
+            {
+              data: [
+                {
+                  value: 5200,
+                  __ssPayload: {
+                    region: 'South',
+                    revenue: 5200,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        widgetId: 'chart-6',
+        onEvent,
+      }),
+    );
+
+    const clickHandler = chartInstance.on.mock.calls.find(
+      ([eventName]) => eventName === 'click',
+    )?.[1] as (params: unknown) => void;
+    const mouseoverHandler = chartInstance.on.mock.calls.find(
+      ([eventName]) => eventName === 'mouseover',
+    )?.[1] as (params: unknown) => void;
+    const chartElement = container.querySelector('.ss-chart');
+    expect(chartElement).toBeTruthy();
+
+    mouseoverHandler({
+      data: {
+        __ssPayload: {
+          region: 'South',
+          revenue: 5200,
+        },
+      },
+    });
+    fireEvent.click(chartElement as Element);
+    clickHandler({
+      data: {
+        __ssPayload: {
+          region: 'South',
+          revenue: 5200,
+        },
+      },
+    });
+    await Promise.resolve();
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenCalledWith({
+      type: 'click',
+      widgetId: 'chart-6',
+      payload: {
+        region: 'South',
+        revenue: 5200,
+      },
+    });
   });
 
   it('skips setOption when the chart instance is already disposed', () => {


### PR DESCRIPTION
## Summary
- add a DOM click fallback in BaseChart when native ECharts click callbacks do not fire
- preserve payload extraction for real chart clicks and add focused BaseChart event coverage
- add a browser regression proving a real overview chart click navigates to the detail page

## Testing
- corepack pnpm --filter @supersubset/charts-echarts test -- test/base-chart-events.test.tsx
- SUPERSUBSET_DEV_APP_PORT=3006 corepack pnpm exec playwright test --config playwright.e2e.config.ts e2e/workflows/filter-cascade.spec.ts --grep "real overview chart clicks navigate to the detail page"

Closes #133