### PR TITLE
docs: clarify release recovery guidance

### DIFF
--- a/.github/skills/publish-npm-release/SKILL.md
+++ b/.github/skills/publish-npm-release/SKILL.md
@@ -39,18 +39,26 @@ Commit and push the new `.changeset/*.md` (and any config edits) to `main`.
 
 ## Preconditions (CI / org)
 
-- Repo secret **`NPM_TOKEN`**: npm token with publish access to **`@supersubset`** (granular token: scope + read/write + bypass 2FA for automation if required).
+- Repo secret **`NPM_TOKEN`**: npm automation token that can publish the existing **`@supersubset/*`** packages. For granular tokens, this means **package write** on the published packages and **`bypass_2fa: true`** for automation. `npm whoami` alone is not enough to prove this.
 - **Org → Actions → Workflow permissions:** allow **read/write** and **“Allow GitHub Actions to create and approve pull requests”** so `changesets/action` can open the version PR. If repo UI is grayed out, an **org owner** must relax the org default.
+
+## Token preflight (recommended before updating GitHub secret)
+
+- `npm whoami` proves the token authenticates, but not that it can publish.
+- `npm owner ls @supersubset/runtime` confirms the account still has owner access on an existing package.
+- `npm token list --json` should show the candidate automation token with publish-capable scope and **`"bypass_2fa": true`**. A token can pass `whoami` and still fail publish if either package-write or bypass-2FA is missing.
 
 ## When Release fails
 
-| Symptom                                            | Fix                                                                        |
-| -------------------------------------------------- | -------------------------------------------------------------------------- |
-| “not permitted to create or approve pull requests” | Org/repo workflow permissions (above). Re-run failed **Release** job.      |
-| `403` / `ENEEDAUTH` on publish                     | `NPM_TOKEN` missing, expired, wrong scope, or npm 2FA blocking automation. |
-| Duplicate version                                  | Version already on registry; add a new changeset with a higher bump.       |
+| Symptom                                                                               | Fix                                                                                                                                                                                          |
+| ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| “not permitted to create or approve pull requests”                                    | Org/repo workflow permissions (above). Re-run failed **Release** job.                                                                                                                        |
+| `E404` on `PUT https://registry.npmjs.org/@supersubset%2f...` for an existing package | Granular token is authenticated but does not actually have **package write** for that package/scope. Replace `NPM_TOKEN` with a package-write token, then re-run the failed **Release** job. |
+| `E403` saying bypass 2FA is required                                                  | Token has enough auth to reach npm, but **`bypass_2fa` is false**. Create a new automation token with bypass 2FA enabled, update `NPM_TOKEN`, then re-run the failed **Release** job.        |
+| `403` / `ENEEDAUTH` on publish without the bypass message                             | `NPM_TOKEN` is missing, expired, or otherwise not usable for npm publish.                                                                                                                    |
+| Duplicate version                                                                     | Version already on registry; add a new changeset with a higher bump.                                                                                                                         |
 
-Inspect: **Actions → Release → failed run → logs**. Locally: `pnpm -r publish --dry-run --no-git-checks` (from repo root) to validate tarballs without publishing.
+Inspect: **Actions → Release → failed run → logs**. After fixing npm auth, re-run the same failed **Release** workflow for the existing `main` commit; do **not** add another changeset just to retry the same release. Locally: `pnpm -r publish --dry-run --no-git-checks` (from repo root) to validate tarballs without publishing.
 
 ## Branch protection
 
@@ -59,9 +67,11 @@ Keep **`main` protected**. Land the **changeset commit** via **PR into `main`** 
 ## Verify publish
 
 ```bash
-npm view @supersubset/schema version
-npm view @supersubset/cli version
+npm view @supersubset/schema version dist-tags --json
+npm view @supersubset/cli version dist-tags --json
 ```
+
+Prefer `npm view` over relying on the npm website alone; the web UI can lag slightly after a successful publish.
 
 ## Anti-patterns
 

--- a/.github/skills/release-runbook/SKILL.md
+++ b/.github/skills/release-runbook/SKILL.md
@@ -113,6 +113,16 @@ If local Playwright `webServer` startup is flaky, start the servers manually and
 pnpm exec playwright test --config=playwright.e2e.config.ts
 ```
 
+If you are validating against leased DevEnv ports locally, export all three host ports before running the host-backed E2E suite:
+
+```bash
+export SUPERSUBSET_DEV_APP_PORT=<dev-app-port>
+export SUPERSUBSET_EXAMPLE_NEXTJS_PORT=<nextjs-port>
+export SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT=<vite-port>
+```
+
+Without the explicit example-host vars, workbench/probe specs can silently fall back to `3001` / `3002` even when leased ports are active.
+
 Optional but recommended for release confidence:
 
 ```bash
@@ -197,13 +207,25 @@ Expected behavior:
 
 If no version-packages PR appears, verify again that the merged branch actually contained a pending `.changeset`.
 
+If the second pass fails because of npm token/auth issues, fix the secret and re-run the failed `release.yml` run for the same `main` commit. Do not create another changeset or another version PR just to retry the same publish.
+
 ## Step 9: Verify published artifacts
 
 After publish:
 
 - check the release workflow conclusion in GitHub Actions
-- confirm the expected package versions exist in npm
+- confirm the expected package versions exist in npm via `npm view`, not only the npm website or PR checks
 - note the published version that downstream consumers should adopt
+
+Recommended checks:
+
+```bash
+npm view @supersubset/runtime version
+npm view @supersubset/schema version
+npm view @supersubset/charts-echarts version
+```
+
+Treat the registry CLI result as the source of truth. The npm website can lag briefly after publish.
 
 Do not open downstream upgrade PRs against hypothetical versions that have not been published yet.
 
@@ -227,10 +249,16 @@ Prefer published versions. If pre-publish validation is required, use tarballs o
   - switch to manually started servers and `playwright.e2e.config.ts`
 - No pending `.changeset`:
   - stop the publish path and add a release note on `develop`
+- Publish returns `E404` on `PUT https://registry.npmjs.org/@supersubset%2f...` for existing packages:
+  - suspect a granular token that authenticates but is missing package-write access; `npm whoami` is insufficient proof
+- Publish returns `E403` requiring bypass 2FA:
+  - create a new automation token with `bypass_2fa` enabled, update the GitHub secret, then rerun the failed release job
 - Browser-auth-gated downstream app:
   - verify as much as possible locally, then call out the blocked surface explicitly
 - GitHub API or tool restrictions:
   - fall back to `gh` CLI rather than abandoning issue or PR automation
+- `gh run watch` is unreliable in a given terminal:
+  - poll the run via `gh api repos/<owner>/<repo>/actions/runs/<id>` for attempt/status/conclusion, then confirm registry state with `npm view`
 
 ## Current default path for the repo
 


### PR DESCRIPTION
## Summary
- document the npm token failure modes observed during the 0.1.4 publish recovery
- add token preflight guidance and explicit retry instructions for failed release runs
- capture leased-port Playwright env requirements and safer release verification steps

## Validation
- get_errors on .github/skills/publish-npm-release/SKILL.md
- get_errors on .github/skills/release-runbook/SKILL.md
- git diff --check -- .github/skills/publish-npm-release/SKILL.md .github/skills/release-runbook/SKILL.md
