### PR TITLE
Add host QA regressions and fix publish draft persistence

### DIFF
--- a/e2e/workflows/filter-cascade.spec.ts
+++ b/e2e/workflows/filter-cascade.spec.ts
@@ -21,6 +21,15 @@ test.describe('Filter Cascade Workflow', () => {
     await expect(page.getByRole('button', { name: 'Overview' })).toBeVisible();
   }
 
+  async function openSeparateDashboardsDemo(page: import('@playwright/test').Page) {
+    const dashboardsScenarioButton = page.getByRole('button', {
+      name: 'Two separate dashboards',
+    });
+    await expect(dashboardsScenarioButton).toBeVisible();
+    await dashboardsScenarioButton.click();
+    await expect(page.getByRole('button', { name: 'Executive Overview' })).toBeVisible();
+  }
+
   async function clickOverviewRegionDatum(page: import('@playwright/test').Page) {
     const canvas = page.locator('[data-ss-node="pages-region-chart-host"] canvas').first();
     await expect(canvas).toBeVisible();
@@ -151,6 +160,35 @@ test.describe('Filter Cascade Workflow', () => {
         revenue: expect.any(Number),
       }),
     });
+  });
+
+  test('separate dashboards switch document identity instead of preserving workbook state', async ({
+    page,
+  }) => {
+    await openSeparateDashboardsDemo(page);
+
+    const dashboard = page.locator('[data-ss-dashboard]');
+
+    await expect(dashboard).toHaveAttribute('data-ss-dashboard', 'dashboard-executive');
+    await expect(dashboard).toHaveAttribute('data-ss-page', 'page-executive');
+    await expect(
+      page.getByRole('heading', { name: 'Dashboard 1: Executive Overview' }),
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: 'Fulfillment Ops' }).click();
+
+    await expect(dashboard).toHaveAttribute('data-ss-dashboard', 'dashboard-operations');
+    await expect(dashboard).toHaveAttribute('data-ss-page', 'page-operations');
+    await expect(page.getByRole('heading', { name: 'Dashboard 2: Fulfillment Ops' })).toBeVisible();
+    await expect(page.locator('.ss-table tbody tr')).toHaveCount(8);
+
+    await page.getByRole('button', { name: 'Executive Overview' }).click();
+
+    await expect(dashboard).toHaveAttribute('data-ss-dashboard', 'dashboard-executive');
+    await expect(dashboard).toHaveAttribute('data-ss-page', 'page-executive');
+    await expect(
+      page.getByRole('heading', { name: 'Dashboard 1: Executive Overview' }),
+    ).toBeVisible();
   });
 
   test('page-scoped category filter changes overview widgets without leaking into detail widgets', async ({

--- a/e2e/workflows/host-workbench.spec.ts
+++ b/e2e/workflows/host-workbench.spec.ts
@@ -72,6 +72,23 @@ function buildStructuredAlertsWorkbenchDashboard() {
   return JSON.stringify(dashboard, null, 2);
 }
 
+function buildFieldBackedFilterWorkbenchDashboard() {
+  const dashboard = structuredClone(workbenchStarterDashboard) as DashboardDefinition;
+  const regionFilter = dashboard.filters?.find((filter) => filter.id === 'filter-region');
+  if (!regionFilter) {
+    throw new Error('Expected filter-region in workbench starter dashboard');
+  }
+
+  dashboard.title = 'Northstar Field-backed Filters Workbench';
+  regionFilter.optionSource = {
+    kind: 'field',
+    strategy: 'search',
+    minSearchChars: 2,
+  };
+
+  return JSON.stringify(dashboard, null, 2);
+}
+
 test.describe('Next.js Real Host Workbench', () => {
   test('logs in, loads datasets, and re-queries a query-backed alerts tile in viewer mode', async ({
     page,
@@ -214,6 +231,59 @@ test.describe('Next.js Real Host Workbench', () => {
       true,
     );
     expect(requestUrls.some((url) => url.includes('/api/analytics/supersubset/query'))).toBe(true);
+    expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
+  });
+
+  test('imports a field-backed filter dashboard and shows the explicit unavailable state in viewer mode', async ({
+    page,
+  }) => {
+    const fieldBackedDashboard = buildFieldBackedFilterWorkbenchDashboard();
+    const requestUrls: string[] = [];
+    const consoleErrors: string[] = [];
+
+    page.on('request', (request) => requestUrls.push(request.url()));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto(`${NEXTJS_WORKBENCH_ORIGIN}/workbench`);
+
+    await expect(page.getByTestId('workbench-login-form')).toBeVisible();
+    await page.getByTestId('workbench-login-submit').click();
+
+    await expect(page.getByTestId('workbench-shell')).toBeVisible();
+    await expect(page.getByTestId('workbench-dataset-status')).toContainText('1 dataset(s)');
+
+    await page.getByTestId('import-btn').click();
+    await expect(page.getByTestId('import-export-dialog')).toBeVisible();
+    await page.getByTestId('import-textarea').fill(fieldBackedDashboard);
+    await page.getByTestId('import-submit-btn').click();
+    await expect(page.getByTestId('import-export-dialog')).toHaveCount(0);
+
+    await page.getByTestId('workbench-code-toggle').click();
+    await expect(page.getByTestId('code-view-panel')).toContainText(
+      'Northstar Field-backed Filters Workbench',
+    );
+    await expect(page.getByTestId('code-view-content')).toContainText('"kind": "field"');
+
+    await page.getByTestId('workbench-mode-viewer').click();
+
+    const regionFilter = page.getByLabel('Region');
+    const carrierFilter = page.getByLabel('Carrier');
+
+    await expect(regionFilter).toBeDisabled();
+    await expect(regionFilter.locator('option')).toHaveText([
+      'Field-backed options require host support',
+    ]);
+    await expect(carrierFilter).toBeEnabled();
+    await expect(carrierFilter.locator('option')).toContainText(['All', 'Atlas Air']);
+
+    expect(requestUrls.some((url) => url.includes('/api/graphql'))).toBe(true);
+    expect(requestUrls.some((url) => url.includes('/api/analytics/supersubset/datasets'))).toBe(
+      true,
+    );
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });
 });

--- a/e2e/workflows/host-workbench.spec.ts
+++ b/e2e/workflows/host-workbench.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 import type { DashboardDefinition } from '@supersubset/schema';
 import { workbenchStarterDashboard } from '../../examples/nextjs-ecommerce/lib/workbench-dashboard';
 import { WORKBENCH_DATASET_ID } from '../../examples/nextjs-ecommerce/lib/workbench-shared';
@@ -87,6 +87,20 @@ function buildFieldBackedFilterWorkbenchDashboard() {
   };
 
   return JSON.stringify(dashboard, null, 2);
+}
+
+async function ensureDesignerMenuBarExpanded(page: Page) {
+  const dashboardTitleInput = page.getByTestId('designer-dashboard-title-input');
+  if (await dashboardTitleInput.isVisible()) {
+    return;
+  }
+
+  const toggleMenuBarButton = page.getByRole('button', { name: 'Toggle menu bar' });
+  if (await toggleMenuBarButton.isVisible()) {
+    await toggleMenuBarButton.click();
+  }
+
+  await expect(dashboardTitleInput).toBeVisible();
 }
 
 test.describe('Next.js Real Host Workbench', () => {
@@ -284,6 +298,52 @@ test.describe('Next.js Real Host Workbench', () => {
     expect(requestUrls.some((url) => url.includes('/api/analytics/supersubset/datasets'))).toBe(
       true,
     );
+    expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
+  });
+
+  test('publishes an edited dashboard title and reloads the persisted workbench state without another login', async ({
+    page,
+  }) => {
+    const editedDashboardTitle = 'Northstar Logistics Persisted Host Workflow';
+    const consoleErrors: string[] = [];
+
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto(`${NEXTJS_WORKBENCH_ORIGIN}/workbench`);
+
+    await expect(page.getByTestId('workbench-login-form')).toBeVisible();
+    await page.getByTestId('workbench-login-submit').click();
+
+    await expect(page.getByTestId('workbench-shell')).toBeVisible();
+    await ensureDesignerMenuBarExpanded(page);
+    await expect(page.getByTestId('designer-dashboard-title-input')).toHaveValue(
+      'Northstar Logistics Control Tower',
+    );
+    await page.getByTestId('designer-dashboard-title-input').fill(editedDashboardTitle);
+    await page.getByTestId('designer-dashboard-title-input').blur();
+    await page.getByText('Publish', { exact: true }).click();
+
+    await expect(page.getByTestId('workbench-query-log')).toContainText(
+      '"datasetId": "ops-shipments"',
+    );
+
+    await page.reload();
+
+    await expect(page.getByTestId('workbench-shell')).toBeVisible();
+    await expect(page.getByTestId('workbench-login-form')).toHaveCount(0);
+    await page.getByTestId('workbench-mode-designer').click();
+    await ensureDesignerMenuBarExpanded(page);
+    await expect(page.getByTestId('designer-dashboard-title-input')).toHaveValue(
+      editedDashboardTitle,
+    );
+
+    await page.getByTestId('workbench-code-toggle').click();
+    await expect(page.getByTestId('code-view-content')).toContainText(editedDashboardTitle);
+
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });
 });

--- a/packages/designer/src/components/SupersubsetDesigner.tsx
+++ b/packages/designer/src/components/SupersubsetDesigner.tsx
@@ -370,6 +370,20 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
     [emitDashboardChange, sourceDashboard],
   );
 
+  const effectiveDashboardTitle = useMemo(
+    () =>
+      normalizePageTitle(dashboardTitleDraft, sourceDashboard?.title ?? DEFAULT_DASHBOARD_TITLE),
+    [dashboardTitleDraft, sourceDashboard?.title],
+  );
+
+  const effectivePageTitle = useMemo(() => {
+    if (!activePage) {
+      return undefined;
+    }
+
+    return normalizePageTitle(pageTitleDraft, activePage.title);
+  }, [activePage, pageTitleDraft]);
+
   // Sidebar icon overrides + header actions wrapper
   const overrides = useMemo(
     () => ({
@@ -791,20 +805,20 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
     (puckData: Data) => {
       const dashboard = puckToCanonical(puckData, {
         dashboardId: dashboardIdRef.current,
-        dashboardTitle: sourceDashboard?.title ?? dashboardTitleDraft ?? DEFAULT_DASHBOARD_TITLE,
+        dashboardTitle: effectiveDashboardTitle,
         baseDashboard: sourceDashboard,
         pageIndex: activePageIndex,
         pageId: activePage?.id,
-        pageTitle: activePage?.title,
+        pageTitle: effectivePageTitle,
       });
       emitDashboardChange(dashboard);
     },
     [
       activePage?.id,
-      activePage?.title,
       activePageIndex,
-      dashboardTitleDraft,
       emitDashboardChange,
+      effectiveDashboardTitle,
+      effectivePageTitle,
       sourceDashboard,
     ],
   );
@@ -814,20 +828,20 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
       if (onPublish) {
         const dashboard = puckToCanonical(puckData, {
           dashboardId: dashboardIdRef.current,
-          dashboardTitle: sourceDashboard?.title ?? dashboardTitleDraft ?? DEFAULT_DASHBOARD_TITLE,
+          dashboardTitle: effectiveDashboardTitle,
           baseDashboard: sourceDashboard,
           pageIndex: activePageIndex,
           pageId: activePage?.id,
-          pageTitle: activePage?.title,
+          pageTitle: effectivePageTitle,
         });
         onPublish(dashboard);
       }
     },
     [
       activePage?.id,
-      activePage?.title,
       activePageIndex,
-      dashboardTitleDraft,
+      effectiveDashboardTitle,
+      effectivePageTitle,
       onPublish,
       sourceDashboard,
     ],

--- a/packages/designer/test/designer.test.tsx
+++ b/packages/designer/test/designer.test.tsx
@@ -33,6 +33,19 @@ vi.mock('@puckeditor/core', () => ({
             children: React.createElement('span', { 'data-testid': 'default-actions' }),
           })
         : null,
+      typeof props.onPublish === 'function'
+        ? React.createElement(
+            'button',
+            {
+              type: 'button',
+              'data-testid': 'mock-puck-publish',
+              onClick: () => {
+                (props.onPublish as (data: unknown) => void)(props.data);
+              },
+            },
+            'Publish',
+          )
+        : null,
       React.createElement('iframe', { 'data-testid': 'mock-preview-iframe' }),
       React.createElement(
         'select',
@@ -202,6 +215,26 @@ describe('SupersubsetDesigner', () => {
     render(React.createElement(SupersubsetDesigner, { onPublish }));
     const editor = screen.getByTestId('puck-editor');
     expect(editor.getAttribute('data-has-on-publish')).toBe('true');
+  });
+
+  it('publishes the current dashboard title draft without waiting for blur', () => {
+    const onPublish = vi.fn();
+
+    render(
+      React.createElement(SupersubsetDesigner, {
+        value: minimalDashboard,
+        onChange: vi.fn(),
+        onPublish,
+      }),
+    );
+
+    const titleInput = screen.getByTestId('designer-dashboard-title-input');
+    fireEvent.change(titleInput, { target: { value: 'Executive Dashboard' } });
+    fireEvent.click(screen.getByTestId('mock-puck-publish'));
+
+    expect(onPublish).toHaveBeenCalledTimes(1);
+    const nextDashboard = onPublish.mock.calls[0]?.[0] as DashboardDefinition;
+    expect(nextDashboard.title).toBe('Executive Dashboard');
   });
 
   it('wires onChange callback', () => {


### PR DESCRIPTION
## Summary
- add browser coverage that proves the separate-dashboards demo switches document identity instead of preserving workbook page state
- add real-host workbench coverage for field-backed filters and for publish-plus-reload persistence of authored dashboard metadata
- fix SupersubsetDesigner so publish and canonical change paths use the live header title drafts instead of stale dashboard metadata

## Testing
- corepack pnpm --filter @supersubset/designer exec vitest run test/designer.test.tsx
- PLAYWRIGHT_HTML_OPEN=never SUPERSUBSET_EXAMPLE_NEXTJS_PORT=3411 corepack pnpm exec playwright test -c playwright.e2e.config.ts e2e/workflows/host-workbench.spec.ts --project=chromium --reporter=line
- PLAYWRIGHT_HTML_OPEN=never SUPERSUBSET_DEV_APP_PORT=3410 corepack pnpm exec playwright test -c playwright.e2e.config.ts e2e/workflows/filter-cascade.spec.ts --project=chromium --reporter=line
