### PR TITLE
Fix cross-tab workbench dashboard sync

### DIFF
--- a/e2e/workflows/host-workbench.spec.ts
+++ b/e2e/workflows/host-workbench.spec.ts
@@ -485,4 +485,90 @@ test.describe('Next.js Real Host Workbench', () => {
       await sharedContext.close();
     }
   });
+
+  test('rehydrates a newer publish in an already-authenticated second tab without a reload', async ({
+    browser,
+  }) => {
+    const publishedDashboardTitle = 'Northstar Live Cross Tab Sync';
+    const sharedContext = await browser.newContext();
+    const firstPage = await sharedContext.newPage();
+    const secondPage = await sharedContext.newPage();
+
+    try {
+      await firstPage.goto(`${NEXTJS_WORKBENCH_ORIGIN}/workbench`);
+      await secondPage.goto(`${NEXTJS_WORKBENCH_ORIGIN}/workbench`);
+
+      await expect(firstPage.getByTestId('workbench-login-form')).toBeVisible();
+      await expect(secondPage.getByTestId('workbench-login-form')).toBeVisible();
+
+      await firstPage.getByTestId('workbench-login-submit').click();
+      await secondPage.getByTestId('workbench-login-submit').click();
+
+      await expect(firstPage.getByTestId('workbench-shell')).toBeVisible();
+      await expect(secondPage.getByTestId('workbench-shell')).toBeVisible();
+      await secondPage.getByTestId('workbench-mode-viewer').click();
+
+      await firstPage.getByTestId('workbench-mode-designer').click();
+      await ensureDesignerMenuBarExpanded(firstPage);
+      await firstPage.getByTestId('designer-dashboard-title-input').fill(publishedDashboardTitle);
+      await firstPage.getByTestId('designer-dashboard-title-input').blur();
+      await firstPage.getByText('Publish', { exact: true }).click();
+      await expect(firstPage.getByTestId('workbench-query-log')).toContainText(
+        '"datasetId": "ops-shipments"',
+      );
+
+      await secondPage.getByTestId('workbench-mode-designer').click();
+      await ensureDesignerMenuBarExpanded(secondPage);
+      await expect(secondPage.getByTestId('designer-dashboard-title-input')).toHaveValue(
+        publishedDashboardTitle,
+      );
+      await expect(secondPage.getByTestId('workbench-login-form')).toHaveCount(0);
+    } finally {
+      await sharedContext.close();
+    }
+  });
+
+  test('preserves an unpublished draft in a second tab while syncing the newer published dashboard', async ({
+    browser,
+  }) => {
+    const draftDashboardTitle = 'Northstar Draft Should Survive';
+    const publishedDashboardTitle = 'Northstar External Publish Wins';
+    const sharedContext = await browser.newContext();
+    const firstPage = await sharedContext.newPage();
+    const secondPage = await sharedContext.newPage();
+
+    try {
+      await firstPage.goto(`${NEXTJS_WORKBENCH_ORIGIN}/workbench`);
+      await secondPage.goto(`${NEXTJS_WORKBENCH_ORIGIN}/workbench`);
+
+      await expect(firstPage.getByTestId('workbench-login-form')).toBeVisible();
+      await expect(secondPage.getByTestId('workbench-login-form')).toBeVisible();
+
+      await firstPage.getByTestId('workbench-login-submit').click();
+      await secondPage.getByTestId('workbench-login-submit').click();
+
+      await expect(firstPage.getByTestId('workbench-shell')).toBeVisible();
+      await expect(secondPage.getByTestId('workbench-shell')).toBeVisible();
+
+      await secondPage.getByTestId('workbench-mode-designer').click();
+      await ensureDesignerMenuBarExpanded(secondPage);
+      await secondPage.getByTestId('designer-dashboard-title-input').fill(draftDashboardTitle);
+
+      await firstPage.getByTestId('workbench-mode-designer').click();
+      await ensureDesignerMenuBarExpanded(firstPage);
+      await firstPage.getByTestId('designer-dashboard-title-input').fill(publishedDashboardTitle);
+      await firstPage.getByTestId('designer-dashboard-title-input').blur();
+      await firstPage.getByText('Publish', { exact: true }).click();
+      await expect(firstPage.getByTestId('workbench-query-log')).toContainText(
+        '"datasetId": "ops-shipments"',
+      );
+
+      await expect(secondPage.getByTestId('designer-dashboard-title-input')).toHaveValue(
+        draftDashboardTitle,
+      );
+      await expect(secondPage.getByTestId('workbench-login-form')).toHaveCount(0);
+    } finally {
+      await sharedContext.close();
+    }
+  });
 });

--- a/e2e/workflows/host-workbench.spec.ts
+++ b/e2e/workflows/host-workbench.spec.ts
@@ -346,4 +346,143 @@ test.describe('Next.js Real Host Workbench', () => {
 
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });
+
+  test('keeps the published dashboard across logout while discarding an unpublished draft after re-login', async ({
+    page,
+  }) => {
+    const publishedDashboardTitle = 'Northstar Published Session Boundary';
+    const unpublishedDraftTitle = 'Northstar Unpublished Logout Probe';
+    const consoleErrors: string[] = [];
+
+    await page.addInitScript(() => {
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+    });
+
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto(`${NEXTJS_WORKBENCH_ORIGIN}/workbench`);
+
+    await expect(page.getByTestId('workbench-login-form')).toBeVisible();
+    await page.getByTestId('workbench-login-submit').click();
+
+    await expect(page.getByTestId('workbench-shell')).toBeVisible();
+    await ensureDesignerMenuBarExpanded(page);
+    await page.getByTestId('designer-dashboard-title-input').fill(publishedDashboardTitle);
+    await page.getByTestId('designer-dashboard-title-input').blur();
+    await page.getByText('Publish', { exact: true }).click();
+
+    await expect(page.getByTestId('workbench-query-log')).toContainText(
+      '"datasetId": "ops-shipments"',
+    );
+
+    await page.getByTestId('workbench-mode-designer').click();
+    await ensureDesignerMenuBarExpanded(page);
+    await expect(page.getByTestId('designer-dashboard-title-input')).toHaveValue(
+      publishedDashboardTitle,
+    );
+    await page.getByTestId('designer-dashboard-title-input').fill(unpublishedDraftTitle);
+
+    await page.getByTestId('workbench-logout').click();
+    await expect(page.getByTestId('workbench-login-form')).toBeVisible();
+
+    await page.getByTestId('workbench-login-submit').click();
+    await expect(page.getByTestId('workbench-shell')).toBeVisible();
+    await expect(page.getByTestId('workbench-login-form')).toHaveCount(0);
+    await ensureDesignerMenuBarExpanded(page);
+    await expect(page.getByTestId('designer-dashboard-title-input')).toHaveValue(
+      publishedDashboardTitle,
+    );
+    await expect(page.getByTestId('designer-dashboard-title-input')).not.toHaveValue(
+      unpublishedDraftTitle,
+    );
+
+    await page.getByTestId('workbench-code-toggle').click();
+    await expect(page.getByTestId('code-view-content')).toContainText(publishedDashboardTitle);
+    await expect(page.getByTestId('code-view-content')).not.toContainText(unpublishedDraftTitle);
+
+    expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
+  });
+
+  test('requires login in a second tab while rehydrating the published dashboard after login', async ({
+    browser,
+  }) => {
+    const publishedDashboardTitle = 'Northstar Cross Tab Probe';
+    const firstContext = await browser.newContext();
+    const firstPage = await firstContext.newPage();
+    const secondPage = await firstContext.newPage();
+
+    try {
+      await firstPage.goto(`${NEXTJS_WORKBENCH_ORIGIN}/workbench`);
+      await expect(firstPage.getByTestId('workbench-login-form')).toBeVisible();
+      await firstPage.getByTestId('workbench-login-submit').click();
+
+      await expect(firstPage.getByTestId('workbench-shell')).toBeVisible();
+      await firstPage.getByTestId('workbench-mode-designer').click();
+      await ensureDesignerMenuBarExpanded(firstPage);
+      await firstPage.getByTestId('designer-dashboard-title-input').fill(publishedDashboardTitle);
+      await firstPage.getByTestId('designer-dashboard-title-input').blur();
+      await firstPage.getByText('Publish', { exact: true }).click();
+      await expect(firstPage.getByTestId('workbench-query-log')).toContainText(
+        '"datasetId": "ops-shipments"',
+      );
+
+      await secondPage.goto(`${NEXTJS_WORKBENCH_ORIGIN}/workbench`);
+      await expect(secondPage.getByTestId('workbench-login-form')).toBeVisible();
+      await expect(secondPage.getByTestId('workbench-shell')).toHaveCount(0);
+
+      await secondPage.getByTestId('workbench-login-submit').click();
+      await expect(secondPage.getByTestId('workbench-shell')).toBeVisible();
+      await secondPage.getByTestId('workbench-mode-designer').click();
+      await ensureDesignerMenuBarExpanded(secondPage);
+      await expect(secondPage.getByTestId('designer-dashboard-title-input')).toHaveValue(
+        publishedDashboardTitle,
+      );
+    } finally {
+      await firstContext.close();
+    }
+  });
+
+  test('rehydrates a newer publish when a second tab logs in after mounting before the publish', async ({
+    browser,
+  }) => {
+    const publishedDashboardTitle = 'Northstar Cross Tab Rehydrate On Login';
+    const sharedContext = await browser.newContext();
+    const firstPage = await sharedContext.newPage();
+    const secondPage = await sharedContext.newPage();
+
+    try {
+      await firstPage.goto(`${NEXTJS_WORKBENCH_ORIGIN}/workbench`);
+      await secondPage.goto(`${NEXTJS_WORKBENCH_ORIGIN}/workbench`);
+
+      await expect(firstPage.getByTestId('workbench-login-form')).toBeVisible();
+      await expect(secondPage.getByTestId('workbench-login-form')).toBeVisible();
+
+      await firstPage.getByTestId('workbench-login-submit').click();
+      await expect(firstPage.getByTestId('workbench-shell')).toBeVisible();
+      await firstPage.getByTestId('workbench-mode-designer').click();
+      await ensureDesignerMenuBarExpanded(firstPage);
+      await firstPage.getByTestId('designer-dashboard-title-input').fill(publishedDashboardTitle);
+      await firstPage.getByTestId('designer-dashboard-title-input').blur();
+      await firstPage.getByText('Publish', { exact: true }).click();
+      await expect(firstPage.getByTestId('workbench-query-log')).toContainText(
+        '"datasetId": "ops-shipments"',
+      );
+
+      await expect(secondPage.getByTestId('workbench-shell')).toHaveCount(0);
+      await secondPage.getByTestId('workbench-login-submit').click();
+      await expect(secondPage.getByTestId('workbench-shell')).toBeVisible();
+      await secondPage.getByTestId('workbench-mode-designer').click();
+      await ensureDesignerMenuBarExpanded(secondPage);
+      await expect(secondPage.getByTestId('designer-dashboard-title-input')).toHaveValue(
+        publishedDashboardTitle,
+      );
+    } finally {
+      await sharedContext.close();
+    }
+  });
 });

--- a/examples/nextjs-ecommerce/components/WorkbenchHost.tsx
+++ b/examples/nextjs-ecommerce/components/WorkbenchHost.tsx
@@ -26,6 +26,7 @@ import {
   readStoredWorkbenchToken,
 } from '../lib/workbench-client';
 import { WORKBENCH_LOGIN_EMAIL, WORKBENCH_LOGIN_PASSWORD } from '../lib/workbench-auth';
+import { WORKBENCH_DASHBOARD_STORAGE_KEY } from '../lib/workbench-shared';
 import { workbenchStarterDashboard } from '../lib/workbench-dashboard';
 
 export function WorkbenchHost() {
@@ -79,6 +80,36 @@ export function WorkbenchHost() {
 
     setToken(storedToken);
   }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    function handleStorage(event: StorageEvent) {
+      if (
+        event.storageArea !== window.localStorage ||
+        event.key !== WORKBENCH_DASHBOARD_STORAGE_KEY
+      ) {
+        return;
+      }
+
+      const storedDashboard = readStoredWorkbenchDashboard();
+      if (!storedDashboard) {
+        return;
+      }
+
+      setPublishedDashboard(storedDashboard);
+      if (mode !== 'designer') {
+        setDashboard(storedDashboard);
+      }
+    }
+
+    window.addEventListener('storage', handleStorage);
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, [mode]);
 
   useEffect(() => {
     if (!token) {

--- a/examples/nextjs-ecommerce/components/WorkbenchHost.tsx
+++ b/examples/nextjs-ecommerce/components/WorkbenchHost.tsx
@@ -46,6 +46,17 @@ export function WorkbenchHost() {
   const [queryLog, setQueryLog] = useState<string[]>([]);
   const queryCycleRef = useRef({ generation: 0, pending: 0, failed: false });
 
+  function rehydratePublishedDashboardFromStorage() {
+    const storedDashboard = readStoredWorkbenchDashboard();
+    if (!storedDashboard) {
+      return;
+    }
+
+    setDashboard(storedDashboard);
+    setPublishedDashboard(storedDashboard);
+    setMode('viewer');
+  }
+
   function resetSession(nextError = '') {
     clearStoredWorkbenchToken();
     setToken('');
@@ -58,12 +69,7 @@ export function WorkbenchHost() {
   }
 
   useEffect(() => {
-    const storedDashboard = readStoredWorkbenchDashboard();
-    if (storedDashboard) {
-      setDashboard(storedDashboard);
-      setPublishedDashboard(storedDashboard);
-      setMode('viewer');
-    }
+    rehydratePublishedDashboardFromStorage();
 
     const storedToken = readStoredWorkbenchToken();
     if (!storedToken) {
@@ -229,6 +235,7 @@ export function WorkbenchHost() {
 
     try {
       const nextToken = await loginToWorkbench(email, password);
+      rehydratePublishedDashboardFromStorage();
       persistWorkbenchToken(nextToken);
       setToken(nextToken);
     } catch (nextError) {


### PR DESCRIPTION
Summary
- Rehydrate the latest published dashboard after login so stale tabs do not keep an old snapshot.
- Sync published dashboard changes into already-authenticated viewer tabs.
- Preserve active designer drafts in other tabs during cross-tab publishes.
- Add real-host regressions for logout/login boundaries, login-time rehydration, viewer sync, and draft preservation.

Validation
- Focused Playwright cross-tab regressions passed.
- Full host-workbench Playwright suite passed: 9 tests.