### PR TITLE
docs: batch trivial cleanup guidance

### DIFF
--- a/.github/skills/ai-code-cleanup/SKILL.md
+++ b/.github/skills/ai-code-cleanup/SKILL.md
@@ -99,6 +99,7 @@ Before ending a cleanup session, promote anything another agent must know into r
 - Extracting an abstraction from a single call site with speculative flags.
 - Keeping dead branches, stale props, or compatibility aliases after the caller set is known.
 - Bundling behavior changes, formatting churn, and cleanup in the same PR.
+- Opening one PR per trivial lint-only cleanup when a same-class batch would stay readable and share the same proof.
 - Relaxing CI, tests, or types to make a generated diff pass.
 - Writing tests that prove a click happened but not that the dashboard meaning changed.
 - Treating cleanup as a monthly refactor sprint instead of continuous garbage collection.
@@ -117,6 +118,14 @@ Before ending a cleanup session, promote anything another agent must know into r
 - Keep each cleanup task inside one package or one explicit shared contract whenever possible.
 - Split local simplification from architecture decisions.
 - Prefer several small cleanup tasks over one omnibus "AI cleanup" branch.
+
+### 2.5 Batch trivial slices
+
+- Batch trivial cleanup changes into one PR when they are the same class of change, carry the same risk, and share the same proof standard.
+- Good batch candidates: several unused imports or dead locals in one package, several stale path references in one docs area, or several adjacent lint-only simplifications that do not change behavior.
+- A trivial batch should still stay small enough to review quickly. Prefer one cleanup class per PR, usually across roughly 3 to 10 low-risk edits.
+- Stop batching when the next edit changes package ownership, needs a different validation method, touches hot files, or changes runtime behavior.
+- For trivial batches, run one local verification gate for the whole batch and then one PR plus CI cycle. Do not open a separate PR for every single unused import or stale path fix.
 
 ### 3. Route through the orchestrator
 
@@ -157,6 +166,7 @@ Before ending a cleanup session, promote anything another agent must know into r
 ### 7. Merge or escalate
 
 - Small, reversible cleanup with strong proof can merge quickly.
+- Trivial same-class cleanup may merge as a batched PR when the review surface is still tight and the validation is shared.
 - Cleanup that changes public API, package boundaries, schema contracts, or behavior requires explicit review and often `architecture` involvement.
 - Never weaken CI or coverage gates just to land a cleanup PR.
 

--- a/docs/cleanup/history/2026-05-10-batched-trivial-cleanups.md
+++ b/docs/cleanup/history/2026-05-10-batched-trivial-cleanups.md
@@ -34,16 +34,18 @@ The cleanup loop was moving too slowly because trivial one-line changes were bei
 
 ## PR
 
-- pending
+- open: PR #144
+- url: https://github.com/wandir-tech/supersubset/pull/144
 
 ## Cloud CI
 
-- pending
+- pending at PR creation time
+- initial observed checks: `CI/Detect Changes`, `CI/Format Check`
 
 ## Human Check
 
-- not required before local validation, PR creation, and green required CI
+- not started; blocked until PR #144 required CI is green
 
 ## Next Step
 
-- open one batched cleanup PR instead of separate docs/process PRs
+- wait for PR #144 required CI to finish, then merge or address any failures

--- a/docs/cleanup/history/2026-05-10-batched-trivial-cleanups.md
+++ b/docs/cleanup/history/2026-05-10-batched-trivial-cleanups.md
@@ -1,0 +1,49 @@
+# Batched Trivial Cleanups
+
+## Signal
+
+The cleanup loop was moving too slowly because trivial one-line changes were being sent as separate PRs. The repo also still had living testing docs that described the retired `e2e/renderer`, `e2e/designer`, and `e2e/integration` layout.
+
+## Scope
+
+- cleanup skill batching guidance
+- testing docs that still describe the old Playwright topology
+
+## Findings
+
+- the cleanup skill encouraged small slices but did not explicitly say when multiple trivial same-class fixes should be batched into one PR
+- `docs/testing/verification-strategy.md` still presented the old split E2E layout as current
+- `docs/testing/playwright-scaffold-plan.md` still reads like the older scaffold paths are the live source of truth unless the reader already knows the repo evolved
+
+## Fixes
+
+- updated `.github/skills/ai-code-cleanup/SKILL.md` with explicit trivial-batch guidance
+- updated `docs/testing/verification-strategy.md` to point at the current `e2e/` topology
+- added a historical-note banner to `docs/testing/playwright-scaffold-plan.md`
+
+## Local Validation
+
+- `get_errors` reported no issues in the touched skill and markdown files
+- verified every newly referenced `e2e/...` path exists in the current repo tree
+- `corepack pnpm install --frozen-lockfile`
+- `corepack pnpm -r build`
+- `corepack pnpm -r lint`
+- `corepack pnpm -r typecheck`
+- `corepack pnpm -r test`
+- note: root `corepack pnpm lint` shells to bare `pnpm -r lint` and failed in this shell because `pnpm` is not on `PATH`; reran the branch gate with explicit `corepack pnpm -r ...` commands
+
+## PR
+
+- pending
+
+## Cloud CI
+
+- pending
+
+## Human Check
+
+- not required before local validation, PR creation, and green required CI
+
+## Next Step
+
+- open one batched cleanup PR instead of separate docs/process PRs

--- a/docs/testing/playwright-scaffold-plan.md
+++ b/docs/testing/playwright-scaffold-plan.md
@@ -5,6 +5,8 @@
 > **Author**: Testing Agent  
 > **Date**: 2026-04-08
 
+> **Historical note**: This document preserves the original scaffold proposal. The current authoritative suite layout is the live `e2e/` tree plus `docs/testing/verification-strategy.md`. References below to `e2e/renderer/`, `e2e/designer/`, `e2e/integration/`, and `e2e/fixtures/` describe the older scaffold target, not the current converged directory layout.
+
 ---
 
 ## 1. Playwright Project Configuration
@@ -71,15 +73,15 @@ export default defineConfig({
 
 ### Key decisions
 
-| Decision | Rationale |
-|----------|-----------|
-| Config at monorepo root | Single `pnpm test:e2e` entry point; accesses `packages/dev-app` via `webServer` |
-| Chromium + Firefox only | WebKit adds CI cost with minimal user base benefit; add later in Phase 5 |
-| Mobile Chrome project | Scoped to responsive-tagged tests only; avoids running all tests on mobile viewport |
-| 2 retries in CI | Handles transient ECharts rendering timing issues |
-| 2 workers in CI | Balances speed vs determinism on standard CI runners |
-| `trace: on-first-retry` | Captures Playwright traces only when needed, keeps artifacts small |
-| 1% pixel diff threshold | Tight enough to catch regressions, loose enough for anti-aliasing differences |
+| Decision                | Rationale                                                                           |
+| ----------------------- | ----------------------------------------------------------------------------------- |
+| Config at monorepo root | Single `pnpm test:e2e` entry point; accesses `packages/dev-app` via `webServer`     |
+| Chromium + Firefox only | WebKit adds CI cost with minimal user base benefit; add later in Phase 5            |
+| Mobile Chrome project   | Scoped to responsive-tagged tests only; avoids running all tests on mobile viewport |
+| 2 retries in CI         | Handles transient ECharts rendering timing issues                                   |
+| 2 workers in CI         | Balances speed vs determinism on standard CI runners                                |
+| `trace: on-first-retry` | Captures Playwright traces only when needed, keeps artifacts small                  |
+| 1% pixel diff threshold | Tight enough to catch regressions, loose enough for anti-aliasing differences       |
 
 ---
 
@@ -123,6 +125,7 @@ e2e/
 ### Fixture dashboard (`four-widget-dashboard.json`)
 
 This is the primary test fixture. It represents a canonical `DashboardDefinition` with:
+
 - 1 line chart (sales over time, x = `order_date`, y = `revenue`)
 - 1 bar chart (products by category, x = `category`, y = `count`)
 - 1 table (order details, columns: `id`, `customer`, `amount`, `date`)
@@ -208,15 +211,15 @@ The dev app (`packages/dev-app/`) must satisfy these requirements so Playwright 
 
 ### 3.1 Routes
 
-| Route | Purpose | Available from |
-|-------|---------|----------------|
-| `/` | Renderer: loads `four-widget-dashboard.json` fixture | Phase 1 (task 1.16) |
-| `/renderer` | Renderer: accepts `?fixture=<name>` query param | Phase 1 (task 1.16) |
-| `/renderer/empty` | Renderer: empty dashboard (zero widgets) | Phase 1 |
-| `/designer` | Designer: empty editor state | Phase 2 (task 2.1) |
-| `/designer?load=<name>` | Designer: pre-loaded with named fixture | Phase 2 |
-| `/integration/host-mount` | Host integration: simulates host app mounting | Phase 5 (task 5.5) |
-| `/integration/multi-instance` | Two renderer instances on one page | Phase 5 |
+| Route                         | Purpose                                              | Available from      |
+| ----------------------------- | ---------------------------------------------------- | ------------------- |
+| `/`                           | Renderer: loads `four-widget-dashboard.json` fixture | Phase 1 (task 1.16) |
+| `/renderer`                   | Renderer: accepts `?fixture=<name>` query param      | Phase 1 (task 1.16) |
+| `/renderer/empty`             | Renderer: empty dashboard (zero widgets)             | Phase 1             |
+| `/designer`                   | Designer: empty editor state                         | Phase 2 (task 2.1)  |
+| `/designer?load=<name>`       | Designer: pre-loaded with named fixture              | Phase 2             |
+| `/integration/host-mount`     | Host integration: simulates host app mounting        | Phase 5 (task 5.5)  |
+| `/integration/multi-instance` | Two renderer instances on one page                   | Phase 5             |
 
 ### 3.2 Data attributes
 
@@ -242,12 +245,14 @@ data-testid="empty-state"            — Empty data state container
 ### 3.3 Adapter configuration
 
 The dev app must support a **fixture adapter** that:
+
 1. Returns pre-defined query results from `e2e/fixtures/query-results/`
 2. Can simulate delays (for loading state tests)
 3. Can simulate errors (for error state tests)
 4. Requires zero network requests
 
 Configuration via environment variable or query parameter:
+
 ```
 VITE_ADAPTER_MODE=fixture      # Use fixture adapter
 VITE_ADAPTER_DELAY=0           # Default: no delay
@@ -268,82 +273,83 @@ Tests are written **with** each feature, not after. This section maps which test
 
 ### Phase 0 — Scaffold only (task 0.22)
 
-| File | Content |
-|------|---------|
-| `e2e/playwright.config.ts` | Configuration per section 1 |
-| `e2e/fixtures/` | Directory structure + placeholder fixture files |
-| `e2e/helpers/dev-app.ts` | Health-check helper (waits for dev app) |
-| `e2e/helpers/fixtures.ts` | Fixture loader |
-| `e2e/helpers/screenshot.ts` | Screenshot naming utility |
-| `e2e/helpers/widget-locators.ts` | Page object stub |
-| `e2e/helpers/mock-adapter.ts` | Mock adapter stub |
-| `e2e/helpers/schema-assertions.ts` | Schema validation stub |
-| `e2e/renderer/.gitkeep` | Placeholder |
-| `e2e/designer/.gitkeep` | Placeholder |
-| `e2e/interactions/.gitkeep` | Placeholder |
-| `e2e/integration/.gitkeep` | Placeholder |
-| `e2e/workflows/.gitkeep` | Placeholder |
+| File                               | Content                                         |
+| ---------------------------------- | ----------------------------------------------- |
+| `e2e/playwright.config.ts`         | Configuration per section 1                     |
+| `e2e/fixtures/`                    | Directory structure + placeholder fixture files |
+| `e2e/helpers/dev-app.ts`           | Health-check helper (waits for dev app)         |
+| `e2e/helpers/fixtures.ts`          | Fixture loader                                  |
+| `e2e/helpers/screenshot.ts`        | Screenshot naming utility                       |
+| `e2e/helpers/widget-locators.ts`   | Page object stub                                |
+| `e2e/helpers/mock-adapter.ts`      | Mock adapter stub                               |
+| `e2e/helpers/schema-assertions.ts` | Schema validation stub                          |
+| `e2e/renderer/.gitkeep`            | Placeholder                                     |
+| `e2e/designer/.gitkeep`            | Placeholder                                     |
+| `e2e/interactions/.gitkeep`        | Placeholder                                     |
+| `e2e/integration/.gitkeep`         | Placeholder                                     |
+| `e2e/workflows/.gitkeep`           | Placeholder                                     |
 
 No runnable tests yet — just the harness.
 
 ### Phase 1 — Renderer & Chart Tests
 
-| Task | Test file created | Test scope |
-|------|-------------------|------------|
-| 1.6 | `e2e/renderer/basic-render.spec.ts` | Renderer mounts, no console errors, empty dashboard renders placeholder |
-| 1.11 | `e2e/renderer/chart-types.spec.ts` | Line chart renders from fixture, canvas present, no errors |
-| 1.12 | (same file) | Bar chart renders from fixture |
-| 1.13 | (same file) | Table renders with correct row/column count |
-| 1.14 | (same file) | KPI card shows value and label |
-| 1.16 | `e2e/renderer/basic-render.spec.ts` (extended) | Full dev app loads fixture dashboard, all 4 widgets visible |
+| Task | Test file created                              | Test scope                                                              |
+| ---- | ---------------------------------------------- | ----------------------------------------------------------------------- |
+| 1.6  | `e2e/renderer/basic-render.spec.ts`            | Renderer mounts, no console errors, empty dashboard renders placeholder |
+| 1.11 | `e2e/renderer/chart-types.spec.ts`             | Line chart renders from fixture, canvas present, no errors              |
+| 1.12 | (same file)                                    | Bar chart renders from fixture                                          |
+| 1.13 | (same file)                                    | Table renders with correct row/column count                             |
+| 1.14 | (same file)                                    | KPI card shows value and label                                          |
+| 1.16 | `e2e/renderer/basic-render.spec.ts` (extended) | Full dev app loads fixture dashboard, all 4 widgets visible             |
 
 **Phase 1 also produces**:
+
 - `e2e/renderer/loading-states.spec.ts` — skeleton/spinner during adapter delay
 - `e2e/renderer/responsive.spec.ts` — viewport resize test stub (filled in Phase 5)
 
 ### Phase 2 — Designer Tests
 
-| Task | Test file created | Test scope |
-|------|-------------------|------------|
-| 2.1 | `e2e/designer/editor-load.spec.ts` | Designer mounts empty, palette visible, no errors |
-| 2.2 | `e2e/designer/drag-drop.spec.ts` | Drag chart block from palette to canvas, widget appears |
-| 2.5 | `e2e/designer/property-edit.spec.ts` | Select widget, edit property, widget updates |
-| 2.7 | `e2e/designer/field-binding.spec.ts` | Open field picker, bind field to axis, chart updates |
-| 2.11 | `e2e/designer/import-export.spec.ts` | Export JSON, export YAML, import JSON, compare |
-| 2.12 | `e2e/designer/code-view.spec.ts` | Code view shows valid canonical JSON, edits sync |
-| 2.14 | `e2e/designer/undo-redo.spec.ts` | Add widget → undo → widget removed → redo → widget back |
+| Task | Test file created                            | Test scope                                                  |
+| ---- | -------------------------------------------- | ----------------------------------------------------------- |
+| 2.1  | `e2e/designer/editor-load.spec.ts`           | Designer mounts empty, palette visible, no errors           |
+| 2.2  | `e2e/designer/drag-drop.spec.ts`             | Drag chart block from palette to canvas, widget appears     |
+| 2.5  | `e2e/designer/property-edit.spec.ts`         | Select widget, edit property, widget updates                |
+| 2.7  | `e2e/designer/field-binding.spec.ts`         | Open field picker, bind field to axis, chart updates        |
+| 2.11 | `e2e/designer/import-export.spec.ts`         | Export JSON, export YAML, import JSON, compare              |
+| 2.12 | `e2e/designer/code-view.spec.ts`             | Code view shows valid canonical JSON, edits sync            |
+| 2.14 | `e2e/designer/undo-redo.spec.ts`             | Add widget → undo → widget removed → redo → widget back     |
 | 2.17 | `e2e/workflows/designer-to-renderer.spec.ts` | Full workflow: create in designer → save → load in renderer |
-| 2.18 | `e2e/workflows/import-export-cycle.spec.ts` | Create → export JSON → export YAML → import both → compare |
+| 2.18 | `e2e/workflows/import-export-cycle.spec.ts`  | Create → export JSON → export YAML → import both → compare  |
 
 ### Phase 3 — Adapter Tests (unit only, no new E2E)
 
 Phase 3 adapters are tested via Vitest unit/integration tests in each `packages/adapter-*/test/` directory. One E2E workflow test validates the end-to-end chain:
 
-| Task | Test file created | Test scope |
-|------|-------------------|------------|
-| 3.7 | `e2e/workflows/metadata-to-dashboard.spec.ts` | Load Prisma fixture → browse fields → bind → render |
+| Task | Test file created                             | Test scope                                          |
+| ---- | --------------------------------------------- | --------------------------------------------------- |
+| 3.7  | `e2e/workflows/metadata-to-dashboard.spec.ts` | Load Prisma fixture → browse fields → bind → render |
 
 ### Phase 4 — Interaction Tests
 
-| Task | Test file created | Test scope |
-|------|-------------------|------------|
-| 4.1 | `e2e/interactions/dashboard-filter.spec.ts` | Add filter, select value, all widgets update |
-| 4.2 | `e2e/interactions/cross-filter.spec.ts` | Click bar chart → line chart + table filter |
-| 4.5 | `e2e/interactions/drill-action.spec.ts` | Click data point → drill callback fires |
-| 4.7 | `e2e/interactions/state-persistence.spec.ts` | Apply filter → reload → filter state preserved |
-| 4.9 | `e2e/workflows/filter-cascade.spec.ts` | 3 cascading filters → apply → clear → verify |
+| Task | Test file created                            | Test scope                                     |
+| ---- | -------------------------------------------- | ---------------------------------------------- |
+| 4.1  | `e2e/interactions/dashboard-filter.spec.ts`  | Add filter, select value, all widgets update   |
+| 4.2  | `e2e/interactions/cross-filter.spec.ts`      | Click bar chart → line chart + table filter    |
+| 4.5  | `e2e/interactions/drill-action.spec.ts`      | Click data point → drill callback fires        |
+| 4.7  | `e2e/interactions/state-persistence.spec.ts` | Apply filter → reload → filter state preserved |
+| 4.9  | `e2e/workflows/filter-cascade.spec.ts`       | 3 cascading filters → apply → clear → verify   |
 
 ### Phase 5 — Integration & Hardening Tests
 
-| Task | Test file created | Test scope |
-|------|-------------------|------------|
-| 5.7 | `e2e/workflows/host-integration.spec.ts` | Mount in host → save → remount renderer → verify |
-| 5.7 | `e2e/integration/host-mount.spec.ts` | Component mounts in host container |
-| 5.7 | `e2e/integration/multiple-instances.spec.ts` | Two renderers coexist |
-| 5.7 | `e2e/integration/no-backend.spec.ts` | No external network requests |
-| 5.8 | `e2e/integration/bundle-size.spec.ts` | Bundle size within thresholds |
-| 5.2 | Plan C regression tests integrated into existing spec files | Edge cases + robustness |
-| 5.8 | `e2e/renderer/responsive.spec.ts` (filled in) | Desktop → tablet → mobile viewports |
+| Task | Test file created                                           | Test scope                                       |
+| ---- | ----------------------------------------------------------- | ------------------------------------------------ |
+| 5.7  | `e2e/workflows/host-integration.spec.ts`                    | Mount in host → save → remount renderer → verify |
+| 5.7  | `e2e/integration/host-mount.spec.ts`                        | Component mounts in host container               |
+| 5.7  | `e2e/integration/multiple-instances.spec.ts`                | Two renderers coexist                            |
+| 5.7  | `e2e/integration/no-backend.spec.ts`                        | No external network requests                     |
+| 5.8  | `e2e/integration/bundle-size.spec.ts`                       | Bundle size within thresholds                    |
+| 5.2  | Plan C regression tests integrated into existing spec files | Edge cases + robustness                          |
+| 5.8  | `e2e/renderer/responsive.spec.ts` (filled in)               | Desktop → tablet → mobile viewports              |
 
 ---
 
@@ -403,21 +409,21 @@ jobs:
 
 ### Execution model
 
-| Trigger | Projects | Workers | Retries |
-|---------|----------|---------|---------|
-| PR | chromium only | 2 | 2 |
-| Push to main | chromium + firefox | 2 | 2 |
-| Manual (release) | chromium + firefox + mobile-chrome | 1 | 0 |
+| Trigger          | Projects                           | Workers | Retries |
+| ---------------- | ---------------------------------- | ------- | ------- |
+| PR               | chromium only                      | 2       | 2       |
+| Push to main     | chromium + firefox                 | 2       | 2       |
+| Manual (release) | chromium + firefox + mobile-chrome | 1       | 0       |
 
 **PR optimization**: Only run chromium in PRs to keep CI fast. Full browser matrix runs on `main` merges.
 
 ### Artifact retention
 
-| Artifact | When uploaded | Retention |
-|----------|-------------|-----------|
-| HTML report | Always | 14 days |
-| Playwright traces | On failure | 7 days |
-| Screenshot diffs | On failure | 14 days |
+| Artifact          | When uploaded | Retention |
+| ----------------- | ------------- | --------- |
+| HTML report       | Always        | 14 days   |
+| Playwright traces | On failure    | 7 days    |
+| Screenshot diffs  | On failure    | 14 days   |
 
 ---
 
@@ -425,10 +431,10 @@ jobs:
 
 ### Two modes of screenshots
 
-| Mode | Tool | Purpose | Storage |
-|------|------|---------|---------|
-| **Regression baselines** | Playwright `toHaveScreenshot()` | Automated pixel-diff in CI | `e2e/__screenshots__/` (gitignored selectively) |
-| **Milestone evidence** | Chrome MCP | Human-reviewable proof at checkpoints | `screenshots/phase-N/` (committed to git) |
+| Mode                     | Tool                            | Purpose                               | Storage                                         |
+| ------------------------ | ------------------------------- | ------------------------------------- | ----------------------------------------------- |
+| **Regression baselines** | Playwright `toHaveScreenshot()` | Automated pixel-diff in CI            | `e2e/__screenshots__/` (gitignored selectively) |
+| **Milestone evidence**   | Chrome MCP                      | Human-reviewable proof at checkpoints | `screenshots/phase-N/` (committed to git)       |
 
 ### Regression baselines (`toHaveScreenshot()`)
 
@@ -436,6 +442,7 @@ jobs:
 (Configured via `snapshotPathTemplate` in `playwright.config.ts`)
 
 **Baseline management workflow**:
+
 1. Developer writes test with `await expect(page).toHaveScreenshot('chart-rendered.png')`
 2. First run: `pnpm test:e2e:update-snapshots` creates baseline image
 3. Baseline committed to git
@@ -444,6 +451,7 @@ jobs:
 6. Developer reviews diff in HTML report → either fixes regression or updates baseline
 
 **Baseline update protocol**:
+
 - Only update baselines intentionally: `pnpm test:e2e:update-snapshots`
 - Baseline update commits must include a justification in the commit message
 - PR reviewers must inspect baseline diffs before approving
@@ -451,13 +459,14 @@ jobs:
 
 **Diff thresholds**:
 
-| Content type | `maxDiffPixelRatio` | Rationale |
-|-------------|---------------------|-----------|
-| Chart rendering | 0.01 (1%) | Anti-aliasing + font rendering variance |
-| Layout structure | 0.005 (0.5%) | Tighter — layout shifts are always bugs |
-| Full page | 0.01 (1%) | Balanced for overall stability |
+| Content type     | `maxDiffPixelRatio` | Rationale                               |
+| ---------------- | ------------------- | --------------------------------------- |
+| Chart rendering  | 0.01 (1%)           | Anti-aliasing + font rendering variance |
+| Layout structure | 0.005 (0.5%)        | Tighter — layout shifts are always bugs |
+| Full page        | 0.01 (1%)           | Balanced for overall stability          |
 
 Per-assertion overrides are allowed:
+
 ```ts
 await expect(page).toHaveScreenshot('layout.png', {
   maxDiffPixelRatio: 0.005,
@@ -470,12 +479,12 @@ await expect(page).toHaveScreenshot('layout.png', {
 
 These are NOT used for automated comparison — they are visual evidence for human checkpoint reviews.
 
-| Phase | Screenshots captured | Naming convention |
-|-------|---------------------|-------------------|
-| 1 | First chart render, all 4 types | `screenshots/phase-1/charts-first-render.png` |
-| 2 | Empty designer, drag-drop before/after, property edit, full dashboard, round-trip | `screenshots/phase-2/{descriptive-name}.png` |
-| 4 | Cross-filter before/after | `screenshots/phase-4/cross-filter-{before,after}.png` |
-| 5 | Responsive (desktop/tablet/mobile), dark theme, host integration | `screenshots/phase-5/{descriptive-name}.png` |
+| Phase | Screenshots captured                                                              | Naming convention                                     |
+| ----- | --------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| 1     | First chart render, all 4 types                                                   | `screenshots/phase-1/charts-first-render.png`         |
+| 2     | Empty designer, drag-drop before/after, property edit, full dashboard, round-trip | `screenshots/phase-2/{descriptive-name}.png`          |
+| 4     | Cross-filter before/after                                                         | `screenshots/phase-4/cross-filter-{before,after}.png` |
+| 5     | Responsive (desktop/tablet/mobile), dark theme, host integration                  | `screenshots/phase-5/{descriptive-name}.png`          |
 
 **Protocol**: The testing agent captures these using Chrome MCP at the milestone moment, commits them to `screenshots/`, and references them in the human checkpoint brief (`docs/status/checkpoints/hc-N-brief.md`).
 
@@ -499,8 +508,8 @@ e2e/playwright-report/
 
 ### npm packages
 
-| Package | Version | Purpose |
-|---------|---------|---------|
+| Package            | Version | Purpose                              |
+| ------------------ | ------- | ------------------------------------ |
 | `@playwright/test` | `^1.50` | Test framework + assertions + runner |
 
 That's it. Playwright bundles its own browser binaries, expect library, and reporter. No additional test dependencies are needed.
@@ -529,6 +538,7 @@ pnpm exec playwright install --with-deps chromium firefox
 ### Dev app dependencies (prerequisites, not Playwright deps)
 
 The dev app must be buildable and servable before E2E tests run. This means:
+
 - `packages/dev-app` depends on `packages/runtime`, `packages/schema`, `packages/charts-echarts`
 - The `webServer` config in Playwright handles starting the dev app
 - `pnpm build` must succeed before `pnpm test:e2e`
@@ -539,12 +549,12 @@ The dev app must be buildable and servable before E2E tests run. This means:
 
 Each browser test plan maps to specific Playwright spec files:
 
-| Test Plan | Playwright Coverage |
-|-----------|-------------------|
-| [Plan A — Designer Happy Path](browser-test-plans/plan-a-designer-happy-path.md) | `e2e/designer/*.spec.ts` + `e2e/workflows/designer-to-renderer.spec.ts` + `e2e/workflows/import-export-cycle.spec.ts` |
-| [Plan B — Renderer Happy Path](browser-test-plans/plan-b-renderer-happy-path.md) | `e2e/renderer/*.spec.ts` + `e2e/interactions/*.spec.ts` |
-| [Plan C — Regression & Robustness](browser-test-plans/plan-c-regression-robustness.md) | Assertions distributed across existing spec files + `e2e/renderer/responsive.spec.ts` |
-| [Plan D — Host Integration](browser-test-plans/plan-d-host-integration.md) | `e2e/integration/*.spec.ts` + `e2e/workflows/host-integration.spec.ts` |
+| Test Plan                                                                              | Playwright Coverage                                                                                                   |
+| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| [Plan A — Designer Happy Path](browser-test-plans/plan-a-designer-happy-path.md)       | `e2e/designer/*.spec.ts` + `e2e/workflows/designer-to-renderer.spec.ts` + `e2e/workflows/import-export-cycle.spec.ts` |
+| [Plan B — Renderer Happy Path](browser-test-plans/plan-b-renderer-happy-path.md)       | `e2e/renderer/*.spec.ts` + `e2e/interactions/*.spec.ts`                                                               |
+| [Plan C — Regression & Robustness](browser-test-plans/plan-c-regression-robustness.md) | Assertions distributed across existing spec files + `e2e/renderer/responsive.spec.ts`                                 |
+| [Plan D — Host Integration](browser-test-plans/plan-d-host-integration.md)             | `e2e/integration/*.spec.ts` + `e2e/workflows/host-integration.spec.ts`                                                |
 
 Plan C regression scenarios are **not** a separate test suite — they are woven into existing spec files as edge-case assertions (malformed input in import tests, error states in render tests, etc.).
 
@@ -553,6 +563,7 @@ Plan C regression scenarios are **not** a separate test suite — they are woven
 ## Appendix: Relationship to Verification Strategy
 
 This scaffold plan implements the Playwright-specific portions of the [Verification Strategy](verification-strategy.md). The verification strategy remains the authoritative document for:
+
 - Layer definitions (unit → E2E → Chrome MCP → acceptance workflows)
 - Per-task test requirements
 - Screenshot review protocol

--- a/docs/testing/verification-strategy.md
+++ b/docs/testing/verification-strategy.md
@@ -20,6 +20,8 @@ For BI-facing features, add one more rule: do not stop at proving that a control
 
 For schema-first features, add another rule: do not treat a test as sufficient when it only passes because the harness injects authored semantics through helper props, static option maps, or other sidecar data that is not part of the intended product contract.
 
+Current note: the Playwright suite has converged away from the older `e2e/renderer/`, `e2e/designer/`, and `e2e/integration/` split. Treat the current `e2e/` topology described below as authoritative for new work. Historical task tables later in this document preserve the earlier planning vocabulary for phase context.
+
 ---
 
 ## Test Layers and Ownership
@@ -39,16 +41,14 @@ For schema-first features, add another rule: do not treat a test as sufficient w
 
 ### Layer 2: Playwright E2E Tests (incremental, per-feature)
 
-| What                               | When Written                 | Where               | Runs            |
-| ---------------------------------- | ---------------------------- | ------------------- | --------------- |
-| Renderer renders fixture dashboard | Task 1.16 (dev app scaffold) | `e2e/renderer/`     | CI + pre-commit |
-| Each chart type renders            | Tasks 1.11–1.14 (each chart) | `e2e/charts/`       | CI              |
-| Designer loads empty state         | Task 2.1 (editor shell)      | `e2e/designer/`     | CI              |
-| Drag-and-drop adds widget          | Task 2.2 (first block)       | `e2e/designer/`     | CI              |
-| Property edit updates widget       | Task 2.5 (property panels)   | `e2e/designer/`     | CI              |
-| Import/export round-trip           | Task 2.10 (import/export)    | `e2e/designer/`     | CI              |
-| Cross-filter propagates            | Task 4.2 (cross-filtering)   | `e2e/interactions/` | CI              |
-| Host mount works                   | Task 5.5 (host examples)     | `e2e/integration/`  | CI              |
+| What                                   | When Written                        | Where                                                                                   | Runs            |
+| -------------------------------------- | ----------------------------------- | --------------------------------------------------------------------------------------- | --------------- |
+| Dev app loads and basic shell renders  | Task 1.16 (dev app scaffold)        | `e2e/smoke.spec.ts`                                                                     | CI + pre-commit |
+| Chart and widget browser proof         | Tasks 1.11–1.14 and later hardening | `e2e/visual/` + `e2e/workflows/designer-chart-matrix.spec.ts`                           | CI              |
+| Designer authoring happy path          | Task 2.x shell and editing work     | `e2e/plan-a-designer-happy-path.spec.ts` + `e2e/workflows/designer-to-renderer.spec.ts` | CI              |
+| Import/export round-trip               | Task 2.10 (import/export)           | `e2e/workflows/import-export-cycle.spec.ts`                                             | CI              |
+| Cross-filter and filter cascade        | Task 4.x interactions               | `e2e/interactions/dashboard-filter.spec.ts` + `e2e/workflows/filter-cascade.spec.ts`    | CI              |
+| Host mount and host workbench behavior | Task 5.5 (host examples)            | `e2e/workflows/host-integration.spec.ts` + `e2e/workflows/host-workbench.spec.ts`       | CI              |
 
 **Rule**: Every UI-visible feature ships WITH its Playwright test, not after.
 
@@ -132,50 +132,29 @@ Use the real host examples whenever they provide stronger proof than the dev-app
 
 ```
 e2e/
-├── playwright.config.ts
-├── fixtures/
-│   ├── sample-dashboard.json      # Canonical dashboard for renderer tests
-│   ├── sample-dashboard.yaml      # Same in YAML
-│   ├── prisma-schema.prisma       # Sample Prisma model
-│   ├── metadata-model.json        # Pre-normalized metadata
-│   └── query-results/             # Mock query responses
-│       ├── sales-by-month.json
-│       ├── products-table.json
-│       └── kpi-revenue.json
-├── helpers/
-│   ├── dev-app.ts                 # Start/stop dev app
-│   ├── screenshot.ts              # Screenshot capture + naming
-│   └── schema-assertions.ts       # Canonical schema validation helpers
-├── renderer/
-│   ├── basic-render.spec.ts       # Fixture dashboard renders all widgets
-│   ├── chart-types.spec.ts        # Each chart type renders correctly
-│   ├── loading-states.spec.ts     # Loading/error/empty states
-│   └── responsive.spec.ts         # Viewport resize behavior
-├── designer/
-│   ├── editor-load.spec.ts        # Designer mounts and loads
-│   ├── drag-drop.spec.ts          # Drag widget to canvas
-│   ├── property-edit.spec.ts      # Edit properties, verify update
-│   ├── field-binding.spec.ts      # Bind data fields to widgets
-│   ├── import-export.spec.ts      # JSON/YAML import/export
-│   ├── undo-redo.spec.ts          # Undo/redo across operations
-│   └── code-view.spec.ts          # Code view shows valid schema
+├── smoke.spec.ts                  # Base dev-app smoke coverage
+├── plan-a-designer-happy-path.spec.ts # Designer smoke and milestone happy path
 ├── interactions/
-│   ├── dashboard-filter.spec.ts   # Dashboard-level filter
-│   ├── cross-filter.spec.ts       # Click chart → other widgets update
-│   ├── drill-action.spec.ts       # Drill-to-detail behavior
-│   └── state-persistence.spec.ts  # Saved filter/interaction state
-├── integration/
-│   ├── host-mount.spec.ts         # Mount in host app container
-│   ├── multiple-instances.spec.ts # Two renderers on same page
-│   ├── no-backend.spec.ts         # Verify no external API calls
-│   └── bundle-size.spec.ts        # Bundle size regression check
+│   └── dashboard-filter.spec.ts   # Dashboard-level filter browser proof
+├── visual/
+│   └── chart-header-layout.spec.ts # Focused visual regression proof
 └── workflows/
+    ├── alerts-widget.spec.ts
+    ├── backend-probe.spec.ts
+    ├── designer-chart-matrix.spec.ts
+    ├── designer-page-management.spec.ts
     ├── designer-to-renderer.spec.ts
+    ├── filter-cascade.spec.ts
+    ├── host-integration.spec.ts
+    ├── host-workbench.spec.ts
     ├── import-export-cycle.spec.ts
     ├── metadata-to-dashboard.spec.ts
-    ├── filter-cascade.spec.ts
-    └── host-integration.spec.ts
+    ├── markdown-widget.spec.ts
+    ├── persistence-regression.spec.ts
+    └── probe-metadata-paste.spec.ts
 ```
+
+Historical task-to-test tables below keep the original phase wording, but when an older row mentions `e2e/renderer/`, `e2e/designer/`, or `e2e/integration/`, map that work onto the current suites above rather than recreating those retired directories.
 
 ---
 


### PR DESCRIPTION
## Summary
- add explicit batching rules for trivial same-class cleanup work
- align the live testing verification doc with the current e2e topology
- mark the older Playwright scaffold doc as historical and record the batch in cleanup history

## Validation
- corepack pnpm install --frozen-lockfile
- corepack pnpm -r build
- corepack pnpm -r lint
- corepack pnpm -r typecheck
- corepack pnpm -r test
- verified every newly referenced e2e path exists in the current repo tree