### PR TITLE
Fix cross-filter query propagation

### DIFF
--- a/packages/runtime/src/layout/LayoutRenderer.tsx
+++ b/packages/runtime/src/layout/LayoutRenderer.tsx
@@ -591,6 +591,8 @@ const VALID_AGGREGATIONS = new Set<AggregationType>([
   'none',
 ]);
 
+const CROSS_FILTER_PREFIX = 'cross-filter:';
+
 function buildWidgetQuery(
   widgetDef: WidgetDefinition,
   filters: FilterDefinition[] | undefined,
@@ -819,19 +821,29 @@ function compileActiveFiltersForQuery(
   filters: FilterDefinition[] | undefined,
   activeFilters: FilterValue[] | undefined,
 ): NonNullable<LogicalQuery['filters']> {
-  if (!filters || !activeFilters || activeFilters.length === 0) {
+  if (!activeFilters || activeFilters.length === 0) {
     return [];
   }
 
-  const filterDefinitions = new Map(filters.map((filter) => [filter.id, filter]));
+  const filterDefinitions = new Map((filters ?? []).map((filter) => [filter.id, filter]));
 
   return activeFilters.flatMap((activeFilter) => {
     const definition = filterDefinitions.get(activeFilter.filterId);
-    if (!definition || definition.datasetRef !== datasetId) {
+    if (definition) {
+      if (definition.datasetRef !== datasetId) {
+        return [];
+      }
+
+      const compiledFilter = compileFilterValue(definition, activeFilter.value);
+      return compiledFilter ? [compiledFilter] : [];
+    }
+
+    const crossFilter = parseCrossFilterId(activeFilter.filterId);
+    if (!crossFilter) {
       return [];
     }
 
-    const compiledFilter = compileFilterValue(definition, activeFilter.value);
+    const compiledFilter = compileCrossFilterValue(crossFilter.fieldRef, activeFilter.value);
     return compiledFilter ? [compiledFilter] : [];
   });
 }
@@ -888,6 +900,53 @@ function compileFilterValue(
   };
 }
 
+function compileCrossFilterValue(
+  fieldRef: string,
+  value: unknown,
+): NonNullable<LogicalQuery['filters']>[number] | null {
+  if (value == null) {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    const values = value.filter((entry) => entry != null && entry !== '');
+    if (values.length === 0) {
+      return null;
+    }
+
+    return {
+      fieldId: fieldRef,
+      operator: 'in',
+      value: values,
+    };
+  }
+
+  if (isBetweenValue(value)) {
+    const lower = value.start ?? value.min;
+    const upper = value.end ?? value.max;
+
+    if (lower == null && upper == null) {
+      return null;
+    }
+
+    return {
+      fieldId: fieldRef,
+      operator: 'between',
+      value: [lower, upper],
+    };
+  }
+
+  if (typeof value === 'string' && value.length === 0) {
+    return null;
+  }
+
+  return {
+    fieldId: fieldRef,
+    operator: 'eq',
+    value,
+  };
+}
+
 function normalizeFilterOperator(operator: string): QueryFilterOperator | null {
   if (DIRECT_QUERY_OPERATORS.has(operator as QueryFilterOperator)) {
     return operator as QueryFilterOperator;
@@ -930,21 +989,53 @@ function computeActiveFilters(
   activeFilterValues: FilterValue[] | undefined,
   activePageId: string | undefined,
 ): FilterValue[] {
-  if (!filters || !activeFilterValues || activeFilterValues.length === 0) return [];
+  if (!activeFilterValues || activeFilterValues.length === 0) return [];
 
-  const activeMap = new Map(activeFilterValues.map((fv) => [fv.filterId, fv]));
   const result: FilterValue[] = [];
+  const seenFilterIds = new Set<string>();
 
-  for (const filter of filters) {
-    const fv = activeMap.get(filter.id);
-    if (!fv) continue;
+  if (filters && filters.length > 0) {
+    const activeMap = new Map(activeFilterValues.map((fv) => [fv.filterId, fv]));
 
-    if (filterAppliesToWidget(filter.scope, widgetId, activePageId)) {
-      result.push(fv);
+    for (const filter of filters) {
+      const fv = activeMap.get(filter.id);
+      if (!fv) continue;
+
+      if (filterAppliesToWidget(filter.scope, widgetId, activePageId)) {
+        result.push(fv);
+        seenFilterIds.add(fv.filterId);
+      }
+    }
+  }
+
+  for (const activeFilter of activeFilterValues) {
+    if (seenFilterIds.has(activeFilter.filterId)) {
+      continue;
+    }
+
+    if (parseCrossFilterId(activeFilter.filterId)) {
+      result.push(activeFilter);
     }
   }
 
   return result;
+}
+
+function parseCrossFilterId(filterId: string): { sourceWidgetId: string; fieldRef: string } | null {
+  if (!filterId.startsWith(CROSS_FILTER_PREFIX)) {
+    return null;
+  }
+
+  const remainder = filterId.slice(CROSS_FILTER_PREFIX.length);
+  const separatorIndex = remainder.lastIndexOf(':');
+  if (separatorIndex <= 0 || separatorIndex === remainder.length - 1) {
+    return null;
+  }
+
+  return {
+    sourceWidgetId: remainder.slice(0, separatorIndex),
+    fieldRef: remainder.slice(separatorIndex + 1),
+  };
 }
 
 function renderTabs(

--- a/packages/runtime/test/renderer-interactions.test.tsx
+++ b/packages/runtime/test/renderer-interactions.test.tsx
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { createElement } from 'react';
+import type { LogicalQuery, QueryAdapter, QueryResult } from '@supersubset/data-model';
 import type { DashboardDefinition } from '@supersubset/schema';
 import { SupersubsetRenderer } from '../src/components/SupersubsetRenderer';
 import { createWidgetRegistry, type WidgetProps } from '../src/widgets/registry';
@@ -10,15 +11,60 @@ function ClickableWidget({ widgetId, onEvent }: WidgetProps) {
     'button',
     {
       type: 'button',
-      onClick: () => onEvent?.({
-        type: 'click',
-        widgetId,
-        payload: { region: 'East' },
-      }),
+      onClick: () =>
+        onEvent?.({
+          type: 'click',
+          widgetId,
+          payload: { region: 'East' },
+        }),
     },
     'Trigger interaction',
   );
 }
+
+function ChartTriggerWidget({ widgetId, onEvent }: WidgetProps) {
+  return createElement(
+    'button',
+    {
+      type: 'button',
+      onClick: () =>
+        onEvent?.({
+          type: 'click',
+          widgetId,
+          payload: { region: 'North' },
+        }),
+    },
+    'Filter by North',
+  );
+}
+
+function QueryProbeWidget({ data, loading, error }: WidgetProps) {
+  if (loading) {
+    return createElement('div', { 'data-testid': 'widget-query-probe' }, 'loading');
+  }
+
+  if (error) {
+    return createElement('div', { 'data-testid': 'widget-query-probe' }, `error:${error.message}`);
+  }
+
+  return createElement(
+    'div',
+    { 'data-testid': 'widget-query-probe' },
+    String(data?.[0]?.revenue ?? 'no-data'),
+  );
+}
+
+function createQueryResult(revenue: number): QueryResult {
+  return {
+    columns: [{ fieldId: 'revenue', label: 'Revenue', dataType: 'number' }],
+    rows: [{ revenue }],
+    totalRows: 1,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
 
 const dashboard: DashboardDefinition = {
   schemaVersion: '0.2.0',
@@ -38,7 +84,13 @@ const dashboard: DashboardDefinition = {
       rootNodeId: 'root',
       layout: {
         root: { id: 'root', type: 'root', children: ['grid-main'], meta: {} },
-        'grid-main': { id: 'grid-main', type: 'grid', children: ['widget-node'], parentId: 'root', meta: { columns: 12 } },
+        'grid-main': {
+          id: 'grid-main',
+          type: 'grid',
+          children: ['widget-node'],
+          parentId: 'root',
+          meta: { columns: 12 },
+        },
         'widget-node': {
           id: 'widget-node',
           type: 'widget',
@@ -62,7 +114,13 @@ const dashboard: DashboardDefinition = {
       rootNodeId: 'detail-root',
       layout: {
         'detail-root': { id: 'detail-root', type: 'root', children: ['detail-grid'], meta: {} },
-        'detail-grid': { id: 'detail-grid', type: 'grid', children: [], parentId: 'detail-root', meta: { columns: 12 } },
+        'detail-grid': {
+          id: 'detail-grid',
+          type: 'grid',
+          children: [],
+          parentId: 'detail-root',
+          meta: { columns: 12 },
+        },
       },
       widgets: [],
     },
@@ -73,9 +131,7 @@ describe('SupersubsetRenderer interactions', () => {
   it('routes widget click events through the interaction engine', () => {
     const onNavigate = vi.fn();
     const onWidgetEvent = vi.fn();
-    const registry = createWidgetRegistry([
-      ['clickable-widget', ClickableWidget],
-    ]);
+    const registry = createWidgetRegistry([['clickable-widget', ClickableWidget]]);
 
     render(
       createElement(SupersubsetRenderer, {
@@ -99,5 +155,117 @@ describe('SupersubsetRenderer interactions', () => {
         payload: { region: 'East' },
       }),
     );
+  });
+
+  it('re-executes query-bound widgets when a chart click sets a cross-filter', async () => {
+    const execute = vi.fn<QueryAdapter['execute']>().mockImplementation(async (query) => {
+      const activeRegion = query.filters?.find((filter) => filter.fieldId === 'region')?.value;
+      return createQueryResult(activeRegion === 'North' ? 6400 : 23000);
+    });
+
+    const queryAdapter: QueryAdapter = {
+      name: 'mock-query',
+      execute,
+    };
+
+    const registry = createWidgetRegistry([
+      ['mock-chart', ChartTriggerWidget],
+      ['query-probe', QueryProbeWidget],
+    ]);
+
+    const crossFilterDashboard: DashboardDefinition = {
+      schemaVersion: '0.2.0',
+      id: 'cross-filter-dashboard',
+      title: 'Cross Filter Dashboard',
+      interactions: [
+        {
+          id: 'cross-filter-region',
+          trigger: { type: 'click', sourceWidgetId: 'chart-region-sales' },
+          action: { type: 'filter', fieldRef: 'region', targetWidgetIds: ['kpi-total-revenue'] },
+        },
+      ],
+      pages: [
+        {
+          id: 'overview',
+          title: 'Overview',
+          rootNodeId: 'root',
+          layout: {
+            root: { id: 'root', type: 'root', children: ['grid-main'], meta: {} },
+            'grid-main': {
+              id: 'grid-main',
+              type: 'grid',
+              children: ['chart-node', 'kpi-node'],
+              parentId: 'root',
+              meta: { columns: 12 },
+            },
+            'chart-node': {
+              id: 'chart-node',
+              type: 'widget',
+              children: [],
+              parentId: 'grid-main',
+              meta: { widgetRef: 'chart-region-sales', width: 6 },
+            },
+            'kpi-node': {
+              id: 'kpi-node',
+              type: 'widget',
+              children: [],
+              parentId: 'grid-main',
+              meta: { widgetRef: 'kpi-total-revenue', width: 6 },
+            },
+          },
+          widgets: [
+            {
+              id: 'chart-region-sales',
+              type: 'mock-chart',
+              title: 'Region Sales',
+              config: {},
+            },
+            {
+              id: 'kpi-total-revenue',
+              type: 'query-probe',
+              title: 'Total Revenue',
+              config: {},
+              dataBinding: {
+                datasetRef: 'sales',
+                fields: [{ role: 'value', fieldRef: 'revenue' }],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    render(
+      createElement(SupersubsetRenderer, {
+        definition: crossFilterDashboard,
+        registry,
+        queryAdapter,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(execute).toHaveBeenNthCalledWith(1, {
+        datasetId: 'sales',
+        fields: [{ fieldId: 'revenue' }],
+      } satisfies LogicalQuery);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('widget-query-probe').textContent).toBe('23000');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filter by North' }));
+
+    await waitFor(() => {
+      expect(execute).toHaveBeenNthCalledWith(2, {
+        datasetId: 'sales',
+        fields: [{ fieldId: 'revenue' }],
+        filters: [{ fieldId: 'region', operator: 'eq', value: 'North' }],
+      } satisfies LogicalQuery);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('widget-query-probe').textContent).toBe('6400');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- compile synthetic cross-filter ids into query filters for query-bound widgets
- include synthetic cross-filters in widget active filter selection
- add a renderer regression proving a chart-driven filter interaction changes the executed query and rendered revenue

## Testing
- cd packages/runtime && corepack pnpm test -- test/renderer-interactions.test.tsx

Closes #134