### PR TITLE
test: deepen backend probe browser coverage

### DIFF
--- a/docs/testing/history/2026-05-10-qa-nextjs-workbench-post-merge.md
+++ b/docs/testing/history/2026-05-10-qa-nextjs-workbench-post-merge.md
@@ -1,0 +1,76 @@
+# QA Round 4 — Post-Merge Host And Dev App Workflow Hardening
+
+**Date**: 2026-05-10  
+**Role**: Testing / browser-led workflow QA  
+**Trigger**: Continued post-merge release-surface testing after the workbench sync fixes landed and the cleanup/history skill updates were merged  
+**Worktrees**:
+
+- `issue/qa-config-only-hosts` synced to `38ad046`
+- `issue/qa-pages-filters-nav` synced to `0549db2`
+
+## Scope
+
+Extended real-workflow verification across the host-owned example surfaces and the dev-app authoring/runtime workflows after fast-forwarding the active QA branches to current `develop`.
+
+## Host Workflow Coverage
+
+- `e2e/workflows/host-integration.spec.ts` — `3 passed`
+- `e2e/workflows/host-workbench.spec.ts` — `10 passed`
+
+Verified behaviors:
+
+- config-only host integration remains green on the synced baseline
+- Next.js workbench login, persistence, publish/reload, and cross-tab sync flows remain green on the synced baseline
+
+## Dev App Workflow Coverage
+
+- `e2e/workflows/filter-cascade.spec.ts` — `8 passed`
+- `e2e/workflows/designer-page-management.spec.ts` — `5 passed`
+- `e2e/workflows/persistence-regression.spec.ts` — `2 passed`
+- `e2e/workflows/designer-to-renderer.spec.ts` — `9 passed`
+- `e2e/workflows/import-export-cycle.spec.ts` — `5 passed`
+- `e2e/workflows/probe-metadata-paste.spec.ts` — `1 passed`
+- `e2e/workflows/metadata-to-dashboard.spec.ts` — `3 passed`
+- `e2e/workflows/backend-probe.spec.ts` — `8 passed`
+- `e2e/workflows/alerts-widget.spec.ts` — `2 passed`
+- `e2e/workflows/markdown-widget.spec.ts` — `1 passed`
+- `e2e/workflows/designer-chart-matrix.spec.ts` — `33 passed`
+- `e2e/interactions/dashboard-filter.spec.ts` — `9 passed`
+- `e2e/visual/chart-header-layout.spec.ts` — `1 passed`
+- `e2e/smoke.spec.ts` — `1 passed`
+- `e2e/plan-a-designer-happy-path.spec.ts` — `7 passed`
+
+Verified behaviors:
+
+- shared filters and page navigation remain correct in the workbook demo
+- page add/rename/delete flows remain correct in the designer
+- import/export, persistence, and designer-to-viewer round-trips remain stable
+- probe metadata onboarding, bearer/custom/login auth flows, basic probe error handling, CORS-style fetch failure handling, direct terminal endpoint compatibility, and preview-query execution remain green
+- alerts, markdown, and chart-control/runtime-event workflows remain green
+- placed filter-bar widgets, filter state sharing, and live filter-driven KPI/table changes remain green
+- chart-header visual layout regression remains stable against the screenshot baseline
+- the smoke surface and the automated designer happy-path browser plan both remain green on the synced baseline
+
+## False Alarms Resolved During The Pass
+
+Two failures reproduced immediately after fast-forwarding the QA worktrees to `develop`, but both were stale-build issues rather than fresh product regressions:
+
+1. `host-workbench.spec.ts` initially failed on title/publish persistence expectations because the Next.js example was still consuming stale `@supersubset/designer` build output.
+2. `filter-cascade.spec.ts` initially failed on chart-click page navigation because the dev app was still consuming stale `@supersubset/runtime` / `@supersubset/charts-echarts` build output.
+
+Recovery that restored the expected behavior:
+
+- rebuild the affected workspace packages before trusting browser results after a fast-forward
+- restart the consuming dev server after rebuilds
+- clear `examples/nextjs-ecommerce/.next` before restarting the Next.js example when workbench behavior stays stale
+
+## Durable QA Notes
+
+- Freshly synced worktrees can look regressed until consumed workspace packages are rebuilt from `dist/*`.
+- For host testing, the quickest discriminator is often: rebuild the owning package, restart the example, rerun the narrowest previously failing workflow.
+- Generated `examples/nextjs-ecommerce/next-env.d.ts` noise still appears during Next.js runs and should not be treated as a product change.
+
+## Remaining Gaps
+
+- The main remaining browser gap is deeper probe/live-backend variation against an actual backend surface, especially real cross-origin behavior and contract drift outside the current mocked endpoints.
+- Capture a later dated history entry if this turns into another distinct multi-round QA campaign rather than a continuation of the current post-merge sweep.

--- a/docs/testing/history/README.md
+++ b/docs/testing/history/README.md
@@ -4,10 +4,10 @@ QA audit logs ordered by date. Each file records what was tested, bugs found, bu
 
 Naming convention: dated history entries use `YYYY-MM-DD-slug.md` so directory order matches chronology.
 
-| File                                                                                         | Date       | Scope                                                                                    |
-| -------------------------------------------------------------------------------------------- | ---------- | ---------------------------------------------------------------------------------------- |
-| [2026-04-11-qa-pre-audit.md](2026-04-11-qa-pre-audit.md)                                     | 2026-04-11 | Initial 31-bug sweep across all packages                                                 |
-| [2026-04-16-qa-round-1.md](2026-04-16-qa-round-1.md)                                         | 2026-04-16 | Chart rendering, example apps, QA skill creation                                         |
-| [2026-04-16-qa-round-2.md](2026-04-16-qa-round-2.md)                                         | 2026-04-16 | Lint, a11y, undo/redo, edge cases, performance                                           |
-| [2026-05-02-qa-round-3-market-readiness.md](2026-05-02-qa-round-3-market-readiness.md)       | 2026-05-02 | Market-readiness campaign plan, blocker hunt, and parallel PR dispatch model             |
-| [2026-05-10-qa-nextjs-workbench-post-merge.md](2026-05-10-qa-nextjs-workbench-post-merge.md) | 2026-05-10 | Post-merge Next.js real-host workbench QA, cross-tab sync fixes, and validation evidence |
+| File                                                                                         | Date       | Scope                                                                                                                              |
+| -------------------------------------------------------------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| [2026-04-11-qa-pre-audit.md](2026-04-11-qa-pre-audit.md)                                     | 2026-04-11 | Initial 31-bug sweep across all packages                                                                                           |
+| [2026-04-16-qa-round-1.md](2026-04-16-qa-round-1.md)                                         | 2026-04-16 | Chart rendering, example apps, QA skill creation                                                                                   |
+| [2026-04-16-qa-round-2.md](2026-04-16-qa-round-2.md)                                         | 2026-04-16 | Lint, a11y, undo/redo, edge cases, performance                                                                                     |
+| [2026-05-02-qa-round-3-market-readiness.md](2026-05-02-qa-round-3-market-readiness.md)       | 2026-05-02 | Market-readiness campaign plan, blocker hunt, and parallel PR dispatch model                                                       |
+| [2026-05-10-qa-nextjs-workbench-post-merge.md](2026-05-10-qa-nextjs-workbench-post-merge.md) | 2026-05-10 | Post-merge host and dev-app workflow QA, synced-baseline validation, stale-build recovery notes, and deeper backend-probe coverage |

--- a/e2e/workflows/backend-probe.spec.ts
+++ b/e2e/workflows/backend-probe.spec.ts
@@ -28,6 +28,73 @@ const DISCOVERY_FIXTURE = {
   ],
 };
 
+function buildProbePreviewDashboard() {
+  return JSON.stringify(
+    {
+      schemaVersion: '0.2.0',
+      id: 'probe-preview-dashboard',
+      title: 'Probe Preview Dashboard',
+      pages: [
+        {
+          id: 'page-1',
+          title: 'Page 1',
+          rootNodeId: 'root',
+          layout: {
+            root: { id: 'root', type: 'root', children: ['grid-main'], meta: {} },
+            'grid-main': {
+              id: 'grid-main',
+              type: 'grid',
+              children: ['probe-bar-host'],
+              parentId: 'root',
+              meta: { columns: 12 },
+            },
+            'probe-bar-host': {
+              id: 'probe-bar-host',
+              type: 'widget',
+              children: [],
+              parentId: 'grid-main',
+              meta: { widgetRef: 'probe-bar', width: 12, height: 320 },
+            },
+          },
+          widgets: [
+            {
+              id: 'probe-bar',
+              type: 'bar-chart',
+              title: 'Probe Revenue by Region',
+              dataBinding: {
+                datasetRef: 'orders',
+                fields: [
+                  { role: 'x-axis', fieldRef: 'region' },
+                  { role: 'y-axis', fieldRef: 'revenue' },
+                ],
+              },
+              config: { horizontal: true },
+            },
+          ],
+        },
+      ],
+      defaults: { activePage: 'page-1' },
+    },
+    null,
+    2,
+  );
+}
+
+const RAW_DISCOVERY_FIXTURE = [
+  {
+    id: 'orders',
+    fields: [
+      { id: 'region', dataType: 'string' },
+      { id: 'revenue', dataType: 'number' },
+    ],
+  },
+];
+
+async function openProbe(page: import('@playwright/test').Page) {
+  await page.goto('/');
+  await page.getByTestId('mode-probe').click();
+}
+
 test.describe('Backend probe live discovery', () => {
   test('loads the designer from a live discovery URL with bearer auth', async ({ page }) => {
     let authorizationHeader = '';
@@ -41,10 +108,9 @@ test.describe('Backend probe live discovery', () => {
       });
     });
 
-    await page.goto('/');
+    await openProbe(page);
     const origin = new URL(page.url()).origin;
 
-    await page.getByTestId('mode-probe').click();
     await page.getByTestId('probe-url-input').fill(`${origin}/probe-mock-api`);
     await page.getByTestId('probe-auth-mode').selectOption('bearer');
     await page.getByTestId('probe-jwt-input').fill('dev-probe-token');
@@ -65,5 +131,282 @@ test.describe('Backend probe live discovery', () => {
     const download = await downloadPromise;
 
     expect(download.suggestedFilename()).toBe('backend-probe-dashboard.json');
+  });
+
+  test('loads the designer from a live discovery URL with a custom auth header', async ({
+    page,
+  }) => {
+    let headerName = '';
+    let headerValue = '';
+
+    await page.route('**/probe-mock-api-custom/supersubset/datasets', async (route) => {
+      headerName =
+        Object.keys(route.request().headers()).find((key) => key.toLowerCase() === 'x-probe-key') ??
+        '';
+      headerValue = route.request().headers()['x-probe-key'] ?? '';
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(DISCOVERY_FIXTURE),
+      });
+    });
+
+    await openProbe(page);
+    const origin = new URL(page.url()).origin;
+
+    await page.getByTestId('probe-url-input').fill(`${origin}/probe-mock-api-custom`);
+    await page.getByTestId('probe-auth-mode').selectOption('custom');
+    await page.getByTestId('probe-header-name').fill('X-Probe-Key');
+    await page.getByTestId('probe-header-value').fill('alpha-dev-key');
+    await page.getByTestId('probe-connect-button').click();
+
+    await expect(page.getByTestId('probe-metadata-source-summary')).toContainText(
+      `${origin}/probe-mock-api-custom`,
+    );
+    await expect(page.getByTestId('probe-dataset-count')).toHaveText('1 dataset(s) discovered');
+    await expect(page.getByText('Supersubset Probe Designer')).toBeVisible();
+
+    expect(headerName).toBe('x-probe-key');
+    expect(headerValue).toBe('alpha-dev-key');
+  });
+
+  test('logs in with email and password, then reuses the returned token for discovery', async ({
+    page,
+  }) => {
+    let loginBody: Record<string, unknown> | null = null;
+    let authorizationHeader = '';
+
+    await page.route('**/probe-login-api/graphql', async (route) => {
+      loginBody = JSON.parse(route.request().postData() ?? '{}') as Record<string, unknown>;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            login: {
+              accessToken: 'probe-login-token-12345',
+            },
+          },
+        }),
+      });
+    });
+
+    await page.route('**/probe-login-api/supersubset/datasets', async (route) => {
+      authorizationHeader = route.request().headers()['authorization'] ?? '';
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(DISCOVERY_FIXTURE),
+      });
+    });
+
+    await openProbe(page);
+    const origin = new URL(page.url()).origin;
+
+    await page.getByTestId('probe-url-input').fill(`${origin}/probe-login-api`);
+    await page.getByTestId('probe-auth-mode').selectOption('login');
+    await page.getByTestId('probe-login-url').fill(`${origin}/probe-login-api/graphql`);
+    await page.getByTestId('probe-login-email').fill('dev@example.com');
+    await page.getByTestId('probe-login-password').fill('dev-password');
+    await page.getByTestId('probe-connect-button').click();
+
+    await expect(page.getByTestId('probe-dataset-count')).toHaveText('1 dataset(s) discovered');
+    await expect(page.getByText('Supersubset Probe Designer')).toBeVisible();
+
+    expect(loginBody).toMatchObject({
+      query: expect.stringContaining('mutation login'),
+      variables: {
+        email: 'dev@example.com',
+        password: 'dev-password',
+      },
+    });
+    expect(authorizationHeader).toBe('Bearer probe-login-token-12345');
+  });
+
+  test('stays on the probe form and shows an error when login fails', async ({ page }) => {
+    await page.route('**/probe-login-api-fail/graphql', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          errors: [{ message: 'Invalid credentials' }],
+        }),
+      });
+    });
+
+    await openProbe(page);
+    const origin = new URL(page.url()).origin;
+
+    await page.getByTestId('probe-url-input').fill(`${origin}/probe-login-api-fail`);
+    await page.getByTestId('probe-auth-mode').selectOption('login');
+    await page.getByTestId('probe-login-url').fill(`${origin}/probe-login-api-fail/graphql`);
+    await page.getByTestId('probe-login-email').fill('dev@example.com');
+    await page.getByTestId('probe-login-password').fill('wrong-password');
+    await page.getByTestId('probe-connect-button').click();
+
+    await expect(page.getByTestId('probe-error')).toContainText(
+      'Login failed: Invalid credentials',
+    );
+    await expect(page.getByText('Supersubset Probe Designer')).toHaveCount(0);
+    await expect(page.getByTestId('probe-connect-button')).toBeVisible();
+  });
+
+  test('shows an error when discovery succeeds but returns no datasets', async ({ page }) => {
+    await page.route('**/probe-empty-api/supersubset/datasets', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ datasets: [] }),
+      });
+    });
+
+    await openProbe(page);
+    const origin = new URL(page.url()).origin;
+
+    await page.getByTestId('probe-url-input').fill(`${origin}/probe-empty-api`);
+    await page.getByTestId('probe-connect-button').click();
+
+    await expect(page.getByTestId('probe-error')).toContainText(
+      'Metadata loaded successfully, but no datasets were discovered.',
+    );
+    await expect(page.getByText('Supersubset Probe Designer')).toHaveCount(0);
+    await expect(page.getByTestId('probe-connect-button')).toBeVisible();
+  });
+
+  test('shows the CORS-style connection message when metadata discovery cannot be fetched', async ({
+    page,
+  }) => {
+    await page.route('**/probe-network-fail/supersubset/datasets', async (route) => {
+      await route.abort('failed');
+    });
+
+    await openProbe(page);
+    const origin = new URL(page.url()).origin;
+
+    await page.getByTestId('probe-url-input').fill(`${origin}/probe-network-fail`);
+    await page.getByTestId('probe-connect-button').click();
+
+    await expect(page.getByTestId('probe-error')).toContainText(
+      'Connection failed. Check the backend URL and CORS policy, then try again.',
+    );
+    await expect(page.getByTestId('probe-connect-stage-metadata')).toHaveAttribute(
+      'data-status',
+      'error',
+    );
+    await expect(page.getByText('Supersubset Probe Designer')).toHaveCount(0);
+  });
+
+  test('accepts raw dataset arrays from direct /datasets and /query endpoints', async ({
+    page,
+  }) => {
+    const importedDashboard = buildProbePreviewDashboard();
+    let previewRequestBody: Record<string, unknown> | null = null;
+
+    await page.route('**/probe-direct-api/datasets', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(RAW_DISCOVERY_FIXTURE),
+      });
+    });
+
+    await page.route('**/probe-direct-api/query', async (route) => {
+      previewRequestBody = JSON.parse(route.request().postData() ?? '{}') as Record<
+        string,
+        unknown
+      >;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          columns: [
+            { fieldId: 'region', label: 'Region', dataType: 'string' },
+            { fieldId: 'revenue', label: 'Revenue', dataType: 'number' },
+          ],
+          rows: [{ region: 'West', revenue: 125000 }],
+        }),
+      });
+    });
+
+    await openProbe(page);
+    const origin = new URL(page.url()).origin;
+
+    await page.getByTestId('probe-url-input').fill(`${origin}/probe-direct-api/datasets`);
+    await page.getByTestId('probe-query-url-input').fill(`${origin}/probe-direct-api/query`);
+    await page.getByTestId('probe-connect-button').click();
+
+    await expect(page.getByTestId('probe-dataset-count')).toHaveText('1 dataset(s) discovered');
+    await expect(page.getByText('Supersubset Probe Designer')).toBeVisible();
+    await expect(page.getByTestId('probe-preview-status')).toContainText(
+      `${origin}/probe-direct-api/query`,
+    );
+
+    await page.getByTestId('import-btn').click();
+    await expect(page.getByTestId('import-export-dialog')).toBeVisible();
+    await page.getByTestId('import-textarea').fill(importedDashboard);
+    await page.getByTestId('import-submit-btn').click();
+
+    await expect(page.getByTestId('probe-preview-query-status')).toContainText('Live data');
+    await expect(page.getByTestId('probe-preview-query-status')).toContainText('1 row');
+
+    expect(previewRequestBody).toMatchObject({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'region' }, { fieldId: 'revenue' }],
+    });
+  });
+
+  test('executes preview queries after connecting with pasted metadata and an explicit query URL', async ({
+    page,
+  }) => {
+    const importedDashboard = buildProbePreviewDashboard();
+    let previewRequestBody: Record<string, unknown> | null = null;
+
+    await page.route('**/probe-preview-api/supersubset/query', async (route) => {
+      previewRequestBody = JSON.parse(route.request().postData() ?? '{}') as Record<
+        string,
+        unknown
+      >;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          columns: [
+            { fieldId: 'region', label: 'Region', dataType: 'string' },
+            { fieldId: 'revenue', label: 'Revenue', dataType: 'number' },
+          ],
+          rows: [
+            { region: 'West', revenue: 125000 },
+            { region: 'East', revenue: 118000 },
+          ],
+        }),
+      });
+    });
+
+    await openProbe(page);
+    const origin = new URL(page.url()).origin;
+
+    await page.getByTestId('probe-metadata-mode').selectOption('paste-json');
+    await page.getByTestId('probe-metadata-json-input').fill(JSON.stringify(DISCOVERY_FIXTURE));
+    await page.getByTestId('probe-query-url-input').fill(`${origin}/probe-preview-api`);
+    await page.getByTestId('probe-connect-button').click();
+
+    await expect(page.getByText('Supersubset Probe Designer')).toBeVisible();
+    await expect(page.getByTestId('probe-preview-status')).toContainText(
+      `${origin}/probe-preview-api`,
+    );
+
+    await page.getByTestId('import-btn').click();
+    await expect(page.getByTestId('import-export-dialog')).toBeVisible();
+    await page.getByTestId('import-textarea').fill(importedDashboard);
+    await page.getByTestId('import-submit-btn').click();
+
+    await expect(page.getByTestId('probe-preview-query-status')).toContainText('Live data');
+    await expect(page.getByTestId('probe-preview-query-status')).toContainText('2 rows');
+    await expect(page.getByTestId('probe-preview-query-status')).toContainText('orders');
+
+    expect(previewRequestBody).toMatchObject({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'region' }, { fieldId: 'revenue' }],
+    });
   });
 });


### PR DESCRIPTION
## Summary
- extend backend probe browser coverage across auth, error, and preview-query paths
- add browser regressions for CORS-style fetch failure and direct /datasets and /query endpoint compatibility
- refresh durable QA history for the expanded probe pass

## Validation
- PLAYWRIGHT_HTML_OPEN=never SUPERSUBSET_DEV_APP_PORT=3110 corepack pnpm exec playwright test -c playwright.e2e.config.ts e2e/workflows/backend-probe.spec.ts --project=chromium --reporter=line
- 8 passed (5.1s)
