### PR TITLE
Improve date-aware dashboard filters

### DIFF
--- a/features/filters-and-interactions.feature.yaml
+++ b/features/filters-and-interactions.feature.yaml
@@ -22,6 +22,15 @@ components:
         requirement: Filter controls support the standard operator set advertised
           by the host query *adapter* or *probe* capabilities and reject unsupported
           operators during validation.
+      4:
+        requirement: Date and datetime *filter* controls are authored as
+          date-aware controls, including range, relative preset, and weekly
+          period options, rather than generic value dropdowns.
+      5:
+        requirement: Weekly date *filter* controls generate viewer options from
+          authored boundary weekday, lookback window, and lookahead window
+          settings and compile selected periods into concrete *logical query*
+          date ranges.
   CROSS_WIDGET_FILTERS:
     name: Cross-Widget Filters
     description: Propagation of filter state across widgets on a page.

--- a/packages/designer/src/components/FilterBuilderPanel.tsx
+++ b/packages/designer/src/components/FilterBuilderPanel.tsx
@@ -12,6 +12,7 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { NormalizedDataset } from '@supersubset/data-model';
 import type {
+  DateFilterConfig,
   FilterDefinition,
   FilterOptionDefinition,
   FilterOptionSource,
@@ -78,6 +79,22 @@ const SELECT_FILTER_CONTROL_TYPES = new Set<SupportedFilterControlType>(['select
 type StaticFilterOptionSource = Extract<FilterOptionSource, { kind: 'static' }>;
 type FieldFilterOptionSource = Extract<FilterOptionSource, { kind: 'field' }>;
 
+const WEEKDAY_OPTIONS = [
+  { value: 0, label: 'Sunday' },
+  { value: 1, label: 'Monday' },
+  { value: 2, label: 'Tuesday' },
+  { value: 3, label: 'Wednesday' },
+  { value: 4, label: 'Thursday' },
+  { value: 5, label: 'Friday' },
+  { value: 6, label: 'Saturday' },
+] as const;
+
+const DATE_FILTER_MODE_OPTIONS = [
+  { value: 'preset', label: 'Preset or custom range' },
+  { value: 'range', label: 'Custom date range' },
+  { value: 'weekly', label: 'Weekly range dropdown' },
+] as const;
+
 function isSelectFilterControlType(type: string): type is 'select' | 'multi-select' {
   return SELECT_FILTER_CONTROL_TYPES.has(type as SupportedFilterControlType);
 }
@@ -114,6 +131,17 @@ function createFieldOptionSource(): FieldFilterOptionSource {
   };
 }
 
+function createDefaultDateConfig(mode: DateFilterConfig['mode'] = 'preset'): DateFilterConfig {
+  return {
+    mode,
+    allowCustomRange: mode !== 'weekly',
+    weekStartsOn: 0,
+    weeksBack: 4,
+    weeksForward: 0,
+    includeCurrentWeek: true,
+  };
+}
+
 function coercePositiveInteger(value: string): number | undefined {
   if (value.trim().length === 0) {
     return undefined;
@@ -125,6 +153,40 @@ function coercePositiveInteger(value: string): number | undefined {
   }
 
   return parsed;
+}
+
+function coerceNonNegativeInteger(value: string): number | undefined {
+  if (value.trim().length === 0) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function isDateDataType(dataType: string | undefined): boolean {
+  return dataType === 'date' || dataType === 'datetime';
+}
+
+function asDateDefaultValue(value: unknown): { preset?: string; start?: string; end?: string } {
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    const candidate = value as { preset?: unknown; start?: unknown; end?: unknown };
+    return {
+      preset: typeof candidate.preset === 'string' ? candidate.preset : undefined,
+      start: typeof candidate.start === 'string' ? candidate.start : undefined,
+      end: typeof candidate.end === 'string' ? candidate.end : undefined,
+    };
+  }
+
+  if (typeof value === 'string' && value.length > 0) {
+    return { start: value };
+  }
+
+  return {};
 }
 
 function normalizeFilterControlType(type: string): SupportedFilterControlType {
@@ -219,10 +281,20 @@ function FilterEditor({
     const dt = field?.dataType ?? 'string';
     return FILTER_OPERATORS.filter((op) => op.types.includes(dt));
   }, [field]);
+  const isDateField = isDateDataType(field?.dataType);
   const normalizedFilterType = useMemo(
     () => normalizeFilterControlType(filter.type),
     [filter.type],
   );
+  const availableControlOptions = useMemo(
+    () =>
+      isDateField
+        ? FILTER_CONTROL_OPTIONS.filter((option) => option.value === 'date')
+        : FILTER_CONTROL_OPTIONS,
+    [isDateField],
+  );
+  const dateConfig = filter.dateConfig ?? createDefaultDateConfig();
+  const defaultDateValue = asDateDefaultValue(filter.defaultValue);
 
   const handleChange = useCallback(
     (patch: Partial<FilterDefinition>) => {
@@ -290,10 +362,39 @@ function FilterEditor({
       if (nextType === 'multi-select' && !['in', 'not_in'].includes(filter.operator)) {
         nextPatch.operator = 'in';
       }
+      if (nextType === 'date') {
+        nextPatch.operator = 'between';
+        nextPatch.optionSource = undefined;
+        nextPatch.dateConfig = filter.dateConfig ?? createDefaultDateConfig();
+      }
 
       handleChange(nextPatch);
     },
-    [filter.operator, handleChange],
+    [filter.dateConfig, filter.operator, handleChange],
+  );
+
+  useEffect(() => {
+    if (isDateField && normalizedFilterType !== 'date') {
+      handleChange({
+        type: 'date',
+        operator: 'between',
+        optionSource: undefined,
+        dateConfig: filter.dateConfig ?? createDefaultDateConfig(),
+      });
+    }
+  }, [filter.dateConfig, handleChange, isDateField, normalizedFilterType]);
+
+  const handleDateConfigChange = useCallback(
+    (patch: Partial<DateFilterConfig>) => {
+      handleChange({
+        dateConfig: {
+          ...createDefaultDateConfig(),
+          ...(filter.dateConfig ?? {}),
+          ...patch,
+        },
+      });
+    },
+    [filter.dateConfig, handleChange],
   );
 
   const handleOptionSourceKindChange = useCallback(
@@ -424,7 +525,22 @@ function FilterEditor({
             id={fieldSelectId}
             name={`filter-field-${filter.id}`}
             value={filter.fieldRef}
-            onChange={(e) => handleChange({ fieldRef: e.target.value })}
+            onChange={(e) => {
+              const nextFieldRef = e.target.value;
+              const nextField = dataset?.fields.find((f) => f.id === nextFieldRef);
+              const nextIsDateField = isDateDataType(nextField?.dataType);
+              handleChange({
+                fieldRef: nextFieldRef,
+                ...(nextIsDateField
+                  ? {
+                      type: 'date',
+                      operator: 'between',
+                      optionSource: undefined,
+                      dateConfig: filter.dateConfig ?? createDefaultDateConfig(),
+                    }
+                  : {}),
+              });
+            }}
             data-testid={`filter-field-${filter.id}`}
             style={selectStyle}
             disabled={!dataset}
@@ -464,20 +580,64 @@ function FilterEditor({
           <label htmlFor={defaultInputId} style={labelStyle}>
             Default value
           </label>
-          <input
-            id={defaultInputId}
-            name={`filter-default-${filter.id}`}
-            type="text"
-            value={filter.defaultValue != null ? String(filter.defaultValue) : ''}
-            onChange={(e) =>
-              handleChange({
-                defaultValue: e.target.value || undefined,
-              })
-            }
-            placeholder="Optional default..."
-            data-testid={`filter-default-${filter.id}`}
-            style={selectStyle}
-          />
+          {normalizedFilterType === 'date' ? (
+            <div style={{ display: 'flex', gap: 6 }}>
+              <input
+                id={defaultInputId}
+                name={`filter-default-start-${filter.id}`}
+                aria-label="Default start date"
+                type="date"
+                value={defaultDateValue.start ?? ''}
+                onChange={(e) => {
+                  const nextStart = e.target.value || undefined;
+                  const nextValue = {
+                    ...defaultDateValue,
+                    start: nextStart,
+                  };
+                  handleChange({
+                    defaultValue:
+                      nextValue.start || nextValue.end || nextValue.preset ? nextValue : undefined,
+                  });
+                }}
+                data-testid={`filter-default-start-${filter.id}`}
+                style={selectStyle}
+              />
+              <input
+                name={`filter-default-end-${filter.id}`}
+                aria-label="Default end date"
+                type="date"
+                value={defaultDateValue.end ?? ''}
+                onChange={(e) => {
+                  const nextEnd = e.target.value || undefined;
+                  const nextValue = {
+                    ...defaultDateValue,
+                    end: nextEnd,
+                  };
+                  handleChange({
+                    defaultValue:
+                      nextValue.start || nextValue.end || nextValue.preset ? nextValue : undefined,
+                  });
+                }}
+                data-testid={`filter-default-end-${filter.id}`}
+                style={selectStyle}
+              />
+            </div>
+          ) : (
+            <input
+              id={defaultInputId}
+              name={`filter-default-${filter.id}`}
+              type="text"
+              value={filter.defaultValue != null ? String(filter.defaultValue) : ''}
+              onChange={(e) =>
+                handleChange({
+                  defaultValue: e.target.value || undefined,
+                })
+              }
+              placeholder="Optional default..."
+              data-testid={`filter-default-${filter.id}`}
+              style={selectStyle}
+            />
+          )}
         </div>
       </div>
 
@@ -494,7 +654,7 @@ function FilterEditor({
           data-testid={`filter-type-${filter.id}`}
           style={selectStyle}
         >
-          {FILTER_CONTROL_OPTIONS.map((option) => (
+          {availableControlOptions.map((option) => (
             <option key={option.value} value={option.value}>
               {option.label}
             </option>
@@ -502,7 +662,130 @@ function FilterEditor({
         </select>
       </div>
 
-      {isSelectFilterControlType(normalizedFilterType) && (
+      {normalizedFilterType === 'date' && (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+            padding: 10,
+            borderRadius: 6,
+            border: '1px solid #dbe4ee',
+            background: '#fff',
+          }}
+        >
+          <div style={{ display: 'flex', gap: 8 }}>
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+              <label htmlFor={`ss-filter-date-mode-${filter.id}`} style={labelStyle}>
+                Date mode
+              </label>
+              <select
+                id={`ss-filter-date-mode-${filter.id}`}
+                name={`filter-date-mode-${filter.id}`}
+                value={dateConfig.mode ?? 'preset'}
+                onChange={(e) =>
+                  handleDateConfigChange({
+                    mode: e.target.value as NonNullable<DateFilterConfig['mode']>,
+                    allowCustomRange: e.target.value !== 'weekly',
+                  })
+                }
+                data-testid={`filter-date-mode-${filter.id}`}
+                style={selectStyle}
+              >
+                {DATE_FILTER_MODE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <label
+              style={{
+                display: 'flex',
+                alignItems: 'flex-end',
+                gap: 6,
+                fontSize: 12,
+                color: '#475569',
+                paddingBottom: 5,
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={dateConfig.allowCustomRange !== false}
+                onChange={(e) => handleDateConfigChange({ allowCustomRange: e.target.checked })}
+                data-testid={`filter-date-allow-custom-${filter.id}`}
+              />
+              Allow custom
+            </label>
+          </div>
+
+          {(dateConfig.mode ?? 'preset') === 'weekly' && (
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8 }}>
+              <div style={{ display: 'flex', flexDirection: 'column' }}>
+                <label htmlFor={`ss-filter-week-start-${filter.id}`} style={labelStyle}>
+                  Week starts on
+                </label>
+                <select
+                  id={`ss-filter-week-start-${filter.id}`}
+                  name={`filter-week-start-${filter.id}`}
+                  value={dateConfig.weekStartsOn ?? 0}
+                  onChange={(e) =>
+                    handleDateConfigChange({
+                      weekStartsOn: Number(e.target.value) as DateFilterConfig['weekStartsOn'],
+                    })
+                  }
+                  data-testid={`filter-week-start-${filter.id}`}
+                  style={selectStyle}
+                >
+                  {WEEKDAY_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column' }}>
+                <label htmlFor={`ss-filter-weeks-back-${filter.id}`} style={labelStyle}>
+                  Weeks back
+                </label>
+                <input
+                  id={`ss-filter-weeks-back-${filter.id}`}
+                  name={`filter-weeks-back-${filter.id}`}
+                  type="number"
+                  min={0}
+                  value={dateConfig.weeksBack ?? 4}
+                  onChange={(e) =>
+                    handleDateConfigChange({ weeksBack: coerceNonNegativeInteger(e.target.value) })
+                  }
+                  data-testid={`filter-weeks-back-${filter.id}`}
+                  style={selectStyle}
+                />
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column' }}>
+                <label htmlFor={`ss-filter-weeks-forward-${filter.id}`} style={labelStyle}>
+                  Weeks forward
+                </label>
+                <input
+                  id={`ss-filter-weeks-forward-${filter.id}`}
+                  name={`filter-weeks-forward-${filter.id}`}
+                  type="number"
+                  min={0}
+                  value={dateConfig.weeksForward ?? 0}
+                  onChange={(e) =>
+                    handleDateConfigChange({
+                      weeksForward: coerceNonNegativeInteger(e.target.value),
+                    })
+                  }
+                  data-testid={`filter-weeks-forward-${filter.id}`}
+                  style={selectStyle}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {isSelectFilterControlType(normalizedFilterType) && !isDateField && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           <div style={{ display: 'flex', flexDirection: 'column' }}>
             <label htmlFor={optionSourceSelectId} style={labelStyle}>

--- a/packages/designer/src/components/FilterBuilderPanel.tsx
+++ b/packages/designer/src/components/FilterBuilderPanel.tsx
@@ -90,9 +90,26 @@ const WEEKDAY_OPTIONS = [
 ] as const;
 
 const DATE_FILTER_MODE_OPTIONS = [
-  { value: 'preset', label: 'Preset or custom range' },
+  { value: 'preset', label: 'Relative date menu' },
   { value: 'range', label: 'Custom date range' },
   { value: 'weekly', label: 'Weekly range dropdown' },
+] as const;
+
+const DATE_DEFAULT_OPTIONS = [
+  { value: '', label: 'No default' },
+  { value: 'today', label: 'Today' },
+  { value: 'yesterday', label: 'Yesterday' },
+  { value: 'last_7_days', label: 'Last 7 days' },
+  { value: 'last_30_days', label: 'Last 30 days' },
+  { value: 'this_week', label: 'Current week' },
+  { value: 'last_week', label: 'Previous week' },
+  { value: 'custom', label: 'Specific date range' },
+] as const;
+
+const WEEKLY_DATE_DEFAULT_OPTIONS = [
+  { value: '', label: 'No default' },
+  { value: 'this_week', label: 'Current week' },
+  { value: 'last_week', label: 'Previous week' },
 ] as const;
 
 function isSelectFilterControlType(type: string): type is 'select' | 'multi-select' {
@@ -187,6 +204,59 @@ function asDateDefaultValue(value: unknown): { preset?: string; start?: string; 
   }
 
   return {};
+}
+
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function addDays(date: Date, days: number): Date {
+  const nextDate = new Date(date);
+  nextDate.setDate(nextDate.getDate() + days);
+  return nextDate;
+}
+
+function clampWeekday(
+  value: DateFilterConfig['weekStartsOn'] | undefined,
+): 0 | 1 | 2 | 3 | 4 | 5 | 6 {
+  return value === 0 ||
+    value === 1 ||
+    value === 2 ||
+    value === 3 ||
+    value === 4 ||
+    value === 5 ||
+    value === 6
+    ? value
+    : 0;
+}
+
+function getWeekStart(date: Date, weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6): Date {
+  const localDate = startOfLocalDay(date);
+  const dayOffset = (localDate.getDay() - weekStartsOn + 7) % 7;
+  return addDays(localDate, -dayOffset);
+}
+
+function formatShortDate(date: Date): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+  }).format(date);
+}
+
+function getWeeklyPreviewLabels(config: DateFilterConfig): string[] {
+  const weekStartsOn = clampWeekday(config.weekStartsOn);
+  const currentWeekStart = getWeekStart(new Date(), weekStartsOn);
+  const weeksBack = config.weeksBack ?? 4;
+  const weeksForward = config.weeksForward ?? 0;
+  const labels: string[] = [];
+
+  for (let offset = -weeksBack; offset <= weeksForward; offset += 1) {
+    const start = addDays(currentWeekStart, offset * 7);
+    const end = addDays(start, 6);
+    labels.push(`${formatShortDate(start)} - ${formatShortDate(end)}`);
+  }
+
+  return labels.reverse().slice(0, 3);
 }
 
 function normalizeFilterControlType(type: string): SupportedFilterControlType {
@@ -286,15 +356,21 @@ function FilterEditor({
     () => normalizeFilterControlType(filter.type),
     [filter.type],
   );
-  const availableControlOptions = useMemo(
-    () =>
-      isDateField
-        ? FILTER_CONTROL_OPTIONS.filter((option) => option.value === 'date')
-        : FILTER_CONTROL_OPTIONS,
-    [isDateField],
-  );
   const dateConfig = filter.dateConfig ?? createDefaultDateConfig();
+  const dateMode = dateConfig.mode ?? 'preset';
   const defaultDateValue = asDateDefaultValue(filter.defaultValue);
+  const rawSelectedDateDefault =
+    defaultDateValue.start || defaultDateValue.end ? 'custom' : (defaultDateValue.preset ?? '');
+  const selectedDateDefault =
+    dateMode === 'weekly' &&
+    rawSelectedDateDefault !== 'this_week' &&
+    rawSelectedDateDefault !== 'last_week'
+      ? ''
+      : rawSelectedDateDefault;
+  const dateDefaultOptions =
+    dateMode === 'weekly' ? WEEKLY_DATE_DEFAULT_OPTIONS : DATE_DEFAULT_OPTIONS;
+  const shouldShowDateDefaultRange = dateMode === 'range' || selectedDateDefault === 'custom';
+  const weeklyPreviewLabels = useMemo(() => getWeeklyPreviewLabels(dateConfig), [dateConfig]);
 
   const handleChange = useCallback(
     (patch: Partial<FilterDefinition>) => {
@@ -335,6 +411,35 @@ function FilterEditor({
     fontWeight: 600,
     color: '#555',
     marginBottom: 2,
+  };
+  const sectionStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8,
+    padding: 10,
+    borderRadius: 6,
+    border: '1px solid #dbe4ee',
+    background: '#fff',
+  };
+  const sectionTitleStyle: React.CSSProperties = {
+    fontSize: 11,
+    fontWeight: 700,
+    letterSpacing: 0,
+    color: '#334155',
+  };
+  const hintStyle: React.CSSProperties = {
+    fontSize: 12,
+    lineHeight: 1.4,
+    color: '#64748b',
+  };
+  const summaryStyle: React.CSSProperties = {
+    padding: '7px 9px',
+    borderRadius: 4,
+    background: '#f8fafc',
+    border: '1px solid #e2e8f0',
+    color: '#475569',
+    fontSize: 12,
+    lineHeight: 1.4,
   };
   const titleInputId = `ss-filter-title-${filter.id}`;
   const datasetSelectId = `ss-filter-dataset-${filter.id}`;
@@ -395,6 +500,33 @@ function FilterEditor({
       });
     },
     [filter.dateConfig, handleChange],
+  );
+
+  const handleDateModeChange = useCallback(
+    (mode: NonNullable<DateFilterConfig['mode']>) => {
+      const nextPatch: Partial<FilterDefinition> = {
+        type: 'date',
+        operator: 'between',
+        optionSource: undefined,
+        dateConfig: {
+          ...createDefaultDateConfig(mode),
+          ...(filter.dateConfig ?? {}),
+          mode,
+          allowCustomRange: mode !== 'weekly',
+        },
+      };
+
+      if (
+        mode === 'weekly' &&
+        defaultDateValue.preset !== 'this_week' &&
+        defaultDateValue.preset !== 'last_week'
+      ) {
+        nextPatch.defaultValue = undefined;
+      }
+
+      handleChange(nextPatch);
+    },
+    [defaultDateValue.preset, filter.dateConfig, handleChange],
   );
 
   const handleOptionSourceKindChange = useCallback(
@@ -555,139 +687,20 @@ function FilterEditor({
         </div>
       </div>
 
-      {/* Operator + Default value */}
-      <div style={{ display: 'flex', gap: 8 }}>
-        <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-          <label htmlFor={operatorSelectId} style={labelStyle}>
-            Operator
-          </label>
-          <select
-            id={operatorSelectId}
-            name={`filter-operator-${filter.id}`}
-            value={filter.operator}
-            onChange={(e) => handleChange({ operator: e.target.value })}
-            data-testid={`filter-operator-${filter.id}`}
-            style={selectStyle}
-          >
-            {applicableOperators.map((op) => (
-              <option key={op.value} value={op.value}>
-                {op.label}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-          <label htmlFor={defaultInputId} style={labelStyle}>
-            Default value
-          </label>
-          {normalizedFilterType === 'date' ? (
-            <div style={{ display: 'flex', gap: 6 }}>
-              <input
-                id={defaultInputId}
-                name={`filter-default-start-${filter.id}`}
-                aria-label="Default start date"
-                type="date"
-                value={defaultDateValue.start ?? ''}
-                onChange={(e) => {
-                  const nextStart = e.target.value || undefined;
-                  const nextValue = {
-                    ...defaultDateValue,
-                    start: nextStart,
-                  };
-                  handleChange({
-                    defaultValue:
-                      nextValue.start || nextValue.end || nextValue.preset ? nextValue : undefined,
-                  });
-                }}
-                data-testid={`filter-default-start-${filter.id}`}
-                style={selectStyle}
-              />
-              <input
-                name={`filter-default-end-${filter.id}`}
-                aria-label="Default end date"
-                type="date"
-                value={defaultDateValue.end ?? ''}
-                onChange={(e) => {
-                  const nextEnd = e.target.value || undefined;
-                  const nextValue = {
-                    ...defaultDateValue,
-                    end: nextEnd,
-                  };
-                  handleChange({
-                    defaultValue:
-                      nextValue.start || nextValue.end || nextValue.preset ? nextValue : undefined,
-                  });
-                }}
-                data-testid={`filter-default-end-${filter.id}`}
-                style={selectStyle}
-              />
-            </div>
-          ) : (
-            <input
-              id={defaultInputId}
-              name={`filter-default-${filter.id}`}
-              type="text"
-              value={filter.defaultValue != null ? String(filter.defaultValue) : ''}
-              onChange={(e) =>
-                handleChange({
-                  defaultValue: e.target.value || undefined,
-                })
-              }
-              placeholder="Optional default..."
-              data-testid={`filter-default-${filter.id}`}
-              style={selectStyle}
-            />
-          )}
-        </div>
-      </div>
-
-      {/* Filter type */}
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
-        <label htmlFor={typeSelectId} style={labelStyle}>
-          Control type
-        </label>
-        <select
-          id={typeSelectId}
-          name={`filter-type-${filter.id}`}
-          value={normalizedFilterType}
-          onChange={(e) => handleControlTypeChange(e.target.value as SupportedFilterControlType)}
-          data-testid={`filter-type-${filter.id}`}
-          style={selectStyle}
-        >
-          {availableControlOptions.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      {normalizedFilterType === 'date' && (
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 8,
-            padding: 10,
-            borderRadius: 6,
-            border: '1px solid #dbe4ee',
-            background: '#fff',
-          }}
-        >
-          <div style={{ display: 'flex', gap: 8 }}>
-            <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+      {normalizedFilterType === 'date' ? (
+        <>
+          <div style={sectionStyle}>
+            <div style={sectionTitleStyle}>End-user control</div>
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
               <label htmlFor={`ss-filter-date-mode-${filter.id}`} style={labelStyle}>
-                Date mode
+                Date filter style
               </label>
               <select
                 id={`ss-filter-date-mode-${filter.id}`}
                 name={`filter-date-mode-${filter.id}`}
-                value={dateConfig.mode ?? 'preset'}
+                value={dateMode}
                 onChange={(e) =>
-                  handleDateConfigChange({
-                    mode: e.target.value as NonNullable<DateFilterConfig['mode']>,
-                    allowCustomRange: e.target.value !== 'weekly',
-                  })
+                  handleDateModeChange(e.target.value as NonNullable<DateFilterConfig['mode']>)
                 }
                 data-testid={`filter-date-mode-${filter.id}`}
                 style={selectStyle}
@@ -699,90 +712,255 @@ function FilterEditor({
                 ))}
               </select>
             </div>
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'flex-end',
-                gap: 6,
-                fontSize: 12,
-                color: '#475569',
-                paddingBottom: 5,
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={dateConfig.allowCustomRange !== false}
-                onChange={(e) => handleDateConfigChange({ allowCustomRange: e.target.checked })}
-                data-testid={`filter-date-allow-custom-${filter.id}`}
-              />
-              Allow custom
-            </label>
+
+            {dateMode === 'weekly' && (
+              <>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 2fr', gap: 8 }}>
+                  <div style={{ display: 'flex', flexDirection: 'column' }}>
+                    <label htmlFor={`ss-filter-week-start-${filter.id}`} style={labelStyle}>
+                      Week starts on
+                    </label>
+                    <select
+                      id={`ss-filter-week-start-${filter.id}`}
+                      name={`filter-week-start-${filter.id}`}
+                      value={dateConfig.weekStartsOn ?? 0}
+                      onChange={(e) =>
+                        handleDateConfigChange({
+                          weekStartsOn: Number(e.target.value) as DateFilterConfig['weekStartsOn'],
+                        })
+                      }
+                      data-testid={`filter-week-start-${filter.id}`}
+                      style={selectStyle}
+                    >
+                      {WEEKDAY_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+                    <div style={{ display: 'flex', flexDirection: 'column' }}>
+                      <label htmlFor={`ss-filter-weeks-back-${filter.id}`} style={labelStyle}>
+                        Weeks back
+                      </label>
+                      <input
+                        id={`ss-filter-weeks-back-${filter.id}`}
+                        name={`filter-weeks-back-${filter.id}`}
+                        type="number"
+                        min={0}
+                        value={dateConfig.weeksBack ?? 4}
+                        onChange={(e) =>
+                          handleDateConfigChange({
+                            weeksBack: coerceNonNegativeInteger(e.target.value),
+                          })
+                        }
+                        data-testid={`filter-weeks-back-${filter.id}`}
+                        style={selectStyle}
+                      />
+                    </div>
+                    <div style={{ display: 'flex', flexDirection: 'column' }}>
+                      <label htmlFor={`ss-filter-weeks-forward-${filter.id}`} style={labelStyle}>
+                        Weeks forward
+                      </label>
+                      <input
+                        id={`ss-filter-weeks-forward-${filter.id}`}
+                        name={`filter-weeks-forward-${filter.id}`}
+                        type="number"
+                        min={0}
+                        value={dateConfig.weeksForward ?? 0}
+                        onChange={(e) =>
+                          handleDateConfigChange({
+                            weeksForward: coerceNonNegativeInteger(e.target.value),
+                          })
+                        }
+                        data-testid={`filter-weeks-forward-${filter.id}`}
+                        style={selectStyle}
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div style={{ ...summaryStyle, display: 'flex', flexDirection: 'column', gap: 3 }}>
+                  <strong style={{ color: '#334155', fontSize: 12 }}>Dropdown preview</strong>
+                  {weeklyPreviewLabels.map((label) => (
+                    <span key={label}>{label}</span>
+                  ))}
+                  <span style={{ color: '#64748b' }}>
+                    Showing {Math.min(weeklyPreviewLabels.length, 3)} of{' '}
+                    {(dateConfig.weeksBack ?? 4) + (dateConfig.weeksForward ?? 0) + 1} weeks
+                  </span>
+                </div>
+              </>
+            )}
+
+            {dateMode === 'preset' && (
+              <div style={hintStyle}>
+                End users choose from common relative ranges and, when enabled by the runtime, a
+                custom range.
+              </div>
+            )}
+
+            {dateMode === 'range' && (
+              <div style={hintStyle}>End users enter a start and end date.</div>
+            )}
           </div>
 
-          {(dateConfig.mode ?? 'preset') === 'weekly' && (
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8 }}>
-              <div style={{ display: 'flex', flexDirection: 'column' }}>
-                <label htmlFor={`ss-filter-week-start-${filter.id}`} style={labelStyle}>
-                  Week starts on
-                </label>
-                <select
-                  id={`ss-filter-week-start-${filter.id}`}
-                  name={`filter-week-start-${filter.id}`}
-                  value={dateConfig.weekStartsOn ?? 0}
-                  onChange={(e) =>
-                    handleDateConfigChange({
-                      weekStartsOn: Number(e.target.value) as DateFilterConfig['weekStartsOn'],
-                    })
+          <div style={sectionStyle}>
+            <div style={sectionTitleStyle}>Default selection</div>
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <label htmlFor={defaultInputId} style={labelStyle}>
+                Initial value
+              </label>
+              <select
+                id={defaultInputId}
+                name={`filter-default-preset-${filter.id}`}
+                value={selectedDateDefault}
+                onChange={(e) => {
+                  const nextDefault = e.target.value;
+
+                  if (!nextDefault) {
+                    handleChange({ defaultValue: undefined });
+                    return;
                   }
-                  data-testid={`filter-week-start-${filter.id}`}
-                  style={selectStyle}
-                >
-                  {WEEKDAY_OPTIONS.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div style={{ display: 'flex', flexDirection: 'column' }}>
-                <label htmlFor={`ss-filter-weeks-back-${filter.id}`} style={labelStyle}>
-                  Weeks back
-                </label>
-                <input
-                  id={`ss-filter-weeks-back-${filter.id}`}
-                  name={`filter-weeks-back-${filter.id}`}
-                  type="number"
-                  min={0}
-                  value={dateConfig.weeksBack ?? 4}
-                  onChange={(e) =>
-                    handleDateConfigChange({ weeksBack: coerceNonNegativeInteger(e.target.value) })
+
+                  if (nextDefault === 'custom') {
+                    handleChange({
+                      defaultValue: {
+                        start: defaultDateValue.start,
+                        end: defaultDateValue.end,
+                      },
+                    });
+                    return;
                   }
-                  data-testid={`filter-weeks-back-${filter.id}`}
-                  style={selectStyle}
-                />
-              </div>
-              <div style={{ display: 'flex', flexDirection: 'column' }}>
-                <label htmlFor={`ss-filter-weeks-forward-${filter.id}`} style={labelStyle}>
-                  Weeks forward
-                </label>
-                <input
-                  id={`ss-filter-weeks-forward-${filter.id}`}
-                  name={`filter-weeks-forward-${filter.id}`}
-                  type="number"
-                  min={0}
-                  value={dateConfig.weeksForward ?? 0}
-                  onChange={(e) =>
-                    handleDateConfigChange({
-                      weeksForward: coerceNonNegativeInteger(e.target.value),
-                    })
-                  }
-                  data-testid={`filter-weeks-forward-${filter.id}`}
-                  style={selectStyle}
-                />
-              </div>
+
+                  handleChange({ defaultValue: { preset: nextDefault } });
+                }}
+                data-testid={`filter-date-default-${filter.id}`}
+                style={selectStyle}
+              >
+                {dateDefaultOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
             </div>
-          )}
-        </div>
+
+            {shouldShowDateDefaultRange && (
+              <div style={{ display: 'flex', gap: 6 }}>
+                <input
+                  name={`filter-default-start-${filter.id}`}
+                  aria-label="Default start date"
+                  type="date"
+                  value={defaultDateValue.start ?? ''}
+                  onChange={(e) => {
+                    const nextStart = e.target.value || undefined;
+                    const nextValue = {
+                      ...defaultDateValue,
+                      preset: undefined,
+                      start: nextStart,
+                    };
+                    handleChange({
+                      defaultValue: nextValue.start || nextValue.end ? nextValue : undefined,
+                    });
+                  }}
+                  data-testid={`filter-default-start-${filter.id}`}
+                  style={selectStyle}
+                />
+                <input
+                  name={`filter-default-end-${filter.id}`}
+                  aria-label="Default end date"
+                  type="date"
+                  value={defaultDateValue.end ?? ''}
+                  onChange={(e) => {
+                    const nextEnd = e.target.value || undefined;
+                    const nextValue = {
+                      ...defaultDateValue,
+                      preset: undefined,
+                      end: nextEnd,
+                    };
+                    handleChange({
+                      defaultValue: nextValue.start || nextValue.end ? nextValue : undefined,
+                    });
+                  }}
+                  data-testid={`filter-default-end-${filter.id}`}
+                  style={selectStyle}
+                />
+              </div>
+            )}
+          </div>
+
+          <div style={summaryStyle} data-testid={`filter-date-query-behavior-${filter.id}`}>
+            Applies as: {field?.label ?? filter.fieldRef} between start and end.
+          </div>
+        </>
+      ) : (
+        <>
+          {/* Operator + Default value */}
+          <div style={{ display: 'flex', gap: 8 }}>
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+              <label htmlFor={operatorSelectId} style={labelStyle}>
+                Operator
+              </label>
+              <select
+                id={operatorSelectId}
+                name={`filter-operator-${filter.id}`}
+                value={filter.operator}
+                onChange={(e) => handleChange({ operator: e.target.value })}
+                data-testid={`filter-operator-${filter.id}`}
+                style={selectStyle}
+              >
+                {applicableOperators.map((op) => (
+                  <option key={op.value} value={op.value}>
+                    {op.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+              <label htmlFor={defaultInputId} style={labelStyle}>
+                Default value
+              </label>
+              <input
+                id={defaultInputId}
+                name={`filter-default-${filter.id}`}
+                type="text"
+                value={filter.defaultValue != null ? String(filter.defaultValue) : ''}
+                onChange={(e) =>
+                  handleChange({
+                    defaultValue: e.target.value || undefined,
+                  })
+                }
+                placeholder="Optional default..."
+                data-testid={`filter-default-${filter.id}`}
+                style={selectStyle}
+              />
+            </div>
+          </div>
+
+          {/* Filter type */}
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <label htmlFor={typeSelectId} style={labelStyle}>
+              Control type
+            </label>
+            <select
+              id={typeSelectId}
+              name={`filter-type-${filter.id}`}
+              value={normalizedFilterType}
+              onChange={(e) =>
+                handleControlTypeChange(e.target.value as SupportedFilterControlType)
+              }
+              data-testid={`filter-type-${filter.id}`}
+              style={selectStyle}
+            >
+              {FILTER_CONTROL_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </>
       )}
 
       {isSelectFilterControlType(normalizedFilterType) && !isDateField && (

--- a/packages/designer/src/components/FilterBuilderPanel.tsx
+++ b/packages/designer/src/components/FilterBuilderPanel.tsx
@@ -209,12 +209,17 @@ function asDateDefaultValue(value: unknown): { preset?: string; start?: string; 
   return {};
 }
 
-function getWeeklyPreviewLabels(config: DateFilterConfig): string[] {
+function getWeeklyPreview(config: DateFilterConfig): { labels: string[]; total: number } {
+  const options = generateWeeklyDateRangeOptions(config);
+
   // Preview only the newest few generated choices so the editor stays compact.
-  return generateWeeklyDateRangeOptions(config)
-    .reverse()
-    .slice(0, WEEKLY_PREVIEW_OPTION_COUNT)
-    .map((option) => option.label);
+  return {
+    labels: [...options]
+      .reverse()
+      .slice(0, WEEKLY_PREVIEW_OPTION_COUNT)
+      .map((option) => option.label),
+    total: options.length,
+  };
 }
 
 function normalizeFilterControlType(type: string): SupportedFilterControlType {
@@ -328,7 +333,7 @@ function FilterEditor({
   const dateDefaultOptions =
     dateMode === 'weekly' ? WEEKLY_DATE_DEFAULT_OPTIONS : DATE_DEFAULT_OPTIONS;
   const shouldShowDateDefaultRange = dateMode === 'range' || selectedDateDefault === 'custom';
-  const weeklyPreviewLabels = useMemo(() => getWeeklyPreviewLabels(dateConfig), [dateConfig]);
+  const weeklyPreview = useMemo(() => getWeeklyPreview(dateConfig), [dateConfig]);
 
   const handleChange = useCallback(
     (patch: Partial<FilterDefinition>) => {
@@ -725,12 +730,12 @@ function FilterEditor({
                 </div>
                 <div style={{ ...summaryStyle, display: 'flex', flexDirection: 'column', gap: 3 }}>
                   <strong style={{ color: '#334155', fontSize: 12 }}>Dropdown preview</strong>
-                  {weeklyPreviewLabels.map((label) => (
+                  {weeklyPreview.labels.map((label) => (
                     <span key={label}>{label}</span>
                   ))}
                   <span style={{ color: '#64748b' }}>
-                    Showing {Math.min(weeklyPreviewLabels.length, WEEKLY_PREVIEW_OPTION_COUNT)} of{' '}
-                    {(dateConfig.weeksBack ?? 4) + (dateConfig.weeksForward ?? 0) + 1} weeks
+                    Showing {Math.min(weeklyPreview.labels.length, WEEKLY_PREVIEW_OPTION_COUNT)} of{' '}
+                    {weeklyPreview.total} weeks
                   </span>
                 </div>
               </>

--- a/packages/designer/src/components/FilterBuilderPanel.tsx
+++ b/packages/designer/src/components/FilterBuilderPanel.tsx
@@ -11,12 +11,13 @@
  */
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { NormalizedDataset } from '@supersubset/data-model';
-import type {
-  DateFilterConfig,
-  FilterDefinition,
-  FilterOptionDefinition,
-  FilterOptionSource,
-  FilterScope,
+import {
+  generateWeeklyDateRangeOptions,
+  type DateFilterConfig,
+  type FilterDefinition,
+  type FilterOptionDefinition,
+  type FilterOptionSource,
+  type FilterScope,
 } from '@supersubset/schema';
 
 export type { FilterDefinition, FilterScope } from '@supersubset/schema';
@@ -112,6 +113,8 @@ const WEEKLY_DATE_DEFAULT_OPTIONS = [
   { value: 'last_week', label: 'Previous week' },
 ] as const;
 
+const WEEKLY_PREVIEW_OPTION_COUNT = 3;
+
 function isSelectFilterControlType(type: string): type is 'select' | 'multi-select' {
   return SELECT_FILTER_CONTROL_TYPES.has(type as SupportedFilterControlType);
 }
@@ -206,57 +209,12 @@ function asDateDefaultValue(value: unknown): { preset?: string; start?: string; 
   return {};
 }
 
-function startOfLocalDay(date: Date): Date {
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
-}
-
-function addDays(date: Date, days: number): Date {
-  const nextDate = new Date(date);
-  nextDate.setDate(nextDate.getDate() + days);
-  return nextDate;
-}
-
-function clampWeekday(
-  value: DateFilterConfig['weekStartsOn'] | undefined,
-): 0 | 1 | 2 | 3 | 4 | 5 | 6 {
-  return value === 0 ||
-    value === 1 ||
-    value === 2 ||
-    value === 3 ||
-    value === 4 ||
-    value === 5 ||
-    value === 6
-    ? value
-    : 0;
-}
-
-function getWeekStart(date: Date, weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6): Date {
-  const localDate = startOfLocalDay(date);
-  const dayOffset = (localDate.getDay() - weekStartsOn + 7) % 7;
-  return addDays(localDate, -dayOffset);
-}
-
-function formatShortDate(date: Date): string {
-  return new Intl.DateTimeFormat(undefined, {
-    month: 'short',
-    day: 'numeric',
-  }).format(date);
-}
-
 function getWeeklyPreviewLabels(config: DateFilterConfig): string[] {
-  const weekStartsOn = clampWeekday(config.weekStartsOn);
-  const currentWeekStart = getWeekStart(new Date(), weekStartsOn);
-  const weeksBack = config.weeksBack ?? 4;
-  const weeksForward = config.weeksForward ?? 0;
-  const labels: string[] = [];
-
-  for (let offset = -weeksBack; offset <= weeksForward; offset += 1) {
-    const start = addDays(currentWeekStart, offset * 7);
-    const end = addDays(start, 6);
-    labels.push(`${formatShortDate(start)} - ${formatShortDate(end)}`);
-  }
-
-  return labels.reverse().slice(0, 3);
+  // Preview only the newest few generated choices so the editor stays compact.
+  return generateWeeklyDateRangeOptions(config)
+    .reverse()
+    .slice(0, WEEKLY_PREVIEW_OPTION_COUNT)
+    .map((option) => option.label);
 }
 
 function normalizeFilterControlType(type: string): SupportedFilterControlType {
@@ -657,22 +615,7 @@ function FilterEditor({
             id={fieldSelectId}
             name={`filter-field-${filter.id}`}
             value={filter.fieldRef}
-            onChange={(e) => {
-              const nextFieldRef = e.target.value;
-              const nextField = dataset?.fields.find((f) => f.id === nextFieldRef);
-              const nextIsDateField = isDateDataType(nextField?.dataType);
-              handleChange({
-                fieldRef: nextFieldRef,
-                ...(nextIsDateField
-                  ? {
-                      type: 'date',
-                      operator: 'between',
-                      optionSource: undefined,
-                      dateConfig: filter.dateConfig ?? createDefaultDateConfig(),
-                    }
-                  : {}),
-              });
-            }}
+            onChange={(e) => handleChange({ fieldRef: e.target.value })}
             data-testid={`filter-field-${filter.id}`}
             style={selectStyle}
             disabled={!dataset}
@@ -786,7 +729,7 @@ function FilterEditor({
                     <span key={label}>{label}</span>
                   ))}
                   <span style={{ color: '#64748b' }}>
-                    Showing {Math.min(weeklyPreviewLabels.length, 3)} of{' '}
+                    Showing {Math.min(weeklyPreviewLabels.length, WEEKLY_PREVIEW_OPTION_COUNT)} of{' '}
                     {(dateConfig.weeksBack ?? 4) + (dateConfig.weeksForward ?? 0) + 1} weeks
                   </span>
                 </div>

--- a/packages/designer/test/feature-panels-2.test.tsx
+++ b/packages/designer/test/feature-panels-2.test.tsx
@@ -726,11 +726,23 @@ describe('FilterBuilderPanel', () => {
       scope: { type: 'global' },
     };
 
-    render(<FilterBuilderPanel filters={[filter]} onChange={onChange} datasets={[MOCK_DATASET]} />);
+    const { rerender } = render(
+      <FilterBuilderPanel filters={[filter]} onChange={onChange} datasets={[MOCK_DATASET]} />,
+    );
 
     fireEvent.change(screen.getByTestId('filter-field-f-date'), {
       target: { value: 'order_date' },
     });
+
+    expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ fieldRef: 'order_date' })]);
+
+    rerender(
+      <FilterBuilderPanel
+        filters={[{ ...filter, fieldRef: 'order_date' }]}
+        onChange={onChange}
+        datasets={[MOCK_DATASET]}
+      />,
+    );
 
     expect(onChange).toHaveBeenCalledWith([
       expect.objectContaining({

--- a/packages/designer/test/feature-panels-2.test.tsx
+++ b/packages/designer/test/feature-panels-2.test.tsx
@@ -714,6 +714,66 @@ describe('FilterBuilderPanel', () => {
     expect(optionValues).toEqual(['select', 'multi-select', 'range', 'date', 'text']);
   });
 
+  it('[filters-and-interactions.FILTER_BAR.4] switches date fields to date-aware controls', () => {
+    const onChange = vi.fn();
+    const filter: FilterDefinition = {
+      id: 'f-date',
+      type: 'select',
+      fieldRef: 'region',
+      datasetRef: 'ds-orders',
+      operator: 'equals',
+      scope: { type: 'global' },
+    };
+
+    render(<FilterBuilderPanel filters={[filter]} onChange={onChange} datasets={[MOCK_DATASET]} />);
+
+    fireEvent.change(screen.getByTestId('filter-field-f-date'), {
+      target: { value: 'order_date' },
+    });
+
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        fieldRef: 'order_date',
+        type: 'date',
+        operator: 'between',
+        optionSource: undefined,
+        dateConfig: expect.objectContaining({ mode: 'preset' }),
+      }),
+    ]);
+  });
+
+  it('[filters-and-interactions.FILTER_BAR.4] hides select option sourcing for date filters and exposes weekly settings', () => {
+    const filter: FilterDefinition = {
+      id: 'f-date',
+      type: 'date',
+      fieldRef: 'order_date',
+      datasetRef: 'ds-orders',
+      operator: 'between',
+      dateConfig: {
+        mode: 'weekly',
+        weekStartsOn: 1,
+        weeksBack: 2,
+        weeksForward: 1,
+        includeCurrentWeek: true,
+      },
+      scope: { type: 'global' },
+    };
+
+    render(<FilterBuilderPanel filters={[filter]} onChange={vi.fn()} datasets={[MOCK_DATASET]} />);
+
+    expect(screen.queryByTestId('filter-option-source-kind-f-date')).toBeNull();
+    expect(screen.getByTestId('filter-date-mode-f-date')).toBeTruthy();
+    expect(screen.getByTestId('filter-week-start-f-date')).toBeTruthy();
+    expect(screen.getByTestId('filter-weeks-back-f-date')).toBeTruthy();
+    expect(screen.getByTestId('filter-weeks-forward-f-date')).toBeTruthy();
+
+    const typeValues = Array.from(
+      screen.getByTestId('filter-type-f-date').querySelectorAll('option'),
+    ).map((option) => option.getAttribute('value'));
+
+    expect(typeValues).toEqual(['date']);
+  });
+
   it('lets authors choose a static option source and add authored options', () => {
     const onChange = vi.fn();
     const filter: FilterDefinition = {

--- a/packages/designer/test/feature-panels-2.test.tsx
+++ b/packages/designer/test/feature-panels-2.test.tsx
@@ -787,6 +787,27 @@ describe('FilterBuilderPanel', () => {
     expect(screen.getByTestId('filter-weeks-forward-f-date')).toBeTruthy();
   });
 
+  it('[filters-and-interactions.FILTER_BAR.4] counts weekly preview options after excluding current week', () => {
+    const filter: FilterDefinition = {
+      id: 'f-date',
+      type: 'date',
+      fieldRef: 'order_date',
+      datasetRef: 'ds-orders',
+      operator: 'between',
+      dateConfig: {
+        mode: 'weekly',
+        weeksBack: 1,
+        weeksForward: 1,
+        includeCurrentWeek: false,
+      },
+      scope: { type: 'global' },
+    };
+
+    render(<FilterBuilderPanel filters={[filter]} onChange={vi.fn()} datasets={[MOCK_DATASET]} />);
+
+    expect(screen.getByText('Showing 2 of 2 weeks')).toBeTruthy();
+  });
+
   it('lets authors choose a static option source and add authored options', () => {
     const onChange = vi.fn();
     const filter: FilterDefinition = {

--- a/packages/designer/test/feature-panels-2.test.tsx
+++ b/packages/designer/test/feature-panels-2.test.tsx
@@ -613,7 +613,8 @@ describe('FilterBuilderPanel', () => {
     render(<FilterBuilderPanel filters={[filter]} onChange={onChange} datasets={[MOCK_DATASET]} />);
 
     expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ type: 'date' })]);
-    expect((screen.getByTestId('filter-type-f1') as HTMLSelectElement).value).toBe('date');
+    expect(screen.queryByTestId('filter-type-f1')).toBeNull();
+    expect(screen.getByTestId('filter-date-mode-f1')).toBeTruthy();
   });
 
   it('does not renormalize equivalent legacy filters when props churn', () => {
@@ -762,16 +763,16 @@ describe('FilterBuilderPanel', () => {
     render(<FilterBuilderPanel filters={[filter]} onChange={vi.fn()} datasets={[MOCK_DATASET]} />);
 
     expect(screen.queryByTestId('filter-option-source-kind-f-date')).toBeNull();
+    expect(screen.queryByTestId('filter-type-f-date')).toBeNull();
+    expect(screen.queryByTestId('filter-date-allow-custom-f-date')).toBeNull();
     expect(screen.getByTestId('filter-date-mode-f-date')).toBeTruthy();
+    expect(screen.getByTestId('filter-date-default-f-date')).toBeTruthy();
+    expect(screen.getByTestId('filter-date-query-behavior-f-date').textContent).toContain(
+      'between',
+    );
     expect(screen.getByTestId('filter-week-start-f-date')).toBeTruthy();
     expect(screen.getByTestId('filter-weeks-back-f-date')).toBeTruthy();
     expect(screen.getByTestId('filter-weeks-forward-f-date')).toBeTruthy();
-
-    const typeValues = Array.from(
-      screen.getByTestId('filter-type-f-date').querySelectorAll('option'),
-    ).map((option) => option.getAttribute('value'));
-
-    expect(typeValues).toEqual(['date']);
   });
 
   it('lets authors choose a static option source and add authored options', () => {

--- a/packages/runtime/src/components/FilterBar.tsx
+++ b/packages/runtime/src/components/FilterBar.tsx
@@ -10,6 +10,11 @@ import type {
   FilterOptionDefinition,
 } from '@supersubset/schema';
 import { useFilters } from '../filters/FilterEngine';
+import {
+  DATE_PRESETS,
+  generateWeeklyDateRangeOptions,
+  resolveRelativeDate,
+} from '../filters/date-filter-utils';
 
 // ─── Styles ──────────────────────────────────────────────────
 
@@ -218,7 +223,7 @@ function FilterControl({
       { className: 'ss-filter-label', style: LABEL_STYLE, htmlFor: `${inputIdBase}-primary` },
       label,
     ),
-    renderInput(filter.type, value, onChangeValue, resolvedOptionsState, {
+    renderInput(filter, value, onChangeValue, resolvedOptionsState, {
       inputIdBase,
       inputName: filter.id,
       label,
@@ -227,13 +232,13 @@ function FilterControl({
 }
 
 function renderInput(
-  type: string,
+  filter: FilterDefinition,
   value: unknown,
   onChange: (value: unknown) => void,
   optionsState: ResolvedFilterOptionsState,
   metadata: { inputIdBase: string; inputName: string; label: string },
 ): ReactNode {
-  switch (type) {
+  switch (filter.type) {
     case 'select':
       return renderSelect(value, onChange, optionsState, metadata);
     case 'multi-select':
@@ -243,7 +248,7 @@ function renderInput(
     case 'range':
       return renderRange(value, onChange, metadata);
     case 'date':
-      return renderDate(value, onChange, metadata);
+      return renderDate(filter, value, onChange, metadata);
     default:
       return renderText(value, onChange, metadata);
   }
@@ -395,164 +400,95 @@ function renderRange(
   );
 }
 
-// ─── Relative Date Presets ────────────────────────────────────
-
-export const DATE_PRESETS: { value: string; label: string }[] = [
-  { value: '', label: 'All time' },
-  { value: 'today', label: 'Today' },
-  { value: 'yesterday', label: 'Yesterday' },
-  { value: 'this_week', label: 'This week' },
-  { value: 'last_week', label: 'Last week' },
-  { value: 'this_month', label: 'This month' },
-  { value: 'last_month', label: 'Last month' },
-  { value: 'this_quarter', label: 'This quarter' },
-  { value: 'last_quarter', label: 'Last quarter' },
-  { value: 'this_year', label: 'This year' },
-  { value: 'last_year', label: 'Last year' },
-  { value: 'last_7_days', label: 'Last 7 days' },
-  { value: 'last_30_days', label: 'Last 30 days' },
-  { value: 'last_90_days', label: 'Last 90 days' },
-  { value: 'last_365_days', label: 'Last 365 days' },
-  { value: 'custom', label: 'Custom range…' },
-];
-
-/**
- * Resolve a relative date preset to a concrete { start, end } range (ISO strings).
- * Returns undefined for empty/unknown presets.
- */
-export function resolveRelativeDate(
-  preset: string,
-  now = new Date(),
-): { start: string; end: string } | undefined {
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const iso = (d: Date) => d.toISOString().slice(0, 10);
-
-  switch (preset) {
-    case 'today':
-      return { start: iso(today), end: iso(today) };
-    case 'yesterday': {
-      const d = new Date(today);
-      d.setDate(d.getDate() - 1);
-      return { start: iso(d), end: iso(d) };
-    }
-    case 'this_week': {
-      const d = new Date(today);
-      d.setDate(d.getDate() - d.getDay());
-      return { start: iso(d), end: iso(today) };
-    }
-    case 'last_week': {
-      const end = new Date(today);
-      end.setDate(end.getDate() - end.getDay() - 1);
-      const start = new Date(end);
-      start.setDate(start.getDate() - 6);
-      return { start: iso(start), end: iso(end) };
-    }
-    case 'this_month':
-      return { start: iso(new Date(today.getFullYear(), today.getMonth(), 1)), end: iso(today) };
-    case 'last_month': {
-      const start = new Date(today.getFullYear(), today.getMonth() - 1, 1);
-      const end = new Date(today.getFullYear(), today.getMonth(), 0);
-      return { start: iso(start), end: iso(end) };
-    }
-    case 'this_quarter': {
-      const q = Math.floor(today.getMonth() / 3);
-      return { start: iso(new Date(today.getFullYear(), q * 3, 1)), end: iso(today) };
-    }
-    case 'last_quarter': {
-      const q = Math.floor(today.getMonth() / 3);
-      const start = new Date(today.getFullYear(), (q - 1) * 3, 1);
-      const end = new Date(today.getFullYear(), q * 3, 0);
-      return { start: iso(start), end: iso(end) };
-    }
-    case 'this_year':
-      return { start: iso(new Date(today.getFullYear(), 0, 1)), end: iso(today) };
-    case 'last_year':
-      return {
-        start: iso(new Date(today.getFullYear() - 1, 0, 1)),
-        end: iso(new Date(today.getFullYear() - 1, 11, 31)),
-      };
-    case 'last_7_days': {
-      const d = new Date(today);
-      d.setDate(d.getDate() - 6);
-      return { start: iso(d), end: iso(today) };
-    }
-    case 'last_30_days': {
-      const d = new Date(today);
-      d.setDate(d.getDate() - 29);
-      return { start: iso(d), end: iso(today) };
-    }
-    case 'last_90_days': {
-      const d = new Date(today);
-      d.setDate(d.getDate() - 89);
-      return { start: iso(d), end: iso(today) };
-    }
-    case 'last_365_days': {
-      const d = new Date(today);
-      d.setDate(d.getDate() - 364);
-      return { start: iso(d), end: iso(today) };
-    }
-    default:
-      return undefined;
-  }
-}
-
 function renderDate(
+  filter: FilterDefinition,
   value: unknown,
   onChange: (value: unknown) => void,
   metadata: { inputIdBase: string; inputName: string; label: string },
 ): ReactNode {
   const dateVal = value as { preset?: string; start?: string; end?: string } | string | undefined;
   const isObj = typeof dateVal === 'object' && dateVal !== null;
+  const dateConfig = filter.dateConfig;
+  const isWeekly = dateConfig?.mode === 'weekly';
+  const isRangeMode = dateConfig?.mode === 'range';
+  const allowCustomRange = dateConfig?.allowCustomRange !== false;
   const preset = isObj ? ((dateVal as { preset?: string }).preset ?? '') : '';
-  const isCustom = preset === 'custom';
+  const isCustom =
+    isRangeMode ||
+    (allowCustomRange &&
+      (preset === 'custom' || (!isWeekly && !preset && typeof dateVal === 'string')));
   const customStart = isObj
     ? ((dateVal as { start?: string }).start ?? '')
     : typeof dateVal === 'string'
       ? dateVal
       : '';
   const customEnd = isObj ? ((dateVal as { end?: string }).end ?? '') : '';
+  const weeklyOptions = isWeekly ? generateWeeklyDateRangeOptions(dateConfig) : [];
+  const selectedWeeklyValue =
+    isWeekly && isObj && customStart && customEnd ? `week:${customStart}:${customEnd}` : '';
+  const presetOptions =
+    dateConfig?.presets && dateConfig.presets.length > 0
+      ? DATE_PRESETS.filter(
+          (presetOption) =>
+            presetOption.value === '' ||
+            presetOption.value === 'custom' ||
+            dateConfig.presets?.includes(presetOption.value),
+        )
+      : DATE_PRESETS;
 
   return createElement(
     'div',
     { className: 'ss-filter-date', style: { display: 'flex', alignItems: 'center', gap: '6px' } },
-    // Preset dropdown
-    createElement(
-      'select',
-      {
-        className: 'ss-filter-date-preset',
-        id: `${metadata.inputIdBase}-primary`,
-        name: `${metadata.inputName}-preset`,
-        style: INPUT_STYLE,
-        value: preset,
-        onChange: (e: React.ChangeEvent<HTMLSelectElement>) => {
-          const v = e.target.value;
-          if (v === '') {
-            onChange(undefined);
-          } else if (v === 'custom') {
-            onChange({ preset: 'custom', start: '', end: '' });
-          } else {
-            const resolved = resolveRelativeDate(v);
-            onChange({ preset: v, ...(resolved ?? {}) });
-          }
-        },
-      },
-      ...DATE_PRESETS.map((p) =>
-        createElement('option', { key: p.value, value: p.value }, p.label),
-      ),
-    ),
-    // Custom date pickers (only when "Custom range…" is selected)
+    isRangeMode
+      ? null
+      : createElement(
+          'select',
+          {
+            className: 'ss-filter-date-preset',
+            id: `${metadata.inputIdBase}-primary`,
+            name: `${metadata.inputName}-preset`,
+            style: INPUT_STYLE,
+            value: isWeekly ? selectedWeeklyValue : preset,
+            onChange: (e: React.ChangeEvent<HTMLSelectElement>) => {
+              const v = e.target.value;
+              if (v === '') {
+                onChange(undefined);
+              } else if (isWeekly) {
+                const option = weeklyOptions.find((candidate) => candidate.value === v);
+                if (option) {
+                  onChange({ preset: option.value, start: option.start, end: option.end });
+                }
+              } else if (v === 'custom') {
+                onChange({ preset: 'custom', start: '', end: '' });
+              } else {
+                const resolved = resolveRelativeDate(v, new Date(), dateConfig);
+                onChange({ preset: v, ...(resolved ?? {}) });
+              }
+            },
+          },
+          isWeekly ? createElement('option', { value: '' }, 'All time') : null,
+          ...(isWeekly ? weeklyOptions : presetOptions).map((p) =>
+            createElement('option', { key: p.value, value: p.value }, p.label),
+          ),
+        ),
+    // Custom date pickers (only when custom ranges are enabled and selected)
     isCustom
       ? createElement(
           'div',
           { style: RANGE_STYLE },
           createElement('input', {
+            id: isRangeMode ? `${metadata.inputIdBase}-primary` : undefined,
             name: `${metadata.inputName}-start`,
             'aria-label': `${metadata.label} start date`,
             type: 'date',
             style: { ...INPUT_STYLE, minWidth: '130px' },
             value: customStart,
             onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-              onChange({ preset: 'custom', start: e.target.value, end: customEnd });
+              onChange({
+                ...(isRangeMode ? {} : { preset: 'custom' }),
+                start: e.target.value,
+                end: customEnd,
+              });
             },
           }),
           createElement('span', { style: { color: '#9ca3af' } }, '–'),
@@ -563,7 +499,11 @@ function renderDate(
             style: { ...INPUT_STYLE, minWidth: '130px' },
             value: customEnd,
             onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-              onChange({ preset: 'custom', start: customStart, end: e.target.value });
+              onChange({
+                ...(isRangeMode ? {} : { preset: 'custom' }),
+                start: customStart,
+                end: e.target.value,
+              });
             },
           }),
         )

--- a/packages/runtime/src/components/FilterBar.tsx
+++ b/packages/runtime/src/components/FilterBar.tsx
@@ -424,8 +424,18 @@ function renderDate(
       : '';
   const customEnd = isObj ? ((dateVal as { end?: string }).end ?? '') : '';
   const weeklyOptions = isWeekly ? generateWeeklyDateRangeOptions(dateConfig) : [];
+  const weeklyPresetOption =
+    isWeekly && isObj && !customStart && !customEnd
+      ? weeklyOptions.find((option) =>
+          preset === 'this_week'
+            ? option.offset === 0
+            : preset === 'last_week' && option.offset === -1,
+        )
+      : undefined;
   const selectedWeeklyValue =
-    isWeekly && isObj && customStart && customEnd ? `week:${customStart}:${customEnd}` : '';
+    isWeekly && isObj && customStart && customEnd
+      ? `week:${customStart}:${customEnd}`
+      : (weeklyPresetOption?.value ?? '');
   const presetOptions =
     dateConfig?.presets && dateConfig.presets.length > 0
       ? DATE_PRESETS.filter(

--- a/packages/runtime/src/filters/date-filter-utils.ts
+++ b/packages/runtime/src/filters/date-filter-utils.ts
@@ -1,0 +1,298 @@
+import type { QueryFilter, QueryFilterOperator } from '@supersubset/data-model';
+import type { DateFilterConfig, FilterDefinition } from '@supersubset/schema';
+
+export const DATE_PRESETS: { value: string; label: string }[] = [
+  { value: '', label: 'All time' },
+  { value: 'today', label: 'Today' },
+  { value: 'yesterday', label: 'Yesterday' },
+  { value: 'this_week', label: 'This week' },
+  { value: 'last_week', label: 'Last week' },
+  { value: 'this_month', label: 'This month' },
+  { value: 'last_month', label: 'Last month' },
+  { value: 'this_quarter', label: 'This quarter' },
+  { value: 'last_quarter', label: 'Last quarter' },
+  { value: 'this_year', label: 'This year' },
+  { value: 'last_year', label: 'Last year' },
+  { value: 'last_7_days', label: 'Last 7 days' },
+  { value: 'last_30_days', label: 'Last 30 days' },
+  { value: 'last_90_days', label: 'Last 90 days' },
+  { value: 'last_365_days', label: 'Last 365 days' },
+  { value: 'custom', label: 'Custom range…' },
+];
+
+const DIRECT_QUERY_OPERATORS = new Set<QueryFilterOperator>([
+  'eq',
+  'neq',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'in',
+  'not_in',
+  'like',
+  'not_like',
+  'is_null',
+  'is_not_null',
+  'between',
+]);
+
+export interface DateRangeValue {
+  preset?: string;
+  start?: string;
+  end?: string;
+  min?: number;
+  max?: number;
+}
+
+export interface WeeklyDateRangeOption {
+  value: string;
+  label: string;
+  start: string;
+  end: string;
+  offset: number;
+}
+
+function formatIsoDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function clampWeekday(value: unknown): 0 | 1 | 2 | 3 | 4 | 5 | 6 {
+  return value === 0 ||
+    value === 1 ||
+    value === 2 ||
+    value === 3 ||
+    value === 4 ||
+    value === 5 ||
+    value === 6
+    ? value
+    : 0;
+}
+
+function coerceNonNegativeInteger(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : fallback;
+}
+
+function startOfWeek(date: Date, weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6): Date {
+  const dayOffset = (date.getDay() - weekStartsOn + 7) % 7;
+  return addDays(date, -dayOffset);
+}
+
+function formatDateLabel(isoDate: string): string {
+  const [year, month, day] = isoDate.split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function generateWeeklyDateRangeOptions(
+  config: DateFilterConfig | undefined,
+  now = new Date(),
+): WeeklyDateRangeOption[] {
+  const weekStartsOn = clampWeekday(config?.weekStartsOn);
+  const weeksBack = coerceNonNegativeInteger(config?.weeksBack, 4);
+  const weeksForward = coerceNonNegativeInteger(config?.weeksForward, 0);
+  const includeCurrentWeek = config?.includeCurrentWeek !== false;
+  const currentWeekStart = startOfWeek(startOfLocalDay(now), weekStartsOn);
+  const options: WeeklyDateRangeOption[] = [];
+
+  for (let offset = -weeksBack; offset <= weeksForward; offset += 1) {
+    if (!includeCurrentWeek && offset === 0) {
+      continue;
+    }
+
+    const start = addDays(currentWeekStart, offset * 7);
+    const end = addDays(start, 6);
+    const startIso = formatIsoDate(start);
+    const endIso = formatIsoDate(end);
+
+    options.push({
+      value: `week:${startIso}:${endIso}`,
+      label: `${formatDateLabel(startIso)} - ${formatDateLabel(endIso)}`,
+      start: startIso,
+      end: endIso,
+      offset,
+    });
+  }
+
+  return options;
+}
+
+/**
+ * Resolve a relative date preset to a concrete { start, end } range.
+ * Returns undefined for empty/unknown presets.
+ */
+export function resolveRelativeDate(
+  preset: string,
+  now = new Date(),
+  config?: DateFilterConfig,
+): { start: string; end: string } | undefined {
+  const today = startOfLocalDay(now);
+  const weekStartsOn = clampWeekday(config?.weekStartsOn);
+
+  switch (preset) {
+    case 'today':
+      return { start: formatIsoDate(today), end: formatIsoDate(today) };
+    case 'yesterday': {
+      const d = addDays(today, -1);
+      return { start: formatIsoDate(d), end: formatIsoDate(d) };
+    }
+    case 'this_week': {
+      const start = startOfWeek(today, weekStartsOn);
+      return { start: formatIsoDate(start), end: formatIsoDate(today) };
+    }
+    case 'last_week': {
+      const currentStart = startOfWeek(today, weekStartsOn);
+      const start = addDays(currentStart, -7);
+      const end = addDays(currentStart, -1);
+      return { start: formatIsoDate(start), end: formatIsoDate(end) };
+    }
+    case 'this_month':
+      return {
+        start: formatIsoDate(new Date(today.getFullYear(), today.getMonth(), 1)),
+        end: formatIsoDate(today),
+      };
+    case 'last_month': {
+      const start = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+      const end = new Date(today.getFullYear(), today.getMonth(), 0);
+      return { start: formatIsoDate(start), end: formatIsoDate(end) };
+    }
+    case 'this_quarter': {
+      const q = Math.floor(today.getMonth() / 3);
+      return {
+        start: formatIsoDate(new Date(today.getFullYear(), q * 3, 1)),
+        end: formatIsoDate(today),
+      };
+    }
+    case 'last_quarter': {
+      const q = Math.floor(today.getMonth() / 3);
+      const start = new Date(today.getFullYear(), (q - 1) * 3, 1);
+      const end = new Date(today.getFullYear(), q * 3, 0);
+      return { start: formatIsoDate(start), end: formatIsoDate(end) };
+    }
+    case 'this_year':
+      return {
+        start: formatIsoDate(new Date(today.getFullYear(), 0, 1)),
+        end: formatIsoDate(today),
+      };
+    case 'last_year':
+      return {
+        start: formatIsoDate(new Date(today.getFullYear() - 1, 0, 1)),
+        end: formatIsoDate(new Date(today.getFullYear() - 1, 11, 31)),
+      };
+    case 'last_7_days':
+      return { start: formatIsoDate(addDays(today, -6)), end: formatIsoDate(today) };
+    case 'last_30_days':
+      return { start: formatIsoDate(addDays(today, -29)), end: formatIsoDate(today) };
+    case 'last_90_days':
+      return { start: formatIsoDate(addDays(today, -89)), end: formatIsoDate(today) };
+    case 'last_365_days':
+      return { start: formatIsoDate(addDays(today, -364)), end: formatIsoDate(today) };
+    default:
+      return undefined;
+  }
+}
+
+export function compileFilterDefinitionValue(
+  definition: FilterDefinition,
+  value: unknown,
+): QueryFilter | null {
+  if (value == null) {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    const values = value.filter((entry) => entry != null && entry !== '');
+    if (values.length === 0) {
+      return null;
+    }
+
+    return {
+      fieldId: definition.fieldRef,
+      operator: definition.operator === 'not_in' ? 'not_in' : 'in',
+      value: values,
+    };
+  }
+
+  if (isDateRangeLike(value)) {
+    return compileRangeLikeValue(definition.fieldRef, value);
+  }
+
+  if (typeof value === 'string' && value.length === 0) {
+    return null;
+  }
+
+  const operator = normalizeFilterOperator(definition.operator);
+  if (!operator) {
+    return null;
+  }
+
+  return {
+    fieldId: definition.fieldRef,
+    operator,
+    ...(operator === 'is_null' || operator === 'is_not_null' ? {} : { value }),
+  };
+}
+
+export function isDateRangeLike(value: unknown): value is DateRangeValue {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    ('start' in value || 'end' in value || 'min' in value || 'max' in value)
+  );
+}
+
+function compileRangeLikeValue(fieldId: string, value: DateRangeValue): QueryFilter | null {
+  const lower = value.start ?? value.min;
+  const upper = value.end ?? value.max;
+
+  if (lower == null && upper == null) {
+    return null;
+  }
+
+  if (lower != null && upper != null) {
+    return {
+      fieldId,
+      operator: 'between',
+      value: [lower, upper],
+    };
+  }
+
+  return {
+    fieldId,
+    operator: lower != null ? 'gte' : 'lte',
+    value: lower ?? upper,
+  };
+}
+
+function normalizeFilterOperator(operator: string): QueryFilterOperator | null {
+  if (DIRECT_QUERY_OPERATORS.has(operator as QueryFilterOperator)) {
+    return operator as QueryFilterOperator;
+  }
+
+  switch (operator) {
+    case 'equals':
+      return 'eq';
+    case 'not_equals':
+      return 'neq';
+    case 'contains':
+      return 'like';
+    case 'not_contains':
+      return 'not_like';
+    default:
+      return null;
+  }
+}

--- a/packages/runtime/src/filters/date-filter-utils.ts
+++ b/packages/runtime/src/filters/date-filter-utils.ts
@@ -1,24 +1,23 @@
 import type { QueryFilter, QueryFilterOperator } from '@supersubset/data-model';
-import type { DateFilterConfig, FilterDefinition } from '@supersubset/schema';
+import {
+  DATE_PRESETS,
+  generateWeeklyDateRangeOptions,
+  isDateRangeLike,
+  normalizeRangeBound,
+  resolveRelativeDate,
+  type DateRangeValue,
+  type WeeklyDateRangeOption,
+  type FilterDefinition,
+} from '@supersubset/schema';
 
-export const DATE_PRESETS: { value: string; label: string }[] = [
-  { value: '', label: 'All time' },
-  { value: 'today', label: 'Today' },
-  { value: 'yesterday', label: 'Yesterday' },
-  { value: 'this_week', label: 'This week' },
-  { value: 'last_week', label: 'Last week' },
-  { value: 'this_month', label: 'This month' },
-  { value: 'last_month', label: 'Last month' },
-  { value: 'this_quarter', label: 'This quarter' },
-  { value: 'last_quarter', label: 'Last quarter' },
-  { value: 'this_year', label: 'This year' },
-  { value: 'last_year', label: 'Last year' },
-  { value: 'last_7_days', label: 'Last 7 days' },
-  { value: 'last_30_days', label: 'Last 30 days' },
-  { value: 'last_90_days', label: 'Last 90 days' },
-  { value: 'last_365_days', label: 'Last 365 days' },
-  { value: 'custom', label: 'Custom range…' },
-];
+export {
+  DATE_PRESETS,
+  generateWeeklyDateRangeOptions,
+  isDateRangeLike,
+  resolveRelativeDate,
+  type DateRangeValue,
+  type WeeklyDateRangeOption,
+};
 
 const DIRECT_QUERY_OPERATORS = new Set<QueryFilterOperator>([
   'eq',
@@ -35,177 +34,6 @@ const DIRECT_QUERY_OPERATORS = new Set<QueryFilterOperator>([
   'is_not_null',
   'between',
 ]);
-
-export interface DateRangeValue {
-  preset?: string;
-  start?: string;
-  end?: string;
-  min?: number;
-  max?: number;
-}
-
-export interface WeeklyDateRangeOption {
-  value: string;
-  label: string;
-  start: string;
-  end: string;
-  offset: number;
-}
-
-function formatIsoDate(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
-
-function addDays(date: Date, days: number): Date {
-  const next = new Date(date);
-  next.setDate(next.getDate() + days);
-  return next;
-}
-
-function startOfLocalDay(date: Date): Date {
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
-}
-
-function clampWeekday(value: unknown): 0 | 1 | 2 | 3 | 4 | 5 | 6 {
-  return value === 0 ||
-    value === 1 ||
-    value === 2 ||
-    value === 3 ||
-    value === 4 ||
-    value === 5 ||
-    value === 6
-    ? value
-    : 0;
-}
-
-function coerceNonNegativeInteger(value: unknown, fallback: number): number {
-  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : fallback;
-}
-
-function startOfWeek(date: Date, weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6): Date {
-  const dayOffset = (date.getDay() - weekStartsOn + 7) % 7;
-  return addDays(date, -dayOffset);
-}
-
-function formatDateLabel(isoDate: string): string {
-  const [year, month, day] = isoDate.split('-').map(Number);
-  return new Date(year, month - 1, day).toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-  });
-}
-
-export function generateWeeklyDateRangeOptions(
-  config: DateFilterConfig | undefined,
-  now = new Date(),
-): WeeklyDateRangeOption[] {
-  const weekStartsOn = clampWeekday(config?.weekStartsOn);
-  const weeksBack = coerceNonNegativeInteger(config?.weeksBack, 4);
-  const weeksForward = coerceNonNegativeInteger(config?.weeksForward, 0);
-  const includeCurrentWeek = config?.includeCurrentWeek !== false;
-  const currentWeekStart = startOfWeek(startOfLocalDay(now), weekStartsOn);
-  const options: WeeklyDateRangeOption[] = [];
-
-  for (let offset = -weeksBack; offset <= weeksForward; offset += 1) {
-    if (!includeCurrentWeek && offset === 0) {
-      continue;
-    }
-
-    const start = addDays(currentWeekStart, offset * 7);
-    const end = addDays(start, 6);
-    const startIso = formatIsoDate(start);
-    const endIso = formatIsoDate(end);
-
-    options.push({
-      value: `week:${startIso}:${endIso}`,
-      label: `${formatDateLabel(startIso)} - ${formatDateLabel(endIso)}`,
-      start: startIso,
-      end: endIso,
-      offset,
-    });
-  }
-
-  return options;
-}
-
-/**
- * Resolve a relative date preset to a concrete { start, end } range.
- * Returns undefined for empty/unknown presets.
- */
-export function resolveRelativeDate(
-  preset: string,
-  now = new Date(),
-  config?: DateFilterConfig,
-): { start: string; end: string } | undefined {
-  const today = startOfLocalDay(now);
-  const weekStartsOn = clampWeekday(config?.weekStartsOn);
-
-  switch (preset) {
-    case 'today':
-      return { start: formatIsoDate(today), end: formatIsoDate(today) };
-    case 'yesterday': {
-      const d = addDays(today, -1);
-      return { start: formatIsoDate(d), end: formatIsoDate(d) };
-    }
-    case 'this_week': {
-      const start = startOfWeek(today, weekStartsOn);
-      const end = config?.mode === 'weekly' ? addDays(start, 6) : today;
-      return { start: formatIsoDate(start), end: formatIsoDate(end) };
-    }
-    case 'last_week': {
-      const currentStart = startOfWeek(today, weekStartsOn);
-      const start = addDays(currentStart, -7);
-      const end = addDays(currentStart, -1);
-      return { start: formatIsoDate(start), end: formatIsoDate(end) };
-    }
-    case 'this_month':
-      return {
-        start: formatIsoDate(new Date(today.getFullYear(), today.getMonth(), 1)),
-        end: formatIsoDate(today),
-      };
-    case 'last_month': {
-      const start = new Date(today.getFullYear(), today.getMonth() - 1, 1);
-      const end = new Date(today.getFullYear(), today.getMonth(), 0);
-      return { start: formatIsoDate(start), end: formatIsoDate(end) };
-    }
-    case 'this_quarter': {
-      const q = Math.floor(today.getMonth() / 3);
-      return {
-        start: formatIsoDate(new Date(today.getFullYear(), q * 3, 1)),
-        end: formatIsoDate(today),
-      };
-    }
-    case 'last_quarter': {
-      const q = Math.floor(today.getMonth() / 3);
-      const start = new Date(today.getFullYear(), (q - 1) * 3, 1);
-      const end = new Date(today.getFullYear(), q * 3, 0);
-      return { start: formatIsoDate(start), end: formatIsoDate(end) };
-    }
-    case 'this_year':
-      return {
-        start: formatIsoDate(new Date(today.getFullYear(), 0, 1)),
-        end: formatIsoDate(today),
-      };
-    case 'last_year':
-      return {
-        start: formatIsoDate(new Date(today.getFullYear() - 1, 0, 1)),
-        end: formatIsoDate(new Date(today.getFullYear() - 1, 11, 31)),
-      };
-    case 'last_7_days':
-      return { start: formatIsoDate(addDays(today, -6)), end: formatIsoDate(today) };
-    case 'last_30_days':
-      return { start: formatIsoDate(addDays(today, -29)), end: formatIsoDate(today) };
-    case 'last_90_days':
-      return { start: formatIsoDate(addDays(today, -89)), end: formatIsoDate(today) };
-    case 'last_365_days':
-      return { start: formatIsoDate(addDays(today, -364)), end: formatIsoDate(today) };
-    default:
-      return undefined;
-  }
-}
 
 export function compileFilterDefinitionValue(
   definition: FilterDefinition,
@@ -254,14 +82,6 @@ export function compileFilterDefinitionValue(
   };
 }
 
-export function isDateRangeLike(value: unknown): value is DateRangeValue {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    ('start' in value || 'end' in value || 'min' in value || 'max' in value)
-  );
-}
-
 function isDatePresetValue(value: unknown): value is { preset: string } {
   if (typeof value !== 'object' || value === null || !('preset' in value)) {
     return false;
@@ -291,16 +111,6 @@ function compileRangeLikeValue(fieldId: string, value: DateRangeValue): QueryFil
     operator: lower != null ? 'gte' : 'lte',
     value: lower ?? upper,
   };
-}
-
-function normalizeRangeBound(
-  value: DateRangeValue['start'] | DateRangeValue['min'],
-): string | number | undefined {
-  if (value === '') {
-    return undefined;
-  }
-
-  return value;
 }
 
 function normalizeFilterOperator(operator: string): QueryFilterOperator | null {

--- a/packages/runtime/src/filters/date-filter-utils.ts
+++ b/packages/runtime/src/filters/date-filter-utils.ts
@@ -152,7 +152,8 @@ export function resolveRelativeDate(
     }
     case 'this_week': {
       const start = startOfWeek(today, weekStartsOn);
-      return { start: formatIsoDate(start), end: formatIsoDate(today) };
+      const end = config?.mode === 'weekly' ? addDays(start, 6) : today;
+      return { start: formatIsoDate(start), end: formatIsoDate(end) };
     }
     case 'last_week': {
       const currentStart = startOfWeek(today, weekStartsOn);
@@ -231,6 +232,12 @@ export function compileFilterDefinitionValue(
     return compileRangeLikeValue(definition.fieldRef, value);
   }
 
+  if (isDatePresetValue(value)) {
+    const resolved = resolveRelativeDate(value.preset, new Date(), definition.dateConfig);
+
+    return resolved ? compileRangeLikeValue(definition.fieldRef, resolved) : null;
+  }
+
   if (typeof value === 'string' && value.length === 0) {
     return null;
   }
@@ -255,9 +262,17 @@ export function isDateRangeLike(value: unknown): value is DateRangeValue {
   );
 }
 
+function isDatePresetValue(value: unknown): value is { preset: string } {
+  if (typeof value !== 'object' || value === null || !('preset' in value)) {
+    return false;
+  }
+
+  return typeof (value as { preset?: unknown }).preset === 'string';
+}
+
 function compileRangeLikeValue(fieldId: string, value: DateRangeValue): QueryFilter | null {
-  const lower = value.start ?? value.min;
-  const upper = value.end ?? value.max;
+  const lower = normalizeRangeBound(value.start ?? value.min);
+  const upper = normalizeRangeBound(value.end ?? value.max);
 
   if (lower == null && upper == null) {
     return null;
@@ -276,6 +291,16 @@ function compileRangeLikeValue(fieldId: string, value: DateRangeValue): QueryFil
     operator: lower != null ? 'gte' : 'lte',
     value: lower ?? upper,
   };
+}
+
+function normalizeRangeBound(
+  value: DateRangeValue['start'] | DateRangeValue['min'],
+): string | number | undefined {
+  if (value === '') {
+    return undefined;
+  }
+
+  return value;
 }
 
 function normalizeFilterOperator(operator: string): QueryFilterOperator | null {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -7,12 +7,17 @@ export {
 } from './components/SupersubsetRenderer';
 
 // FilterBar component
+export { FilterBar, type FilterBarProps } from './components/FilterBar';
+
 export {
-  FilterBar,
-  type FilterBarProps,
   DATE_PRESETS,
+  compileFilterDefinitionValue,
+  generateWeeklyDateRangeOptions,
+  isDateRangeLike,
   resolveRelativeDate,
-} from './components/FilterBar';
+  type DateRangeValue,
+  type WeeklyDateRangeOption,
+} from './filters/date-filter-utils';
 
 // DrillBreadcrumbBar component
 export { DrillBreadcrumbBar } from './components/DrillBreadcrumbBar';

--- a/packages/runtime/src/layout/render-query-helpers.ts
+++ b/packages/runtime/src/layout/render-query-helpers.ts
@@ -1,13 +1,13 @@
 import type { AggregationType, LogicalQuery, QueryResult } from '@supersubset/data-model';
 import {
   structuredAlertRuleSchema,
+  type FilterDefinition,
   type StructuredAlertRuleDefinition,
   type WidgetDefinition,
-  type FilterDefinition,
 } from '@supersubset/schema';
 import type { WidgetProps } from '../widgets/registry';
 import { filterAppliesToWidget, type FilterValue } from '../filters/FilterEngine';
-import { compileFilterDefinitionValue, isDateRangeLike } from '../filters/date-filter-utils';
+import { compileFilterDefinitionValue } from '../filters/date-filter-utils';
 import { resolveDataBindingConfig } from './widget-config';
 
 export interface QueryDataState {
@@ -324,65 +324,16 @@ function compileCrossFilterValue(
   fieldRef: string,
   value: unknown,
 ): NonNullable<LogicalQuery['filters']>[number] | null {
-  if (value == null) {
-    return null;
-  }
-
-  if (Array.isArray(value)) {
-    const values = value.filter((entry) => entry != null && entry !== '');
-    if (values.length === 0) {
-      return null;
-    }
-
-    return {
-      fieldId: fieldRef,
-      operator: 'in',
-      value: values,
-    };
-  }
-
-  if (isDateRangeLike(value)) {
-    const lower = normalizeCrossFilterRangeBound(value.start ?? value.min);
-    const upper = normalizeCrossFilterRangeBound(value.end ?? value.max);
-
-    if (lower == null && upper == null) {
-      return null;
-    }
-
-    if (lower != null && upper != null) {
-      return {
-        fieldId: fieldRef,
-        operator: 'between',
-        value: [lower, upper],
-      };
-    }
-
-    return {
-      fieldId: fieldRef,
-      operator: lower != null ? 'gte' : 'lte',
-      value: lower ?? upper,
-    };
-  }
-
-  if (typeof value === 'string' && value.length === 0) {
-    return null;
-  }
-
-  return {
-    fieldId: fieldRef,
-    operator: 'eq',
-    value,
+  const syntheticDefinition: FilterDefinition = {
+    id: `cross-filter:${fieldRef}`,
+    type: 'cross-filter',
+    datasetRef: '__cross_filter__',
+    fieldRef,
+    operator: 'equals',
+    scope: { type: 'global' },
   };
-}
 
-function normalizeCrossFilterRangeBound(
-  value: string | number | undefined,
-): string | number | undefined {
-  if (value === '') {
-    return undefined;
-  }
-
-  return value;
+  return compileFilterDefinitionValue(syntheticDefinition, value);
 }
 
 function normalizeAggregation(value: string | undefined): AggregationType | undefined {

--- a/packages/runtime/src/layout/render-query-helpers.ts
+++ b/packages/runtime/src/layout/render-query-helpers.ts
@@ -1,9 +1,4 @@
-import type {
-  AggregationType,
-  LogicalQuery,
-  QueryFilterOperator,
-  QueryResult,
-} from '@supersubset/data-model';
+import type { AggregationType, LogicalQuery, QueryResult } from '@supersubset/data-model';
 import {
   structuredAlertRuleSchema,
   type StructuredAlertRuleDefinition,
@@ -12,28 +7,13 @@ import {
 } from '@supersubset/schema';
 import type { WidgetProps } from '../widgets/registry';
 import { filterAppliesToWidget, type FilterValue } from '../filters/FilterEngine';
+import { compileFilterDefinitionValue, isDateRangeLike } from '../filters/date-filter-utils';
 import { resolveDataBindingConfig } from './widget-config';
 
 export interface QueryDataState {
   data?: Record<string, unknown>[];
   columns?: WidgetProps['columns'];
 }
-
-const DIRECT_QUERY_OPERATORS = new Set<QueryFilterOperator>([
-  'eq',
-  'neq',
-  'gt',
-  'gte',
-  'lt',
-  'lte',
-  'in',
-  'not_in',
-  'like',
-  'not_like',
-  'is_null',
-  'is_not_null',
-  'between',
-]);
 
 const VALID_AGGREGATIONS = new Set<AggregationType>([
   'sum',
@@ -326,7 +306,7 @@ function compileActiveFiltersForQuery(
         return [];
       }
 
-      const compiledFilter = compileFilterValue(definition, activeFilter.value);
+      const compiledFilter = compileFilterDefinitionValue(definition, activeFilter.value);
       return compiledFilter ? [compiledFilter] : [];
     }
 
@@ -338,58 +318,6 @@ function compileActiveFiltersForQuery(
     const compiledFilter = compileCrossFilterValue(crossFilter.fieldRef, activeFilter.value);
     return compiledFilter ? [compiledFilter] : [];
   });
-}
-
-function compileFilterValue(
-  definition: FilterDefinition,
-  value: unknown,
-): NonNullable<LogicalQuery['filters']>[number] | null {
-  if (value == null) {
-    return null;
-  }
-
-  if (Array.isArray(value)) {
-    const values = value.filter((entry) => entry != null && entry !== '');
-    if (values.length === 0) {
-      return null;
-    }
-
-    return {
-      fieldId: definition.fieldRef,
-      operator: definition.operator === 'not_in' ? 'not_in' : 'in',
-      value: values,
-    };
-  }
-
-  if (isBetweenValue(value)) {
-    const lower = value.start ?? value.min;
-    const upper = value.end ?? value.max;
-
-    if (lower == null && upper == null) {
-      return null;
-    }
-
-    return {
-      fieldId: definition.fieldRef,
-      operator: 'between',
-      value: [lower, upper],
-    };
-  }
-
-  if (typeof value === 'string' && value.length === 0) {
-    return null;
-  }
-
-  const operator = normalizeFilterOperator(definition.operator);
-  if (!operator) {
-    return null;
-  }
-
-  return {
-    fieldId: definition.fieldRef,
-    operator,
-    value,
-  };
 }
 
 function compileCrossFilterValue(
@@ -413,7 +341,7 @@ function compileCrossFilterValue(
     };
   }
 
-  if (isBetweenValue(value)) {
+  if (isDateRangeLike(value)) {
     const lower = value.start ?? value.min;
     const upper = value.end ?? value.max;
 
@@ -439,37 +367,12 @@ function compileCrossFilterValue(
   };
 }
 
-function normalizeFilterOperator(operator: string): QueryFilterOperator | null {
-  if (DIRECT_QUERY_OPERATORS.has(operator as QueryFilterOperator)) {
-    return operator as QueryFilterOperator;
-  }
-
-  switch (operator) {
-    case 'equals':
-      return 'eq';
-    case 'contains':
-      return 'like';
-    default:
-      return null;
-  }
-}
-
 function normalizeAggregation(value: string | undefined): AggregationType | undefined {
   if (!value || !VALID_AGGREGATIONS.has(value as AggregationType) || value === 'none') {
     return undefined;
   }
 
   return value as AggregationType;
-}
-
-function isBetweenValue(
-  value: unknown,
-): value is { start?: string; end?: string; min?: number; max?: number } {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    ('start' in value || 'end' in value || 'min' in value || 'max' in value)
-  );
 }
 
 function parseCrossFilterId(filterId: string): { sourceWidgetId: string; fieldRef: string } | null {

--- a/packages/runtime/src/layout/render-query-helpers.ts
+++ b/packages/runtime/src/layout/render-query-helpers.ts
@@ -342,17 +342,25 @@ function compileCrossFilterValue(
   }
 
   if (isDateRangeLike(value)) {
-    const lower = value.start ?? value.min;
-    const upper = value.end ?? value.max;
+    const lower = normalizeCrossFilterRangeBound(value.start ?? value.min);
+    const upper = normalizeCrossFilterRangeBound(value.end ?? value.max);
 
     if (lower == null && upper == null) {
       return null;
     }
 
+    if (lower != null && upper != null) {
+      return {
+        fieldId: fieldRef,
+        operator: 'between',
+        value: [lower, upper],
+      };
+    }
+
     return {
       fieldId: fieldRef,
-      operator: 'between',
-      value: [lower, upper],
+      operator: lower != null ? 'gte' : 'lte',
+      value: lower ?? upper,
     };
   }
 
@@ -365,6 +373,16 @@ function compileCrossFilterValue(
     operator: 'eq',
     value,
   };
+}
+
+function normalizeCrossFilterRangeBound(
+  value: string | number | undefined,
+): string | number | undefined {
+  if (value === '') {
+    return undefined;
+  }
+
+  return value;
 }
 
 function normalizeAggregation(value: string | undefined): AggregationType | undefined {

--- a/packages/runtime/test/filter-bar.test.tsx
+++ b/packages/runtime/test/filter-bar.test.tsx
@@ -7,6 +7,7 @@ import type { FilterDefinition } from '@supersubset/schema';
 import {
   compileFilterDefinitionValue,
   generateWeeklyDateRangeOptions,
+  isDateRangeLike,
 } from '../src/filters/date-filter-utils';
 
 // Helper: render FilterBar within FilterProvider
@@ -540,6 +541,13 @@ describe('FilterBar', () => {
     );
 
     expect(compileFilterDefinitionValue(rangeDateFilter, { start: '', end: '' })).toBeNull();
+  });
+
+  it('[filters-and-interactions.FILTER_BAR.4] only treats valid range-shaped objects as date ranges', () => {
+    expect(isDateRangeLike({ start: '2026-05-05', end: '' })).toBe(true);
+    expect(isDateRangeLike({ min: 10, max: 20 })).toBe(true);
+    expect(isDateRangeLike({ start: 'open' })).toBe(false);
+    expect(isDateRangeLike({ min: '10' })).toBe(false);
   });
 
   it('calls setFilter via onFilterChange when text is typed', () => {

--- a/packages/runtime/test/filter-bar.test.tsx
+++ b/packages/runtime/test/filter-bar.test.tsx
@@ -475,6 +475,29 @@ describe('FilterBar', () => {
     });
   });
 
+  it('[filters-and-interactions.FILTER_BAR.5] respects relative weekly defaults', () => {
+    const currentWeek = generateWeeklyDateRangeOptions(weeklyDateFilter.dateConfig).find(
+      (option) => option.offset === 0,
+    );
+
+    expect(currentWeek).toBeDefined();
+    if (!currentWeek) {
+      throw new Error('Expected the weekly filter to include the current week');
+    }
+
+    const { container } = renderFilterBar([weeklyDateFilter], {
+      initialValues: { 'f-week': { preset: 'this_week' } },
+    });
+    const select = container.querySelector('.ss-filter-date-preset') as HTMLSelectElement;
+
+    expect(select.value).toBe(currentWeek.value);
+    expect(compileFilterDefinitionValue(weeklyDateFilter, { preset: 'this_week' })).toEqual({
+      fieldId: 'created_at',
+      operator: 'between',
+      value: [currentWeek.start, currentWeek.end],
+    });
+  });
+
   it('[filters-and-interactions.FILTER_BAR.4] renders range-mode date filters as date inputs without a preset dropdown', () => {
     const onFilterChange = vi.fn();
     const { container } = renderFilterBar([rangeDateFilter], { onFilterChange });
@@ -497,6 +520,26 @@ describe('FilterBar', () => {
       operator: 'between',
       value: ['2026-05-01', '2026-05-31'],
     });
+  });
+
+  it('[filters-and-interactions.FILTER_BAR.4] compiles partial date ranges as one-sided filters', () => {
+    expect(compileFilterDefinitionValue(rangeDateFilter, { start: '2026-05-05', end: '' })).toEqual(
+      {
+        fieldId: 'created_at',
+        operator: 'gte',
+        value: '2026-05-05',
+      },
+    );
+
+    expect(compileFilterDefinitionValue(rangeDateFilter, { start: '', end: '2026-05-31' })).toEqual(
+      {
+        fieldId: 'created_at',
+        operator: 'lte',
+        value: '2026-05-31',
+      },
+    );
+
+    expect(compileFilterDefinitionValue(rangeDateFilter, { start: '', end: '' })).toBeNull();
   });
 
   it('calls setFilter via onFilterChange when text is typed', () => {

--- a/packages/runtime/test/filter-bar.test.tsx
+++ b/packages/runtime/test/filter-bar.test.tsx
@@ -4,6 +4,10 @@ import type { QueryAdapter } from '@supersubset/data-model';
 import { FilterBar } from '../src/components/FilterBar';
 import { FilterProvider } from '../src/filters/FilterEngine';
 import type { FilterDefinition } from '@supersubset/schema';
+import {
+  compileFilterDefinitionValue,
+  generateWeeklyDateRangeOptions,
+} from '../src/filters/date-filter-utils';
 
 // Helper: render FilterBar within FilterProvider
 function renderFilterBar(
@@ -76,6 +80,31 @@ const dateFilter: FilterDefinition = {
   datasetRef: 'ds-1',
   operator: 'gte',
   scope: { type: 'page', pageId: 'page-1' },
+};
+
+const weeklyDateFilter: FilterDefinition = {
+  ...dateFilter,
+  id: 'f-week',
+  title: 'Week',
+  operator: 'between',
+  dateConfig: {
+    mode: 'weekly',
+    weekStartsOn: 1,
+    weeksBack: 1,
+    weeksForward: 1,
+    includeCurrentWeek: true,
+  },
+};
+
+const rangeDateFilter: FilterDefinition = {
+  ...dateFilter,
+  id: 'f-date-range',
+  title: 'Created range',
+  operator: 'between',
+  dateConfig: {
+    mode: 'range',
+    allowCustomRange: true,
+  },
 };
 
 const multiSelectFilter: FilterDefinition = {
@@ -394,6 +423,80 @@ describe('FilterBar', () => {
     expect(options!.length).toBeGreaterThan(5);
     // First option is "All time"
     expect(options![0].textContent).toBe('All time');
+  });
+
+  it('[filters-and-interactions.FILTER_BAR.5] renders authored weekly date range options', () => {
+    const options = generateWeeklyDateRangeOptions(
+      weeklyDateFilter.dateConfig,
+      new Date(2026, 4, 28),
+    );
+
+    expect(options).toEqual([
+      expect.objectContaining({ start: '2026-05-18', end: '2026-05-24', offset: -1 }),
+      expect.objectContaining({ start: '2026-05-25', end: '2026-05-31', offset: 0 }),
+      expect.objectContaining({ start: '2026-06-01', end: '2026-06-07', offset: 1 }),
+    ]);
+
+    const { container } = renderFilterBar([weeklyDateFilter]);
+    const select = container.querySelector('.ss-filter-date-preset') as HTMLSelectElement;
+    const labels = Array.from(select.querySelectorAll('option')).map(
+      (option) => option.textContent,
+    );
+
+    expect(labels[0]).toBe('All time');
+    expect(labels).toContain('May 25 - May 31');
+  });
+
+  it('[filters-and-interactions.FILTER_BAR.5] emits weekly range values that compile to logical query ranges', () => {
+    const onFilterChange = vi.fn();
+    const { container } = renderFilterBar([weeklyDateFilter], { onFilterChange });
+    const select = container.querySelector('.ss-filter-date-preset') as HTMLSelectElement;
+    const firstWeeklyValue = Array.from(select.options).find((option) =>
+      option.value.startsWith('week:'),
+    )?.value;
+
+    expect(firstWeeklyValue).toBeTruthy();
+    fireEvent.change(select, { target: { value: firstWeeklyValue } });
+
+    const lastCall = onFilterChange.mock.calls[onFilterChange.mock.calls.length - 1][0];
+    const filterValue = lastCall.values['f-week'];
+
+    expect(filterValue).toEqual(
+      expect.objectContaining({
+        preset: firstWeeklyValue,
+        start: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        end: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      }),
+    );
+    expect(compileFilterDefinitionValue(weeklyDateFilter, filterValue)).toEqual({
+      fieldId: 'created_at',
+      operator: 'between',
+      value: [filterValue.start, filterValue.end],
+    });
+  });
+
+  it('[filters-and-interactions.FILTER_BAR.4] renders range-mode date filters as date inputs without a preset dropdown', () => {
+    const onFilterChange = vi.fn();
+    const { container } = renderFilterBar([rangeDateFilter], { onFilterChange });
+
+    expect(container.querySelector('.ss-filter-date-preset')).toBeNull();
+
+    const startInput = container.querySelector(
+      'input[name="f-date-range-start"]',
+    ) as HTMLInputElement;
+    const endInput = container.querySelector('input[name="f-date-range-end"]') as HTMLInputElement;
+    expect(startInput?.type).toBe('date');
+    expect(endInput?.type).toBe('date');
+
+    fireEvent.change(startInput, { target: { value: '2026-05-01' } });
+    fireEvent.change(endInput, { target: { value: '2026-05-31' } });
+
+    const lastCall = onFilterChange.mock.calls[onFilterChange.mock.calls.length - 1][0];
+    expect(compileFilterDefinitionValue(rangeDateFilter, lastCall.values['f-date-range'])).toEqual({
+      fieldId: 'created_at',
+      operator: 'between',
+      value: ['2026-05-01', '2026-05-31'],
+    });
   });
 
   it('calls setFilter via onFilterChange when text is typed', () => {

--- a/packages/runtime/test/filter-bar.test.tsx
+++ b/packages/runtime/test/filter-bar.test.tsx
@@ -545,6 +545,7 @@ describe('FilterBar', () => {
 
   it('[filters-and-interactions.FILTER_BAR.4] only treats valid range-shaped objects as date ranges', () => {
     expect(isDateRangeLike({ start: '2026-05-05', end: '' })).toBe(true);
+    expect(isDateRangeLike({ start: 10, end: 20 })).toBe(true);
     expect(isDateRangeLike({ min: 10, max: 20 })).toBe(true);
     expect(isDateRangeLike({ start: 'open' })).toBe(false);
     expect(isDateRangeLike({ min: '10' })).toBe(false);

--- a/packages/runtime/test/layout.test.tsx
+++ b/packages/runtime/test/layout.test.tsx
@@ -548,6 +548,10 @@ describe('LayoutRenderer', () => {
             filterId: 'created-at',
             value: { start: '2024-01-01', end: '2024-01-31' },
           },
+          {
+            filterId: 'cross-filter:chart-1:amount',
+            value: { start: 1, end: 10 },
+          },
           { filterId: 'other-page-region', value: 'APAC' },
           { filterId: 'customer-region', value: 'France' },
         ]}
@@ -579,6 +583,11 @@ describe('LayoutRenderer', () => {
             fieldId: 'created_at',
             operator: 'between',
             value: ['2024-01-01', '2024-01-31'],
+          },
+          {
+            fieldId: 'amount',
+            operator: 'between',
+            value: [1, 10],
           },
         ],
       });

--- a/packages/schema/src/date-utils.ts
+++ b/packages/schema/src/date-utils.ts
@@ -21,8 +21,8 @@ export const DATE_PRESETS: { value: string; label: string }[] = [
 
 export interface DateRangeValue {
   preset?: string;
-  start?: string;
-  end?: string;
+  start?: string | number;
+  end?: string | number;
   min?: number;
   max?: number;
 }
@@ -222,7 +222,10 @@ function isValidRangeBound(key: string, value: unknown): boolean {
     return typeof value === 'number' && Number.isFinite(value);
   }
 
-  return typeof value === 'string' && DATE_BOUND_PATTERN.test(value);
+  return (
+    (typeof value === 'number' && Number.isFinite(value)) ||
+    (typeof value === 'string' && DATE_BOUND_PATTERN.test(value))
+  );
 }
 
 export function normalizeRangeBound(

--- a/packages/schema/src/date-utils.ts
+++ b/packages/schema/src/date-utils.ts
@@ -1,0 +1,236 @@
+import type { DateFilterConfig } from './types';
+
+export const DATE_PRESETS: { value: string; label: string }[] = [
+  { value: '', label: 'All time' },
+  { value: 'today', label: 'Today' },
+  { value: 'yesterday', label: 'Yesterday' },
+  { value: 'this_week', label: 'This week' },
+  { value: 'last_week', label: 'Last week' },
+  { value: 'this_month', label: 'This month' },
+  { value: 'last_month', label: 'Last month' },
+  { value: 'this_quarter', label: 'This quarter' },
+  { value: 'last_quarter', label: 'Last quarter' },
+  { value: 'this_year', label: 'This year' },
+  { value: 'last_year', label: 'Last year' },
+  { value: 'last_7_days', label: 'Last 7 days' },
+  { value: 'last_30_days', label: 'Last 30 days' },
+  { value: 'last_90_days', label: 'Last 90 days' },
+  { value: 'last_365_days', label: 'Last 365 days' },
+  { value: 'custom', label: 'Custom range…' },
+];
+
+export interface DateRangeValue {
+  preset?: string;
+  start?: string;
+  end?: string;
+  min?: number;
+  max?: number;
+}
+
+export interface WeeklyDateRangeOption {
+  value: string;
+  label: string;
+  start: string;
+  end: string;
+  offset: number;
+}
+
+const DATE_BOUND_PATTERN = /^\d{4}-\d{2}-\d{2}(?:$|[T\s])/;
+
+export function formatIsoDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+export function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+export function clampWeekday(value: unknown): 0 | 1 | 2 | 3 | 4 | 5 | 6 {
+  return value === 0 ||
+    value === 1 ||
+    value === 2 ||
+    value === 3 ||
+    value === 4 ||
+    value === 5 ||
+    value === 6
+    ? value
+    : 0;
+}
+
+export function coerceNonNegativeInteger(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : fallback;
+}
+
+export function startOfWeek(date: Date, weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6): Date {
+  const dayOffset = (date.getDay() - weekStartsOn + 7) % 7;
+  return addDays(date, -dayOffset);
+}
+
+function formatDateLabel(isoDate: string): string {
+  const [year, month, day] = isoDate.split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function generateWeeklyDateRangeOptions(
+  config: DateFilterConfig | undefined,
+  now = new Date(),
+): WeeklyDateRangeOption[] {
+  const weekStartsOn = clampWeekday(config?.weekStartsOn);
+  const weeksBack = coerceNonNegativeInteger(config?.weeksBack, 4);
+  const weeksForward = coerceNonNegativeInteger(config?.weeksForward, 0);
+  const includeCurrentWeek = config?.includeCurrentWeek !== false;
+  const currentWeekStart = startOfWeek(startOfLocalDay(now), weekStartsOn);
+  const options: WeeklyDateRangeOption[] = [];
+
+  for (let offset = -weeksBack; offset <= weeksForward; offset += 1) {
+    if (!includeCurrentWeek && offset === 0) {
+      continue;
+    }
+
+    const start = addDays(currentWeekStart, offset * 7);
+    const end = addDays(start, 6);
+    const startIso = formatIsoDate(start);
+    const endIso = formatIsoDate(end);
+
+    options.push({
+      value: `week:${startIso}:${endIso}`,
+      label: `${formatDateLabel(startIso)} - ${formatDateLabel(endIso)}`,
+      start: startIso,
+      end: endIso,
+      offset,
+    });
+  }
+
+  return options;
+}
+
+/**
+ * Resolve a relative date preset to a concrete { start, end } range.
+ * Returns undefined for empty/unknown presets.
+ */
+export function resolveRelativeDate(
+  preset: string,
+  now = new Date(),
+  config?: DateFilterConfig,
+): { start: string; end: string } | undefined {
+  const today = startOfLocalDay(now);
+  const weekStartsOn = clampWeekday(config?.weekStartsOn);
+
+  switch (preset) {
+    case 'today':
+      return { start: formatIsoDate(today), end: formatIsoDate(today) };
+    case 'yesterday': {
+      const d = addDays(today, -1);
+      return { start: formatIsoDate(d), end: formatIsoDate(d) };
+    }
+    case 'this_week': {
+      const start = startOfWeek(today, weekStartsOn);
+      const end = config?.mode === 'weekly' ? addDays(start, 6) : today;
+      return { start: formatIsoDate(start), end: formatIsoDate(end) };
+    }
+    case 'last_week': {
+      const currentStart = startOfWeek(today, weekStartsOn);
+      const start = addDays(currentStart, -7);
+      const end = addDays(currentStart, -1);
+      return { start: formatIsoDate(start), end: formatIsoDate(end) };
+    }
+    case 'this_month':
+      return {
+        start: formatIsoDate(new Date(today.getFullYear(), today.getMonth(), 1)),
+        end: formatIsoDate(today),
+      };
+    case 'last_month': {
+      const start = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+      const end = new Date(today.getFullYear(), today.getMonth(), 0);
+      return { start: formatIsoDate(start), end: formatIsoDate(end) };
+    }
+    case 'this_quarter': {
+      const q = Math.floor(today.getMonth() / 3);
+      return {
+        start: formatIsoDate(new Date(today.getFullYear(), q * 3, 1)),
+        end: formatIsoDate(today),
+      };
+    }
+    case 'last_quarter': {
+      const q = Math.floor(today.getMonth() / 3);
+      const start = new Date(today.getFullYear(), (q - 1) * 3, 1);
+      const end = new Date(today.getFullYear(), q * 3, 0);
+      return { start: formatIsoDate(start), end: formatIsoDate(end) };
+    }
+    case 'this_year':
+      return {
+        start: formatIsoDate(new Date(today.getFullYear(), 0, 1)),
+        end: formatIsoDate(today),
+      };
+    case 'last_year':
+      return {
+        start: formatIsoDate(new Date(today.getFullYear() - 1, 0, 1)),
+        end: formatIsoDate(new Date(today.getFullYear() - 1, 11, 31)),
+      };
+    case 'last_7_days':
+      return { start: formatIsoDate(addDays(today, -6)), end: formatIsoDate(today) };
+    case 'last_30_days':
+      return { start: formatIsoDate(addDays(today, -29)), end: formatIsoDate(today) };
+    case 'last_90_days':
+      return { start: formatIsoDate(addDays(today, -89)), end: formatIsoDate(today) };
+    case 'last_365_days':
+      return { start: formatIsoDate(addDays(today, -364)), end: formatIsoDate(today) };
+    default:
+      return undefined;
+  }
+}
+
+export function isRangeLikeValue(value: unknown): value is DateRangeValue {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const presentKeys = ['start', 'end', 'min', 'max'].filter((key) => key in candidate);
+
+  return (
+    presentKeys.length > 0 && presentKeys.every((key) => isValidRangeBound(key, candidate[key]))
+  );
+}
+
+/**
+ * Backwards-compatible alias for the original public runtime helper.
+ * Prefer isRangeLikeValue for new code.
+ */
+export function isDateRangeLike(value: unknown): value is DateRangeValue {
+  return isRangeLikeValue(value);
+}
+
+function isValidRangeBound(key: string, value: unknown): boolean {
+  if (value == null || value === '') {
+    return true;
+  }
+
+  if (key === 'min' || key === 'max') {
+    return typeof value === 'number' && Number.isFinite(value);
+  }
+
+  return typeof value === 'string' && DATE_BOUND_PATTERN.test(value);
+}
+
+export function normalizeRangeBound(
+  value: DateRangeValue['start'] | DateRangeValue['min'],
+): string | number | undefined {
+  if (value === '') {
+    return undefined;
+  }
+
+  return value;
+}

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -2,4 +2,9 @@ export * from './types';
 export * from './validation';
 export * from './serializers';
 export * from './json-schema';
-export { CURRENT_SCHEMA_VERSION, migrateDashboardDefinition, isSupportedSchemaVersion } from './migrations';
+export * from './date-utils';
+export {
+  CURRENT_SCHEMA_VERSION,
+  migrateDashboardDefinition,
+  isSupportedSchemaVersion,
+} from './migrations';

--- a/packages/schema/src/types/dashboard.ts
+++ b/packages/schema/src/types/dashboard.ts
@@ -212,8 +212,20 @@ export interface FilterDefinition {
   datasetRef: string;
   operator: string;
   defaultValue?: unknown;
+  dateConfig?: DateFilterConfig;
   optionSource?: FilterOptionSource;
   scope: FilterScope;
+}
+
+export interface DateFilterConfig {
+  mode?: 'range' | 'preset' | 'weekly';
+  presets?: string[];
+  defaultPreset?: string;
+  allowCustomRange?: boolean;
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  weeksBack?: number;
+  weeksForward?: number;
+  includeCurrentWeek?: boolean;
 }
 
 export interface FilterOptionDefinition {

--- a/packages/schema/src/types/dashboard.ts
+++ b/packages/schema/src/types/dashboard.ts
@@ -220,7 +220,6 @@ export interface FilterDefinition {
 export interface DateFilterConfig {
   mode?: 'range' | 'preset' | 'weekly';
   presets?: string[];
-  defaultPreset?: string;
   allowCustomRange?: boolean;
   weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   weeksBack?: number;

--- a/packages/schema/src/validation/dashboard.ts
+++ b/packages/schema/src/validation/dashboard.ts
@@ -140,6 +140,27 @@ const filterOptionSourceSchema = z.discriminatedUnion('kind', [
   }),
 ]);
 
+const dateFilterConfigSchema = z.object({
+  mode: z.enum(['range', 'preset', 'weekly']).optional(),
+  presets: z.array(z.string().min(1)).optional(),
+  defaultPreset: z.string().min(1).optional(),
+  allowCustomRange: z.boolean().optional(),
+  weekStartsOn: z
+    .union([
+      z.literal(0),
+      z.literal(1),
+      z.literal(2),
+      z.literal(3),
+      z.literal(4),
+      z.literal(5),
+      z.literal(6),
+    ])
+    .optional(),
+  weeksBack: z.number().int().min(0).optional(),
+  weeksForward: z.number().int().min(0).optional(),
+  includeCurrentWeek: z.boolean().optional(),
+});
+
 const filterDefinitionSchema = z.object({
   id: z.string().min(1),
   title: z.string().optional(),
@@ -148,6 +169,7 @@ const filterDefinitionSchema = z.object({
   datasetRef: z.string().min(1),
   operator: z.string().min(1),
   defaultValue: z.unknown().optional(),
+  dateConfig: dateFilterConfigSchema.optional(),
   optionSource: filterOptionSourceSchema.optional(),
   scope: filterScopeSchema,
 });
@@ -405,6 +427,7 @@ export {
   dataBindingSchema,
   fieldBindingSchema,
   filterDefinitionSchema,
+  dateFilterConfigSchema,
   filterOptionDefinitionSchema,
   filterOptionSourceSchema,
   filterScopeSchema,

--- a/packages/schema/src/validation/dashboard.ts
+++ b/packages/schema/src/validation/dashboard.ts
@@ -148,7 +148,6 @@ const dateFilterConfigSchema = z
   .object({
     mode: z.enum(['range', 'preset', 'weekly']).optional(),
     presets: z.array(z.string().min(1)).optional(),
-    defaultPreset: z.string().min(1).optional(),
     allowCustomRange: z.boolean().optional(),
     weekStartsOn: z
       .union([
@@ -175,22 +174,6 @@ const dateFilterConfigSchema = z
         });
       }
     });
-
-    if (config.defaultPreset && !KNOWN_DATE_PRESET_VALUES.has(config.defaultPreset)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['defaultPreset'],
-        message: `Unknown default date preset: ${config.defaultPreset}`,
-      });
-    }
-
-    if (config.defaultPreset && config.presets && !config.presets.includes(config.defaultPreset)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['defaultPreset'],
-        message: 'defaultPreset must be included in presets when presets is set',
-      });
-    }
 
     if (config.mode === 'weekly' && generateWeeklyDateRangeOptions(config).length === 0) {
       ctx.addIssue({

--- a/packages/schema/src/validation/dashboard.ts
+++ b/packages/schema/src/validation/dashboard.ts
@@ -1,8 +1,12 @@
 import { z } from 'zod';
+import { DATE_PRESETS, generateWeeklyDateRangeOptions } from '../date-utils';
 import { VALID_CHILDREN } from '../types/dashboard';
 import type { LayoutComponentType } from '../types/dashboard';
 
 const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const KNOWN_DATE_PRESET_VALUES = new Set(
+  DATE_PRESETS.map((preset) => preset.value).filter((value) => value.length > 0),
+);
 
 function safeRecord<V extends z.ZodTypeAny>(valueSchema: V) {
   return z.record(z.string(), valueSchema).transform((obj) => {
@@ -140,26 +144,62 @@ const filterOptionSourceSchema = z.discriminatedUnion('kind', [
   }),
 ]);
 
-const dateFilterConfigSchema = z.object({
-  mode: z.enum(['range', 'preset', 'weekly']).optional(),
-  presets: z.array(z.string().min(1)).optional(),
-  defaultPreset: z.string().min(1).optional(),
-  allowCustomRange: z.boolean().optional(),
-  weekStartsOn: z
-    .union([
-      z.literal(0),
-      z.literal(1),
-      z.literal(2),
-      z.literal(3),
-      z.literal(4),
-      z.literal(5),
-      z.literal(6),
-    ])
-    .optional(),
-  weeksBack: z.number().int().min(0).optional(),
-  weeksForward: z.number().int().min(0).optional(),
-  includeCurrentWeek: z.boolean().optional(),
-});
+const dateFilterConfigSchema = z
+  .object({
+    mode: z.enum(['range', 'preset', 'weekly']).optional(),
+    presets: z.array(z.string().min(1)).optional(),
+    defaultPreset: z.string().min(1).optional(),
+    allowCustomRange: z.boolean().optional(),
+    weekStartsOn: z
+      .union([
+        z.literal(0),
+        z.literal(1),
+        z.literal(2),
+        z.literal(3),
+        z.literal(4),
+        z.literal(5),
+        z.literal(6),
+      ])
+      .optional(),
+    weeksBack: z.number().int().min(0).optional(),
+    weeksForward: z.number().int().min(0).optional(),
+    includeCurrentWeek: z.boolean().optional(),
+  })
+  .superRefine((config, ctx) => {
+    config.presets?.forEach((preset, index) => {
+      if (!KNOWN_DATE_PRESET_VALUES.has(preset)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['presets', index],
+          message: `Unknown date preset: ${preset}`,
+        });
+      }
+    });
+
+    if (config.defaultPreset && !KNOWN_DATE_PRESET_VALUES.has(config.defaultPreset)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['defaultPreset'],
+        message: `Unknown default date preset: ${config.defaultPreset}`,
+      });
+    }
+
+    if (config.defaultPreset && config.presets && !config.presets.includes(config.defaultPreset)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['defaultPreset'],
+        message: 'defaultPreset must be included in presets when presets is set',
+      });
+    }
+
+    if (config.mode === 'weekly' && generateWeeklyDateRangeOptions(config).length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['includeCurrentWeek'],
+        message: 'weekly date filters must generate at least one option',
+      });
+    }
+  });
 
 const filterDefinitionSchema = z.object({
   id: z.string().min(1),

--- a/packages/schema/test/dashboard.validation.test.ts
+++ b/packages/schema/test/dashboard.validation.test.ts
@@ -210,25 +210,6 @@ describe('dashboardDefinitionSchema date filters', () => {
     ).toBe(true);
   });
 
-  it('[filters-and-interactions.FILTER_BAR.4] rejects default presets outside the curated list', () => {
-    const result = dashboardDefinitionSchema.safeParse(
-      createDashboardWithDateConfig({
-        mode: 'preset',
-        presets: ['today'],
-        defaultPreset: 'last_7_days',
-      }),
-    );
-
-    expect(result.success).toBe(false);
-    expect(
-      result.success
-        ? false
-        : result.error.issues.some((issue) =>
-            issue.path.join('.').endsWith('dateConfig.defaultPreset'),
-          ),
-    ).toBe(true);
-  });
-
   it('[filters-and-interactions.FILTER_BAR.4] rejects weekly configs with no generated options', () => {
     const result = dashboardDefinitionSchema.safeParse(
       createDashboardWithDateConfig({

--- a/packages/schema/test/dashboard.validation.test.ts
+++ b/packages/schema/test/dashboard.validation.test.ts
@@ -54,6 +54,36 @@ function createAlertsDashboard(alertRule: Record<string, unknown>) {
   };
 }
 
+function createDashboardWithDateConfig(dateConfig: Record<string, unknown>) {
+  return {
+    schemaVersion: '0.2.0',
+    id: 'dashboard-date-filters',
+    title: 'Date Filters',
+    pages: [
+      {
+        id: 'page-1',
+        title: 'Overview',
+        rootNodeId: 'root',
+        layout: {
+          root: { id: 'root', type: 'root', children: [], meta: {} },
+        },
+        widgets: [],
+      },
+    ],
+    filters: [
+      {
+        id: 'event-week',
+        type: 'date',
+        fieldRef: 'event_date',
+        datasetRef: 'events',
+        operator: 'between',
+        dateConfig,
+        scope: { type: 'global' },
+      },
+    ],
+  };
+}
+
 describe('dashboardDefinitionSchema alert rules', () => {
   it('keeps widgetDefinitionSchema chainable for sub-schema consumers', () => {
     const extendedWidgetSchema = widgetDefinitionSchema.extend({
@@ -156,6 +186,65 @@ describe('dashboardDefinitionSchema alert rules', () => {
         ? false
         : result.error.issues.some(
             (issue) => issue.path.join('.') === 'pages.0.widgets.0.config.alertRule',
+          ),
+    ).toBe(true);
+  });
+});
+
+describe('dashboardDefinitionSchema date filters', () => {
+  it('[filters-and-interactions.FILTER_BAR.4] rejects unknown date presets', () => {
+    const result = dashboardDefinitionSchema.safeParse(
+      createDashboardWithDateConfig({
+        mode: 'preset',
+        presets: ['next_fortnight'],
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(
+      result.success
+        ? false
+        : result.error.issues.some((issue) =>
+            issue.path.join('.').endsWith('dateConfig.presets.0'),
+          ),
+    ).toBe(true);
+  });
+
+  it('[filters-and-interactions.FILTER_BAR.4] rejects default presets outside the curated list', () => {
+    const result = dashboardDefinitionSchema.safeParse(
+      createDashboardWithDateConfig({
+        mode: 'preset',
+        presets: ['today'],
+        defaultPreset: 'last_7_days',
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(
+      result.success
+        ? false
+        : result.error.issues.some((issue) =>
+            issue.path.join('.').endsWith('dateConfig.defaultPreset'),
+          ),
+    ).toBe(true);
+  });
+
+  it('[filters-and-interactions.FILTER_BAR.4] rejects weekly configs with no generated options', () => {
+    const result = dashboardDefinitionSchema.safeParse(
+      createDashboardWithDateConfig({
+        mode: 'weekly',
+        weeksBack: 0,
+        weeksForward: 0,
+        includeCurrentWeek: false,
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(
+      result.success
+        ? false
+        : result.error.issues.some((issue) =>
+            issue.path.join('.').endsWith('dateConfig.includeCurrentWeek'),
           ),
     ).toBe(true);
   });


### PR DESCRIPTION
## Summary

- Adds date-specific filter authoring UI that hides generic value-filter controls for date fields.
- Adds weekly dropdown authoring with week-start, lookback/lookahead settings, and option preview.
- Supports weekly defaults and compiles partial custom date ranges as one-sided `gte`/`lte` filters instead of malformed `between` filters.

Closes #162.

## Verification

- `pnpm --filter @supersubset/designer test -- feature-panels-2.test.tsx`
- `pnpm --filter @supersubset/runtime test -- filter-bar.test.tsx`
- `pnpm --filter @supersubset/designer typecheck`
- `pnpm --filter @supersubset/runtime typecheck`
- `pnpm --filter @supersubset/designer build`
- `pnpm --filter @supersubset/runtime build`
- `pnpm --filter @supersubset/designer lint`
- `pnpm --filter @supersubset/runtime lint` exits 0 with existing warnings in `FilterBar.tsx` and `render-query-helpers.ts`

## Local smoke

- Linked updated designer/runtime into Tripmatch via `yalc push`.
- Confirmed Tripmatch App Client required a restart because Vite served stale optimized deps for `@supersubset/designer`.
- Confirmed partial date input now compiles start-only as `gte`, end-only as `lte`, and empty bounds as no filter.
