### PR TITLE
Fix clean designer tab publish sync

### DIFF
--- a/e2e/workflows/host-workbench.spec.ts
+++ b/e2e/workflows/host-workbench.spec.ts
@@ -528,6 +528,44 @@ test.describe('Next.js Real Host Workbench', () => {
     }
   });
 
+  test('rehydrates a newer publish in a clean designer tab without a reload', async ({
+    browser,
+  }) => {
+    const publishedDashboardTitle = 'Northstar Clean Designer Sync Probe';
+    const sharedContext = await browser.newContext();
+    const firstPage = await sharedContext.newPage();
+    const secondPage = await sharedContext.newPage();
+
+    try {
+      await firstPage.goto(`${NEXTJS_WORKBENCH_ORIGIN}/workbench`);
+      await secondPage.goto(`${NEXTJS_WORKBENCH_ORIGIN}/workbench`);
+
+      await expect(firstPage.getByTestId('workbench-login-form')).toBeVisible();
+      await expect(secondPage.getByTestId('workbench-login-form')).toBeVisible();
+
+      await firstPage.getByTestId('workbench-login-submit').click();
+      await secondPage.getByTestId('workbench-login-submit').click();
+
+      await expect(firstPage.getByTestId('workbench-shell')).toBeVisible();
+      await expect(secondPage.getByTestId('workbench-shell')).toBeVisible();
+      await ensureDesignerMenuBarExpanded(firstPage);
+      await ensureDesignerMenuBarExpanded(secondPage);
+
+      await firstPage.getByTestId('designer-dashboard-title-input').fill(publishedDashboardTitle);
+      await firstPage.getByTestId('designer-dashboard-title-input').blur();
+      await firstPage.getByText('Publish', { exact: true }).click();
+      await expect(firstPage.getByTestId('workbench-query-log')).toContainText(
+        '"datasetId": "ops-shipments"',
+      );
+
+      await expect(secondPage.getByTestId('designer-dashboard-title-input')).toHaveValue(
+        publishedDashboardTitle,
+      );
+    } finally {
+      await sharedContext.close();
+    }
+  });
+
   test('preserves an unpublished draft in a second tab while syncing the newer published dashboard', async ({
     browser,
   }) => {

--- a/examples/nextjs-ecommerce/components/WorkbenchHost.tsx
+++ b/examples/nextjs-ecommerce/components/WorkbenchHost.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   CodeViewPanel,
   ImportExportPanel,
@@ -40,12 +40,31 @@ export function WorkbenchHost() {
   const [mode, setMode] = useState<'designer' | 'viewer'>('designer');
   const [showCode, setShowCode] = useState(false);
   const [designerRevision, setDesignerRevision] = useState(0);
+  const [designerHasUncommittedDrafts, setDesignerHasUncommittedDrafts] = useState(false);
   const [filterState, setFilterState] = useState<FilterState>({ values: {} });
   const [authStatus, setAuthStatus] = useState<'checking' | 'logged-out' | 'ready'>('checking');
   const [viewerStatus, setViewerStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
   const [error, setError] = useState('');
   const [queryLog, setQueryLog] = useState<string[]>([]);
   const queryCycleRef = useRef({ generation: 0, pending: 0, failed: false });
+  const dashboardRef = useRef(dashboard);
+  const publishedDashboardRef = useRef(publishedDashboard);
+  const designerHasUncommittedDraftsRef = useRef(designerHasUncommittedDrafts);
+
+  const setDashboardState = useCallback((nextDashboard: DashboardDefinition) => {
+    dashboardRef.current = nextDashboard;
+    setDashboard(nextDashboard);
+  }, []);
+
+  const setPublishedDashboardState = useCallback((nextDashboard: DashboardDefinition) => {
+    publishedDashboardRef.current = nextDashboard;
+    setPublishedDashboard(nextDashboard);
+  }, []);
+
+  const setDesignerDraftState = useCallback((hasUncommittedDrafts: boolean) => {
+    designerHasUncommittedDraftsRef.current = hasUncommittedDrafts;
+    setDesignerHasUncommittedDrafts(hasUncommittedDrafts);
+  }, []);
 
   function rehydratePublishedDashboardFromStorage() {
     const storedDashboard = readStoredWorkbenchDashboard();
@@ -53,8 +72,9 @@ export function WorkbenchHost() {
       return;
     }
 
-    setDashboard(storedDashboard);
-    setPublishedDashboard(storedDashboard);
+    setDesignerDraftState(false);
+    setDashboardState(storedDashboard);
+    setPublishedDashboardState(storedDashboard);
     setMode('viewer');
   }
 
@@ -62,6 +82,7 @@ export function WorkbenchHost() {
     clearStoredWorkbenchToken();
     setToken('');
     setDatasets([]);
+    setDesignerDraftState(false);
     setFilterState({ values: {} });
     setQueryLog([]);
     setAuthStatus('logged-out');
@@ -99,9 +120,13 @@ export function WorkbenchHost() {
         return;
       }
 
-      setPublishedDashboard(storedDashboard);
-      if (mode !== 'designer') {
-        setDashboard(storedDashboard);
+      const hasLocalDesignerChanges =
+        dashboardRef.current !== publishedDashboardRef.current ||
+        designerHasUncommittedDraftsRef.current;
+
+      setPublishedDashboardState(storedDashboard);
+      if (!hasLocalDesignerChanges) {
+        setDashboardState(storedDashboard);
       }
     }
 
@@ -109,7 +134,7 @@ export function WorkbenchHost() {
     return () => {
       window.removeEventListener('storage', handleStorage);
     };
-  }, [mode]);
+  }, []);
 
   useEffect(() => {
     if (!token) {
@@ -276,16 +301,18 @@ export function WorkbenchHost() {
   }
 
   function handlePublish(nextDashboard: DashboardDefinition) {
-    setDashboard(nextDashboard);
-    setPublishedDashboard(nextDashboard);
+    setDesignerDraftState(false);
+    setDashboardState(nextDashboard);
+    setPublishedDashboardState(nextDashboard);
     persistWorkbenchDashboard(nextDashboard);
     setMode('viewer');
     setError('');
   }
 
   function handleImport(nextDashboard: DashboardDefinition) {
-    setDashboard(nextDashboard);
-    setPublishedDashboard(nextDashboard);
+    setDesignerDraftState(false);
+    setDashboardState(nextDashboard);
+    setPublishedDashboardState(nextDashboard);
     persistWorkbenchDashboard(nextDashboard);
     setDesignerRevision((current) => current + 1);
   }
@@ -528,7 +555,8 @@ export function WorkbenchHost() {
             <SupersubsetDesigner
               key={designerRevision}
               value={dashboard}
-              onChange={setDashboard}
+              onChange={setDashboardState}
+              onDraftStateChange={setDesignerDraftState}
               onPublish={handlePublish}
               headerTitle="Northstar Logistics Workbench"
               height="720px"

--- a/packages/designer/src/components/SupersubsetDesigner.tsx
+++ b/packages/designer/src/components/SupersubsetDesigner.tsx
@@ -81,6 +81,8 @@ export interface SupersubsetDesignerProps {
   value?: DashboardDefinition;
   /** Controlled mode: called when dashboard changes */
   onChange?: (dashboard: DashboardDefinition) => void;
+  /** Called when local title drafts differ from the canonical dashboard value */
+  onDraftStateChange?: (hasUncommittedDraft: boolean) => void;
   /** Uncontrolled mode: initial dashboard definition */
   defaultValue?: DashboardDefinition;
   /** Called when user clicks "Publish" / Save */
@@ -117,6 +119,7 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
   const {
     value,
     onChange,
+    onDraftStateChange,
     defaultValue,
     onPublish,
     headerTitle,
@@ -151,6 +154,10 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
   const [controlledSyncRevision, setControlledSyncRevision] = useState(0);
   const canMutateDashboard = !isControlled || !!onChange;
   const pendingDeletePage = pages.find((page) => page.id === pendingDeletePageId);
+  const hasUncommittedDraftChanges =
+    canMutateDashboard &&
+    (pageTitleDraft !== (activePage?.title ?? '') ||
+      dashboardTitleDraft !== (sourceDashboard?.title ?? DEFAULT_DASHBOARD_TITLE));
 
   const config = useMemo(
     () => createPuckConfig({ filterDefinitions: sourceDashboard?.filters ?? [] }),
@@ -177,10 +184,15 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
   const a11yInstanceIdRef = useRef(nextDesignerA11yInstanceId++);
   const lastHandledControlledSignatureRef = useRef<string | undefined>(undefined);
   const lastEmittedControlledSignatureRef = useRef<string | undefined>(undefined);
+  const draftStateChangeRef = useRef(onDraftStateChange);
   const controlledValueSignature = useMemo(
     () => (isControlled ? createDashboardSyncSignature(value) : undefined),
     [isControlled, value],
   );
+
+  useEffect(() => {
+    draftStateChangeRef.current = onDraftStateChange;
+  }, [onDraftStateChange]);
 
   useEffect(() => {
     const nextActivePageId = activePage?.id;
@@ -196,6 +208,16 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
   useEffect(() => {
     setDashboardTitleDraft(sourceDashboard?.title ?? DEFAULT_DASHBOARD_TITLE);
   }, [sourceDashboard?.title]);
+
+  useEffect(() => {
+    draftStateChangeRef.current?.(hasUncommittedDraftChanges);
+  }, [hasUncommittedDraftChanges]);
+
+  useEffect(() => {
+    return () => {
+      draftStateChangeRef.current?.(false);
+    };
+  }, []);
 
   useEffect(() => {
     if (!isControlled) {
@@ -234,6 +256,17 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
       onChange?.(dashboard);
     },
     [isControlled, onChange],
+  );
+
+  const reportDraftState = useCallback(
+    (nextDashboardTitleDraft: string, nextPageTitleDraft: string) => {
+      draftStateChangeRef.current?.(
+        canMutateDashboard &&
+          (nextPageTitleDraft !== (activePage?.title ?? '') ||
+            nextDashboardTitleDraft !== (sourceDashboard?.title ?? DEFAULT_DASHBOARD_TITLE)),
+      );
+    },
+    [activePage?.title, canMutateDashboard, sourceDashboard?.title],
   );
 
   const handleAddPage = useCallback(() => {
@@ -604,7 +637,9 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
                   type: 'text',
                   value: pageTitleDraft,
                   onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
-                    setPageTitleDraft(event.target.value);
+                    const nextValue = event.target.value;
+                    setPageTitleDraft(nextValue);
+                    reportDraftState(dashboardTitleDraft, nextValue);
                   },
                   onBlur: commitPageTitle,
                   onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -639,7 +674,9 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
               type: 'text',
               value: dashboardTitleDraft,
               onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
-                setDashboardTitleDraft(event.target.value);
+                const nextValue = event.target.value;
+                setDashboardTitleDraft(nextValue);
+                reportDraftState(nextValue, pageTitleDraft);
               },
               onBlur: commitDashboardTitle,
               onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/packages/designer/test/designer.test.tsx
+++ b/packages/designer/test/designer.test.tsx
@@ -237,6 +237,39 @@ describe('SupersubsetDesigner', () => {
     expect(nextDashboard.title).toBe('Executive Dashboard');
   });
 
+  it('reports uncommitted header drafts before blur and clears them after commit', async () => {
+    const draftStates: boolean[] = [];
+
+    function Harness() {
+      const [dashboard, setDashboard] = React.useState(minimalDashboard);
+
+      return React.createElement(SupersubsetDesigner, {
+        value: dashboard,
+        onChange: setDashboard,
+        onDraftStateChange: (hasDraft) => {
+          draftStates.push(hasDraft);
+        },
+      });
+    }
+
+    render(React.createElement(Harness));
+
+    const titleInput = screen.getByTestId('designer-dashboard-title-input');
+    await waitFor(() => {
+      expect(draftStates.at(-1)).toBe(false);
+    });
+
+    fireEvent.change(titleInput, { target: { value: 'Executive Dashboard' } });
+    await waitFor(() => {
+      expect(draftStates.at(-1)).toBe(true);
+    });
+
+    fireEvent.blur(titleInput);
+    await waitFor(() => {
+      expect(draftStates.at(-1)).toBe(false);
+    });
+  });
+
   it('wires onChange callback', () => {
     const onChange = vi.fn();
     render(


### PR DESCRIPTION
## Summary
- add a draft-state signal from SupersubsetDesigner for uncommitted header edits
- update the Next.js workbench host to rehydrate external publishes in clean tabs while preserving active local drafts
- cover the clean designer-tab sync bug with unit and e2e regression coverage

## Testing
- corepack pnpm test -- test/designer.test.tsx
- PLAYWRIGHT_HTML_OPEN=never SUPERSUBSET_EXAMPLE_NEXTJS_PORT=3001 corepack pnpm exec playwright test -c playwright.e2e.config.ts e2e/workflows/host-workbench.spec.ts --project=chromium --reporter=line