### PR TITLE
release-promotion: staging → main

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,6 +11,7 @@
       "@supersubset/theme",
       "@supersubset/data-model",
       "@supersubset/query-client",
+      "@supersubset/query-sql",
       "@supersubset/cli",
       "@supersubset/adapter-prisma",
       "@supersubset/adapter-sql",

--- a/.changeset/date-aware-filters.md
+++ b/.changeset/date-aware-filters.md
@@ -1,0 +1,27 @@
+---
+'@supersubset/schema': minor
+'@supersubset/runtime': minor
+'@supersubset/designer': minor
+'@supersubset/charts-echarts': minor
+'@supersubset/theme': minor
+'@supersubset/data-model': minor
+'@supersubset/query-client': minor
+'@supersubset/query-sql': minor
+'@supersubset/cli': minor
+'@supersubset/adapter-prisma': minor
+'@supersubset/adapter-sql': minor
+'@supersubset/adapter-json': minor
+'@supersubset/adapter-dbt': minor
+---
+
+Date-aware dashboard filters (closes [#162](https://github.com/wandir-tech/supersubset/issues/162)).
+
+**Schema** — adds optional `FilterDefinition.dateConfig` describing the date-control style (`preset` / `range` / `weekly`), the weekday boundary, and weekly lookback/lookahead. `dateFilterConfigSchema` cross-validates unknown preset values and rejects weekly configs that would generate zero options.
+
+**Shared date utilities** — new `@supersubset/schema/date-utils` exports `generateWeeklyDateRangeOptions`, `resolveRelativeDate`, `isRangeLikeValue` / `isDateRangeLike`, `normalizeRangeBound`, `DATE_PRESETS`, and the supporting `DateRangeValue` / `WeeklyDateRangeOption` types. Designer and runtime now share one source of truth for week-boundary and preset math.
+
+**Designer** — date-typed fields automatically switch to date-aware controls and hide the generic value/operator + select-option-source UI. Authors pick the control style (`Relative date menu` / `Custom date range` / `Weekly range dropdown`), the week-start day, lookback/lookahead, and an authored default value. The weekly mode shows a live dropdown preview with an honest "showing N of M weeks" count.
+
+**Runtime** — `FilterBar` renders weekly dropdowns, custom-range inputs, or relative presets depending on `dateConfig.mode`. Partial custom-range inputs now compile to one-sided `gte` / `lte` filters (previously produced a malformed `between` with `null` bounds). Cross-filter compilation routes through the same `compileFilterDefinitionValue` path so date-range cross-filters behave consistently.
+
+**Backwards compatible.** `dateConfig` is optional; existing dashboards without it keep their prior preset-with-custom-range behavior. The `resolveRelativeDate` and `DATE_PRESETS` public exports keep the same signatures (`resolveRelativeDate` gains an optional third `config` arg).

--- a/.changeset/sql-query-adapter.md
+++ b/.changeset/sql-query-adapter.md
@@ -14,7 +14,7 @@
 '@supersubset/adapter-dbt': minor
 ---
 
-Centralize SQL generation in a reusable `SqlQueryAdapter` (ADR-011).
+Centralize SQL generation in a reusable `SqlQueryAdapter` (ADR-012).
 
 **New package `@supersubset/query-sql`** exporting:
 
@@ -33,6 +33,6 @@ Centralize SQL generation in a reusable `SqlQueryAdapter` (ADR-011).
 
 **`@supersubset/query-client` `QueryClient.resolveFilterOptions`** delegates to the data-model helper instead of throwing when the adapter has no `resolveFilterOptions` — falls through to the generic distinct query.
 
-**ADR updates**: ADR-011 (Accepted) documents the SQL-flavored execution layer the original spec called for, fixing the drift identified in [#160](https://github.com/wandir-tech/supersubset/issues/160). ADR-008 amended to point at ADR-011 for SQL-backed hosts; ADR-009 §2 softened to make the host-side resolver optional (the generic fallback is the default path).
+**ADR updates**: ADR-012 (Accepted) documents the SQL-flavored execution layer the original spec called for, fixing the drift identified in [#160](https://github.com/wandir-tech/supersubset/issues/160). ADR-008 amended to point at ADR-012 for SQL-backed hosts; ADR-009 §2 softened to make the host-side resolver optional (the generic fallback is the default path).
 
 **Designer**: updated the field-backed authoring hint to reflect the new architecture.

--- a/.changeset/sql-query-adapter.md
+++ b/.changeset/sql-query-adapter.md
@@ -1,0 +1,38 @@
+---
+'@supersubset/query-sql': minor
+'@supersubset/data-model': minor
+'@supersubset/query-client': minor
+'@supersubset/runtime': minor
+'@supersubset/designer': minor
+'@supersubset/schema': minor
+'@supersubset/charts-echarts': minor
+'@supersubset/theme': minor
+'@supersubset/cli': minor
+'@supersubset/adapter-prisma': minor
+'@supersubset/adapter-sql': minor
+'@supersubset/adapter-json': minor
+'@supersubset/adapter-dbt': minor
+---
+
+Centralize SQL generation in a reusable `SqlQueryAdapter` (ADR-011).
+
+**New package `@supersubset/query-sql`** exporting:
+
+- `SqlQueryAdapter` — a `QueryAdapter` implementation that turns `LogicalQuery` into SQL via the translator, executes it through a host-provided `SqlExecutor` (`run(sql) → rows`), and returns Supersubset-shaped `QueryResult`. Hosts implement one tiny method (`run(sql)`) instead of writing their own translator.
+- `toSql(query, options?)` — standalone translator returning `{ sql, planned }` for diagnostics, custom executors, or test assertions.
+- Helpers: `planFields`, `escapeLiteral`, `isRealAggregation`.
+
+**`@supersubset/data-model` additions** (all additive):
+
+- `LogicalQuery.distinct?: boolean` — when true, the executor must return distinct rows (`SELECT DISTINCT`). Adapters that ignore it preserve legacy behavior.
+- `QueryResult.truncated?: boolean` and `QueryResult.executionTimeMs?: number` — promoted from previously host-only fields.
+- `QueryFilter.value?: unknown` (was required) — operators like `is_null` / `is_not_null` legitimately omit it.
+- `resolveFilterOptionsWithAdapter(adapter, request)` helper — delegates to `adapter.resolveFilterOptions` if implemented, otherwise synthesizes a `distinct: true` `LogicalQuery` and runs it via `adapter.execute`. Defensive client-side dedup as a safety net.
+
+**`@supersubset/runtime` `FilterBar`** now resolves `optionSource.kind = 'field'` filters asynchronously via the host-provided `QueryAdapter`, with `loading | ready | unavailable | error` states surfaced through the existing select / multi-select controls. Closes the runtime side of [#121](https://github.com/wandir-tech/supersubset/issues/121); combined with `query-sql`, field-backed filters now work end-to-end on any SQL-backed host. Closes [#159](https://github.com/wandir-tech/supersubset/issues/159).
+
+**`@supersubset/query-client` `QueryClient.resolveFilterOptions`** delegates to the data-model helper instead of throwing when the adapter has no `resolveFilterOptions` — falls through to the generic distinct query.
+
+**ADR updates**: ADR-011 (Accepted) documents the SQL-flavored execution layer the original spec called for, fixing the drift identified in [#160](https://github.com/wandir-tech/supersubset/issues/160). ADR-008 amended to point at ADR-011 for SQL-backed hosts; ADR-009 §2 softened to make the host-side resolver optional (the generic fallback is the default path).
+
+**Designer**: updated the field-backed authoring hint to reflect the new architecture.

--- a/.github/skills/maintaining-ai-context/SKILL.md
+++ b/.github/skills/maintaining-ai-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maintaining-ai-context
-description: "Add, update, or audit Supersubset AI context: .github/skills, .github/agents, AGENTS.md, copilot-instructions, docs/status, docs/testing. Use when creating a skill, shrinking bloat, fixing stale cross-references, or aligning agents with orchestration."
+description: 'Add, update, or audit Supersubset AI context: .github/skills, .github/agents, AGENTS.md, copilot-instructions, docs/status, docs/testing. Use when creating a skill, shrinking bloat, fixing stale cross-references, or aligning agents with orchestration.'
 ---
 
 # Maintaining AI Context (Supersubset)
@@ -9,16 +9,18 @@ Supersubset keeps agent/playbook context in **`.github/`** and **`docs/`** (not 
 
 ## Scope (what this skill owns)
 
-| Artifact | Role |
-| -------- | ---- |
-| `.github/skills/*/SKILL.md` | How-to playbooks |
-| `.github/agents/*.agent.md` | Subagent definitions + tool allowlists |
-| `AGENTS.md` | Orchestrator + recovery + pointers |
-| `.github/copilot-instructions.md` | Lean always-on Copilot summary |
-| `.github/skills/github-cli/SKILL.md` | Canonical `gh` patterns for GitHub operations |
-| `docs/bootstrap.md` | Fresh-session orientation |
-| `docs/status/*` | Master plan, risks, phase summaries, checkpoints |
-| `docs/testing/*` | Verification strategy, QA lists, browser plans |
+| Artifact                             | Role                                             |
+| ------------------------------------ | ------------------------------------------------ |
+| `features/*.feature.yaml`            | Acai-compatible product requirements (ADR-011)   |
+| `features/terms/*.term.yaml`         | Glossary terms for requirement prose             |
+| `.github/skills/*/SKILL.md`          | How-to playbooks                                 |
+| `.github/agents/*.agent.md`          | Subagent definitions + tool allowlists           |
+| `AGENTS.md`                          | Orchestrator + recovery + pointers               |
+| `.github/copilot-instructions.md`    | Lean always-on Copilot summary                   |
+| `.github/skills/github-cli/SKILL.md` | Canonical `gh` patterns for GitHub operations    |
+| `docs/bootstrap.md`                  | Fresh-session orientation                        |
+| `docs/status/*`                      | Master plan, risks, phase summaries, checkpoints |
+| `docs/testing/*`                     | Verification strategy, QA lists, browser plans   |
 
 ## When to add a new skill
 
@@ -59,11 +61,11 @@ Run these when context feels bloated or agents misfire.
 
 ## Size guidance
 
-| Artifact | Heuristic |
-| -------- | --------- |
-| `copilot-instructions.md` | Keep roughly under ~80 lines of dense lists |
-| Single skill | Split beyond ~300 lines; add `docs/guides/` for narrative |
-| `AGENTS.md` | Index + protocols; move long prose into skills |
+| Artifact                  | Heuristic                                                 |
+| ------------------------- | --------------------------------------------------------- |
+| `copilot-instructions.md` | Keep roughly under ~80 lines of dense lists               |
+| Single skill              | Split beyond ~300 lines; add `docs/guides/` for narrative |
+| `AGENTS.md`               | Index + protocols; move long prose into skills            |
 
 ## Anti-patterns
 

--- a/.github/skills/publish-npm-release/SKILL.md
+++ b/.github/skills/publish-npm-release/SKILL.md
@@ -39,18 +39,26 @@ Commit and push the new `.changeset/*.md` (and any config edits) to `main`.
 
 ## Preconditions (CI / org)
 
-- Repo secret **`NPM_TOKEN`**: npm token with publish access to **`@supersubset`** (granular token: scope + read/write + bypass 2FA for automation if required).
+- Repo secret **`NPM_TOKEN`**: npm automation token that can publish the existing **`@supersubset/*`** packages. For granular tokens, this means **package write** on the published packages and **`bypass_2fa: true`** for automation. `npm whoami` alone is not enough to prove this.
 - **Org → Actions → Workflow permissions:** allow **read/write** and **“Allow GitHub Actions to create and approve pull requests”** so `changesets/action` can open the version PR. If repo UI is grayed out, an **org owner** must relax the org default.
+
+## Token preflight (recommended before updating GitHub secret)
+
+- `npm whoami` proves the token authenticates, but not that it can publish.
+- `npm owner ls @supersubset/runtime` confirms the account still has owner access on an existing package.
+- `npm token list --json` should show the candidate automation token with publish-capable scope and **`"bypass_2fa": true`**. A token can pass `whoami` and still fail publish if either package-write or bypass-2FA is missing.
 
 ## When Release fails
 
-| Symptom                                            | Fix                                                                        |
-| -------------------------------------------------- | -------------------------------------------------------------------------- |
-| “not permitted to create or approve pull requests” | Org/repo workflow permissions (above). Re-run failed **Release** job.      |
-| `403` / `ENEEDAUTH` on publish                     | `NPM_TOKEN` missing, expired, wrong scope, or npm 2FA blocking automation. |
-| Duplicate version                                  | Version already on registry; add a new changeset with a higher bump.       |
+| Symptom                                                                               | Fix                                                                                                                                                                                          |
+| ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| “not permitted to create or approve pull requests”                                    | Org/repo workflow permissions (above). Re-run failed **Release** job.                                                                                                                        |
+| `E404` on `PUT https://registry.npmjs.org/@supersubset%2f...` for an existing package | Granular token is authenticated but does not actually have **package write** for that package/scope. Replace `NPM_TOKEN` with a package-write token, then re-run the failed **Release** job. |
+| `E403` saying bypass 2FA is required                                                  | Token has enough auth to reach npm, but **`bypass_2fa` is false**. Create a new automation token with bypass 2FA enabled, update `NPM_TOKEN`, then re-run the failed **Release** job.        |
+| `403` / `ENEEDAUTH` on publish without the bypass message                             | `NPM_TOKEN` is missing, expired, or otherwise not usable for npm publish.                                                                                                                    |
+| Duplicate version                                                                     | Version already on registry; add a new changeset with a higher bump.                                                                                                                         |
 
-Inspect: **Actions → Release → failed run → logs**. Locally: `pnpm -r publish --dry-run --no-git-checks` (from repo root) to validate tarballs without publishing.
+Inspect: **Actions → Release → failed run → logs**. After fixing npm auth, re-run the same failed **Release** workflow for the existing `main` commit; do **not** add another changeset just to retry the same release. Locally: `pnpm -r publish --dry-run --no-git-checks` (from repo root) to validate tarballs without publishing.
 
 ## Branch protection
 
@@ -59,9 +67,11 @@ Keep **`main` protected**. Land the **changeset commit** via **PR into `main`** 
 ## Verify publish
 
 ```bash
-npm view @supersubset/schema version
-npm view @supersubset/cli version
+npm view @supersubset/schema version dist-tags --json
+npm view @supersubset/cli version dist-tags --json
 ```
+
+Prefer `npm view` over relying on the npm website alone; the web UI can lag slightly after a successful publish.
 
 ## Anti-patterns
 

--- a/.github/skills/release-runbook/SKILL.md
+++ b/.github/skills/release-runbook/SKILL.md
@@ -113,6 +113,16 @@ If local Playwright `webServer` startup is flaky, start the servers manually and
 pnpm exec playwright test --config=playwright.e2e.config.ts
 ```
 
+If you are validating against leased DevEnv ports locally, export all three host ports before running the host-backed E2E suite:
+
+```bash
+export SUPERSUBSET_DEV_APP_PORT=<dev-app-port>
+export SUPERSUBSET_EXAMPLE_NEXTJS_PORT=<nextjs-port>
+export SUPERSUBSET_EXAMPLE_VITE_SQLITE_PORT=<vite-port>
+```
+
+Without the explicit example-host vars, workbench/probe specs can silently fall back to `3001` / `3002` even when leased ports are active.
+
 Optional but recommended for release confidence:
 
 ```bash
@@ -197,13 +207,25 @@ Expected behavior:
 
 If no version-packages PR appears, verify again that the merged branch actually contained a pending `.changeset`.
 
+If the second pass fails because of npm token/auth issues, fix the secret and re-run the failed `release.yml` run for the same `main` commit. Do not create another changeset or another version PR just to retry the same publish.
+
 ## Step 9: Verify published artifacts
 
 After publish:
 
 - check the release workflow conclusion in GitHub Actions
-- confirm the expected package versions exist in npm
+- confirm the expected package versions exist in npm via `npm view`, not only the npm website or PR checks
 - note the published version that downstream consumers should adopt
+
+Recommended checks:
+
+```bash
+npm view @supersubset/runtime version
+npm view @supersubset/schema version
+npm view @supersubset/charts-echarts version
+```
+
+Treat the registry CLI result as the source of truth. The npm website can lag briefly after publish.
 
 Do not open downstream upgrade PRs against hypothetical versions that have not been published yet.
 
@@ -227,10 +249,16 @@ Prefer published versions. If pre-publish validation is required, use tarballs o
   - switch to manually started servers and `playwright.e2e.config.ts`
 - No pending `.changeset`:
   - stop the publish path and add a release note on `develop`
+- Publish returns `E404` on `PUT https://registry.npmjs.org/@supersubset%2f...` for existing packages:
+  - suspect a granular token that authenticates but is missing package-write access; `npm whoami` is insufficient proof
+- Publish returns `E403` requiring bypass 2FA:
+  - create a new automation token with `bypass_2fa` enabled, update the GitHub secret, then rerun the failed release job
 - Browser-auth-gated downstream app:
   - verify as much as possible locally, then call out the blocked surface explicitly
 - GitHub API or tool restrictions:
   - fall back to `gh` CLI rather than abandoning issue or PR automation
+- `gh run watch` is unreliable in a given terminal:
+  - poll the run via `gh api repos/<owner>/<repo>/actions/runs/<id>` for attempt/status/conclusion, then confirm registry state with `npm view`
 
 ## Current default path for the repo
 

--- a/.github/skills/requirements-driven-work/SKILL.md
+++ b/.github/skills/requirements-driven-work/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: requirements-driven-work
+description: Use when implementing, reviewing, or planning code that should be guided by existing feature specs, glossary terms, or Acai IDs.
+---
+
+# Requirements-Driven Work
+
+Use when code, tests, issues, or reviews need to consume the requirements layer under `features/`.
+
+Use `requirements-intake` when requirements need to be proposed or reorganized. Use `requirements-test-tagging` when adding Acai ID prefixes in tests.
+
+## Quick Start
+
+1. Read `features/README.md`
+2. Identify candidate feature specs from `features/*.feature.yaml`
+3. Read owning feature specs and relevant `features/terms/*.term.yaml` files
+4. List the Acai IDs that should guide the work
+5. If no owner is clear, stop and use `requirements-intake`
+
+## Finding The Owner
+
+Choose the feature that owns the product behavior, not the package where code lives.
+
+- Canonical schema, serialization, migrations: `schema-and-serialization`
+- Puck designer, property panels, import/export UX: `designer-authoring`
+- Layout engine, widget registry, render modes: `runtime-rendering`
+- ECharts wrappers, chart round-trip, field binding: `charts-and-visualization`
+- Prisma/SQL/JSON/dbt adapters, CLI import: `metadata-adapters`
+- Logical query client, HTTP probe contract: `query-and-probe`
+- Filter bar, cross-widget filters, drilldown: `filters-and-interactions`
+- Page navigation, alert rules/widgets: `navigation-and-alerts`
+- Embedding, controlled modes, host ownership: `host-integration`
+- Loading, empty, error, retry UX: `interface-behavior`
+
+## Implementation Workflow
+
+1. Compare requirement text to existing code and tests
+2. Implement missing behavior against the requirement
+3. If the requirement is wrong or absent, update the feature spec before coding through ambiguity
+4. Add or update tests whose primary purpose proves the changed requirements
+5. Run `pnpm run validate:requirements` when specs or test IDs changed
+
+## Review Workflow
+
+1. Enumerate linked Acai IDs from issue, PR, changed tests, and feature specs
+2. Mark each as Evidenced, Gap, N/A, or Cannot verify
+3. Treat durable behavior changes without requirement updates as review findings
+
+## See Also
+
+- `features/README.md`
+- `docs/adr/011-requirements-artifacts.md`
+- `.github/skills/requirements-intake/SKILL.md`
+- `.github/skills/requirements-test-tagging/SKILL.md`
+- `.github/skills/work-kickoff/SKILL.md`

--- a/.github/skills/requirements-intake/SKILL.md
+++ b/.github/skills/requirements-intake/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: requirements-intake
+description: Use when proposing, backfilling, or changing Acai-compatible feature specs, feature maps, glossary terms, platform scope, or stable Acai IDs.
+---
+
+# Requirements Intake
+
+Use this skill to add or maintain Acai-compatible feature specs under `features/` and glossary files under `features/terms/`.
+
+## Scope
+
+- reviewing existing code and backfilling feature specs
+- deciding which `features/*.feature.yaml` file owns a behavior
+- creating or updating Acai-compatible feature specs and glossary terms
+- choosing where stable Acai IDs belong in tests
+- proposing the initial feature map for a major product area
+
+Does not replace GitHub issues, ADRs, orchestration, or `initial-spec.md`. Gives those workflows a durable requirements home.
+
+## Feature Granularity
+
+Use product-sized buckets, not screen-sized or package-sized buckets.
+
+Current Supersubset buckets:
+
+- `schema-and-serialization`
+- `designer-authoring`
+- `runtime-rendering`
+- `charts-and-visualization`
+- `metadata-adapters`
+- `query-and-probe`
+- `filters-and-interactions`
+- `navigation-and-alerts`
+- `host-integration`
+- `interface-behavior`
+
+Use `interface-behavior` for cross-cutting loading, empty, error, and retry UX.
+
+## Chart and Component Properties
+
+Do **not** map every chart/widget property to its own ACID. Use capability-level requirements (Tier A) and cross-cutting rules (Tier B). Property inventories live in schema types, Puck blocks, docs, and exhaustive unit tests.
+
+## Feature YAML Schema
+
+Read `features/README.md` and `features/references/acai-feature-yaml.yaml`.
+
+Supersubset additions:
+
+- `feature.product` is `supersubset`
+- `feature.name` matches the filename stem
+- Group keys are uppercase snake case
+- Platform id is `web` (default; omit `note` when web-only)
+
+## Backfill Workflow
+
+1. Read `features/README.md`
+2. Scan `features/*.feature.yaml` and select the owning feature
+3. Read relevant `features/terms/*.term.yaml` files
+4. Write stable Acai IDs: `<feature-name>.<GROUP_KEY>.<requirement-key>`
+5. Emphasize glossary nouns in requirement prose (`*dashboard*`)
+6. Run `pnpm run validate:requirements`
+
+## Verification
+
+1. Run `pnpm run validate:requirements`
+2. Run `pnpm run requirements:coverage` when adding many ACIDs
+3. Confirm no orphan test refs after tagging
+
+## See Also
+
+- `features/README.md`
+- `docs/adr/011-requirements-artifacts.md`
+- `.github/skills/requirements-driven-work/SKILL.md`
+- `.github/skills/requirements-test-tagging/SKILL.md`
+- `.github/skills/work-kickoff/SKILL.md`

--- a/.github/skills/requirements-test-tagging/SKILL.md
+++ b/.github/skills/requirements-test-tagging/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: requirements-test-tagging
+description: Use when adding, reviewing, or refining Acai ID prefixes in test names so tests act as evidence for feature requirements.
+---
+
+# Requirements Test Tagging
+
+Use when adding or auditing Acai ID prefixes such as `[schema-and-serialization.SERIALIZATION.1]` in Vitest or Playwright test names.
+
+Test prefixes are evidence links, not navigation labels. Prefer no prefix over a misleading prefix.
+
+## Before Tagging
+
+1. Read `features/README.md` and owning `features/*.feature.yaml` files
+2. If a test proves behavior with no requirement, update the feature spec first via `requirements-intake`
+3. Run `pnpm run validate:requirements` if existing tags may be stale
+
+## Tagging Rules
+
+Prefix a test only when:
+
+- The test's primary purpose is to prove one requirement (or a small tightly coupled set)
+- Failure would indicate regression against that requirement's contract
+- You can quote the requirement text and point to the assertion
+
+Do **not** prefix:
+
+- Exhaustive property-matrix tests (`per-chart-properties.test.tsx`, `chart-preview-properties.test.tsx`, `adapter-properties.test.ts`) unless proving a named Tier A/B capability
+- Smoke or umbrella tests spanning many behaviors
+- Doc-screenshot capture tests (`packages/docs/capture/`)
+
+## Format
+
+```ts
+it('[schema-and-serialization.SERIALIZATION.1] JSON round-trip preserves dashboard AST', () => {
+  // ...
+});
+
+test('[designer-authoring.IMPORT_EXPORT.1] export and reimport preserves widget count', async ({
+  page,
+}) => {
+  // ...
+});
+```
+
+Keep the prefix at the start of the test title. Do not put Acai IDs in `describe` blocks.
+
+## Workflow
+
+1. Fix orphan refs first
+2. Tag e2e workflows and contract unit tests before property matrices
+3. Run `pnpm run validate:requirements`
+4. Run `pnpm run requirements:coverage` to inspect gaps
+
+Target ~60–80% spec ACID coverage; do not chase 100% with weak prefixes.
+
+## See Also
+
+- `features/README.md`
+- `docs/adr/011-requirements-artifacts.md`
+- `.github/skills/requirements-intake/SKILL.md`
+- `.github/skills/requirements-driven-work/SKILL.md`
+- `.github/skills/testing-strategy/SKILL.md`

--- a/.github/skills/testing-strategy/SKILL.md
+++ b/.github/skills/testing-strategy/SKILL.md
@@ -27,7 +27,17 @@ Instead, it answers four questions first:
 
 Use this skill before writing or expanding tests. Then route into the narrower skill or document that owns the implementation details.
 
-For BI-facing work, use this skill together with `.github/skills/bi-visualization-quality/SKILL.md`. Technical correctness is not enough if the resulting dashboard is misleading, unreadable, or hard to operate.
+## Acai ID Test Prefixes
+
+When a test primarily proves a durable requirement from `features/*.feature.yaml`, prefix the test name with the Acai ID:
+
+```ts
+it('[schema-and-serialization.SERIALIZATION.1] JSON round-trip preserves dashboard AST', () => { ... });
+```
+
+Read `.github/skills/requirements-test-tagging/SKILL.md` before broad tagging passes. Do not prefix exhaustive property-matrix tests (`per-chart-properties`, `adapter-properties`) unless they prove a named capability requirement. Run `pnpm run validate:requirements` after changing test prefixes.
+
+For BI-facing work, use this skill together with `.github/skills/bi-visualization-quality/SKILL.md`.
 
 ## AI Tester Agent Design Principles
 

--- a/.github/skills/work-kickoff/SKILL.md
+++ b/.github/skills/work-kickoff/SKILL.md
@@ -20,11 +20,12 @@ Turn a described work item into a **self-contained GitHub issue** so a fresh age
 ### Step 1: Orient in-repo
 
 1. Read **`initial-spec.md`** for invariants that must not be violated.
-2. Read **`AGENTS.md`** (orchestrator rules, verification expectations).
-3. Read **`docs/status/master-plan.md`** — note current phase, related tasks, and human checkpoints (HC-N) if any.
-4. Skim **`docs/status/risk-register.md`** when the change affects stability, compatibility, or release timing.
-5. Explore code in the affected packages; find patterns to extend, not reinvent.
-6. For schema-first work, perform a contract-closure audit: can the feature work from `DashboardDefinition` plus explicit host-owned boundaries only, or is the current design sneaking authored semantics into extra props/callbacks?
+2. Scan **`features/*.feature.yaml`** for owning Acai IDs when the work changes durable product behavior (see **`requirements-driven-work`**).
+3. Read **`AGENTS.md`** (orchestrator rules, verification expectations).
+4. Read **`docs/status/master-plan.md`** — note current phase, related tasks, and human checkpoints (HC-N) if any.
+5. Skim **`docs/status/risk-register.md`** when the change affects stability, compatibility, or release timing.
+6. Explore code in the affected packages; find patterns to extend, not reinvent.
+7. For schema-first work, perform a contract-closure audit: can the feature work from `DashboardDefinition` plus explicit host-owned boundaries only, or is the current design sneaking authored semantics into extra props/callbacks?
 
 ### Step 2: Tier the skills (and agents)
 
@@ -36,20 +37,21 @@ Scan **`.github/skills/*/SKILL.md`** and classify each as **essential**, **suppo
 | **Supporting**   | Read when touching that surface                |
 | **Not relevant** | Explicitly excluded (proves you considered it) |
 
-Always evaluate **`orchestration`** for multi-package delivery and **`browser-testing`** when UI behavior is in scope.
+Always evaluate **`orchestration`** for multi-package delivery, **`requirements-driven-work`** when behavior maps to `features/`, and **`browser-testing`** when UI behavior is in scope.
 
 ### Step 3: Write the implementation plan (in the issue body or comment)
 
 Structure:
 
 1. **Context** — Problem, user-visible outcome, link to master-plan task if applicable.
-2. **Design decisions** — Choices + rationale (schema vs UI-only, adapter boundaries, etc.). Name every required host-owned seam and justify any sidecar input that carries authored semantics.
-3. **Phases** — Ordered steps (e.g. schema/types → runtime → designer → tests → docs/screenshots).
-4. **Key files** — Table: path → one-line intent.
-5. **Testing** — Unit targets, `pnpm test`, Playwright / Chrome MCP plans (`docs/testing/`), Storybook if relevant.
+2. **Requirements** — Link relevant Acai IDs from `features/*.feature.yaml` in acceptance criteria when behavior is durable.
+3. **Design decisions** — Choices + rationale (schema vs UI-only, adapter boundaries, etc.). Name every required host-owned seam and justify any sidecar input that carries authored semantics.
+4. **Phases** — Ordered steps (e.g. schema/types → runtime → designer → tests → docs/screenshots).
+5. **Key files** — Table: path → one-line intent.
+6. **Testing** — Unit targets, `pnpm test`, Playwright / Chrome MCP plans (`docs/testing/`), Storybook if relevant. Prefix requirement-proving tests with `[ACID]` per **`requirements-test-tagging`**.
    For parallel local validation, include the leased port tuple and the probe command (`node scripts/find-free-port.mjs --count 3`) in the issue.
-6. **Verification** — Commands: `pnpm lint && pnpm typecheck && pnpm test` (root); package-scoped variants if faster.
-7. **Docs / evidence** — If UI-facing: follow **`document-feature`** (screenshots, MDX); do not commit throwaway images to unrelated paths.
+7. **Verification** — Commands: `pnpm lint && pnpm typecheck && pnpm test` (root); `pnpm run validate:requirements` when feature specs, glossary terms, or test Acai IDs changed.
+8. **Docs / evidence** — If UI-facing: follow **`document-feature`** (screenshots, MDX); do not commit throwaway images to unrelated paths.
 
 ### Step 4: Create or augment the GitHub issue
 
@@ -86,6 +88,8 @@ After approval, implementers: follow the issue, load essential skills, respect a
 
 ## See also
 
+- `.github/skills/requirements-driven-work/SKILL.md`
+- `.github/skills/requirements-test-tagging/SKILL.md`
 - `.github/skills/github-cli/SKILL.md`
 - `.github/skills/orchestration/SKILL.md`
 - `.github/skills/document-feature/SKILL.md`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,11 +267,43 @@ jobs:
           command: code test
           args: --severity-threshold=high
 
+  # ── Requirements Validation ────────────────────────────────
+  requirements-validate:
+    name: Requirements Validate
+    needs: changes
+    if: needs.changes.outputs.full_ci == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run test:requirements-validator
+      - run: pnpm run validate:requirements
+
   # ── CI Gate (required check for branch protection) ─────────
   ci-gate:
     name: CI Gate
     if: always()
-    needs: [changes, docs-build, build, lint, format, typecheck, unit-tests, e2e, security]
+    needs:
+      [
+        changes,
+        docs-build,
+        build,
+        lint,
+        format,
+        typecheck,
+        unit-tests,
+        e2e,
+        security,
+        requirements-validate,
+      ]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
@@ -285,6 +317,7 @@ jobs:
               "${{ needs.unit-tests.result }}"
               "${{ needs.e2e.result }}"
               "${{ needs.security.result }}"
+              "${{ needs.requirements-validate.result }}"
             )
             for r in "${results[@]}"; do
               if [[ "$r" != "success" ]]; then

--- a/.github/workflows/requirements-validate.yml
+++ b/.github/workflows/requirements-validate.yml
@@ -1,0 +1,66 @@
+name: Requirements validation
+
+on:
+  pull_request:
+    branches: [develop, staging, main]
+    paths:
+      - 'features/**'
+      - 'tools/requirements/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '**/*.spec.ts'
+      - '**/*.spec.tsx'
+      - '**/*.spec.js'
+      - '**/*.spec.jsx'
+      - '**/*.test.ts'
+      - '**/*.test.tsx'
+      - '**/*.test.js'
+      - '**/*.test.jsx'
+  push:
+    branches: [develop, staging, main]
+    paths:
+      - 'features/**'
+      - 'tools/requirements/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '**/*.spec.ts'
+      - '**/*.spec.tsx'
+      - '**/*.spec.js'
+      - '**/*.spec.jsx'
+      - '**/*.test.ts'
+      - '**/*.test.tsx'
+      - '**/*.test.js'
+      - '**/*.test.jsx'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: requirements-validate-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '22.13.0'
+
+jobs:
+  validate-requirements:
+    name: validate-requirements
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run requirements validator self-tests
+        run: pnpm run test:requirements-validator
+
+      - name: Validate feature specs and Acai test refs
+        run: pnpm run validate:requirements

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,9 @@ For testing work, pair the `testing` agent with `.github/skills/testing-strategy
 | ----------------------------- | --------------------------------------------------------------------------------------------------------- |
 | `github-cli`                  | Issues, PRs, Actions runs, and API queries — prefer `gh` over the browser                                 |
 | `work-kickoff`                | Turning an idea into a reviewed GitHub issue + implementation plan                                        |
+| `requirements-intake`         | Creating or backfilling Acai-compatible feature specs and glossary terms                                  |
+| `requirements-driven-work`    | Implementing or reviewing against existing `features/*.feature.yaml` ACIDs                                |
+| `requirements-test-tagging`   | Prefixing tests with `[ACID]` evidence links                                                              |
 | `branch-ci-promotion`         | PR readiness: `pnpm lint`, `typecheck`, `test`, E2E, merge expectations                                   |
 | `ai-code-cleanup`             | Continuous AI-code cleanup: drift detection, duplicate removal, bounded refactors, and standards updates  |
 | `release-runbook`             | End-to-end release execution: candidate validation, changesets, branch promotion, publish, downstream PRs |
@@ -98,12 +101,14 @@ If you are a fresh agent session resuming work:
 2. Read `docs/status/risk-register.md` for active risks
 3. Read the latest file in `docs/status/phase-summaries/` for recent progress
 4. Read `docs/adr/` for architecture decisions made so far
-5. Check `git log --oneline -20` for recent commits
-6. Resume from the current phase's incomplete tasks
+5. Scan `features/*.feature.yaml` for durable product requirements (ADR-011)
+6. Check `git log --oneline -20` for recent commits
+7. Resume from the current phase's incomplete tasks
 
 ## File Organization
 
 ```
+features/                   # Acai-compatible product requirements (ADR-011)
 docs/
 ├── adr/                    # Architecture Decision Records
 ├── status/

--- a/docs/adr/008-supersubset-http-probe-contract.md
+++ b/docs/adr/008-supersubset-http-probe-contract.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Proposed — amended by [ADR-011](./011-sql-query-adapter.md) (2026-05-27)
+Proposed — amended by [ADR-012](./012-sql-query-adapter.md) (2026-05-28)
 
-> **Amendment summary (ADR-011, 2026-05-27)**: This ADR's "backend-agnostic, does not prescribe database access" stance remains valid for non-SQL hosts and the dev-app probe. For SQL-backed hosts, ADR-011 adds `@supersubset/query-sql`'s `SqlQueryAdapter` and the `LogicalQuery.distinct` flag, so the SQL execution path the spec called for now exists alongside the agnostic contract.
+> **Amendment summary (ADR-012, 2026-05-28)**: This ADR's "backend-agnostic, does not prescribe database access" stance remains valid for non-SQL hosts and the dev-app probe. For SQL-backed hosts, ADR-012 adds `@supersubset/query-sql`'s `SqlQueryAdapter` and the `LogicalQuery.distinct` flag, so the SQL execution path the spec called for now exists alongside the agnostic contract.
 
 ## Date
 

--- a/docs/adr/008-supersubset-http-probe-contract.md
+++ b/docs/adr/008-supersubset-http-probe-contract.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Proposed
+Proposed — amended by [ADR-011](./011-sql-query-adapter.md) (2026-05-27)
+
+> **Amendment summary (ADR-011, 2026-05-27)**: This ADR's "backend-agnostic, does not prescribe database access" stance remains valid for non-SQL hosts and the dev-app probe. For SQL-backed hosts, ADR-011 adds `@supersubset/query-sql`'s `SqlQueryAdapter` and the `LogicalQuery.distinct` flag, so the SQL execution path the spec called for now exists alongside the agnostic contract.
 
 ## Date
 

--- a/docs/adr/009-filter-option-source-contract.md
+++ b/docs/adr/009-filter-option-source-contract.md
@@ -79,9 +79,9 @@ Implications:
 - `kind: 'static'` is first-class, not a temporary workaround
 - `completeness: 'curated'` explicitly means the authored list is an intentional subset rather than the full domain
 
-### 2. Add a standardized host-owned option resolver for dynamic sources
+### 2. Standardize an optional host-owned option resolver, with a generic fallback
 
-For `optionSource.kind = 'field'`, Supersubset should use an explicit host-owned resolution method instead of overloading undocumented props.
+For `optionSource.kind = 'field'`, Supersubset defines an explicit `resolveFilterOptions` capability on `QueryAdapter`. Hosts MAY implement it for curation, authorization, or backend-specific lookup paths. When a host does not implement it, the runtime falls back to synthesizing a distinct-values query through the existing `execute(LogicalQuery)` method that every adapter must already provide.
 
 Illustrative data-model contract:
 
@@ -106,14 +106,24 @@ interface QueryAdapter {
   readonly name: string;
   execute(query: LogicalQuery): Promise<QueryResult>;
   cancel?(queryId: string): void;
+  // Optional. If absent, Supersubset synthesizes a LogicalQuery via execute().
   resolveFilterOptions?(request: FilterOptionRequest): Promise<FilterOptionResponse>;
 }
 ```
 
-This remains host-owned and backend-agnostic:
+The generic fallback (`resolveFilterOptionsWithAdapter` in `@supersubset/data-model`) builds a `LogicalQuery` selecting the single requested field with no aggregation (which produces an implicit `GROUP BY` and therefore distinct values), applies `request.limit`, and translates `request.search` to a `like` filter. Hosts that already expose a general LogicalQuery executor (DuckDB, Prisma, SQL, dbt) get field-backed filters for free with zero additional integration code.
+
+Hosts SHOULD implement `resolveFilterOptions` themselves when they need:
+
+- **curation** — mapping raw enum values to human labels, or restricting to a curated subset of the field's domain
+- **authorization** — scoping distinct results to values the current user is allowed to see
+- **alternative backends** — fetching options from a lookup service that is not the analytics warehouse
+- **search semantics** — fuzzier matching than the generic `like` translation
+
+This keeps the contract host-owned and backend-agnostic, while eliminating boilerplate for the common case:
 
 - Supersubset does not prescribe SQL, Prisma, dbt, or warehouse semantics
-- the host decides how to authorize and execute the lookup
+- the host can override when it needs to authorize or curate the lookup
 - the runtime gets one stable capability instead of private app wiring
 
 ### 3. Dynamic option resolution must be search-first for large-cardinality fields
@@ -152,13 +162,13 @@ The current runtime prop should remain temporarily so existing hosts do not brea
 Resolution order should become:
 
 1. `FilterDefinition.optionSource.kind = 'static'`
-2. `FilterDefinition.optionSource.kind = 'field'` via `resolveFilterOptions`
+2. `FilterDefinition.optionSource.kind = 'field'` via `queryAdapter.resolveFilterOptions` if implemented, otherwise via the `resolveFilterOptionsWithAdapter` fallback (synthesized LogicalQuery through `execute`)
 3. deprecated legacy `filterOptions` prop
-4. explicit unavailable state
+4. explicit unavailable state (only when no adapter is in scope at all)
 
 If a select filter has no valid option source, the runtime should render a clear unavailable state and the designer should warn during authoring. It should not silently render an empty dropdown that looks valid but cannot function.
 
-During the current rollout, field-backed runtime resolution remains tracked separately in [Issue #121](https://github.com/wandir-tech/supersubset/issues/121). Until that runtime path is wired, unsupported select-like filters must render as unavailable rather than appearing interactive with no usable options.
+Field-backed runtime resolution was originally tracked in [Issue #121](https://github.com/wandir-tech/supersubset/issues/121) as a separate workstream because the runtime had no path to call into the host. That gap closes with the resolver-or-fallback wiring described in §2.
 
 ### 6. Keep option-source semantics on the filter, not only on dataset metadata
 
@@ -186,7 +196,7 @@ Therefore the authored filter definition owns the option-source decision, while 
 
 - The schema and query contracts both gain new surface area.
 - The runtime will need async control states such as loading, empty, unavailable, and paginated search.
-- Hosts that want dynamic select filters must implement another optional capability beyond `execute()`.
+- Hosts that need curation, authorization, or non-warehouse lookups for dynamic select filters must implement the optional `resolveFilterOptions` capability beyond `execute()`. Hosts that only need raw distinct values from the same backend get them through the generic fallback with no extra integration.
 - Designer UX becomes slightly more complex because authors must choose or confirm an option-source strategy.
 
 ### Neutral

--- a/docs/adr/011-requirements-artifacts.md
+++ b/docs/adr/011-requirements-artifacts.md
@@ -1,0 +1,135 @@
+# ADR-011: Acai-Compatible Feature Specs
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-26
+
+## Context
+
+Supersubset's AI workflow has strong execution artifacts: GitHub issues, `.github/skills`, ADRs, master plan, and CI gates. The gap is stable product and system requirements. Issues are good for execution, but they are a poor long-term home for reusable requirements because they close, grow noisy, and mix delivery plan with product contract.
+
+Agents need a durable place to answer:
+
+- Which feature owns this behavior?
+- Which domain nouns have canonical meanings?
+- Which Acai IDs should implementation and tests prove?
+- What is the embeddable library contract vs host-app responsibility?
+
+## Decision
+
+Add Acai-compatible feature specs and supporting requirement vocabulary under root `features/`.
+
+```text
+features/
+  README.md
+  <feature>.feature.yaml
+  references/
+    acai-feature-yaml.yaml
+    platforms.yaml
+    term-yaml.schema.yaml
+  terms/
+    <term>.term.yaml
+```
+
+Root feature specs use Acai's `feature`, `components`, and `constraints` layout. They are the durable home for stable behavior and Acai IDs. GitHub issues remain the execution surface for implementation slices. ADRs remain the durable decision record. `initial-spec.md` and `docs/schema/` remain bootstrap and technical contract references.
+
+Glossary terms are split one term per file under `features/terms/`. `features/references/` owns supporting schemas, imported references, and platform ids.
+
+## Feature Granularity
+
+Use product-sized feature buckets, not screen-sized or package-sized buckets.
+
+Active buckets:
+
+- `schema-and-serialization`
+- `designer-authoring`
+- `runtime-rendering`
+- `charts-and-visualization`
+- `metadata-adapters`
+- `query-and-probe`
+- `filters-and-interactions`
+- `navigation-and-alerts`
+- `host-integration`
+- `interface-behavior`
+
+## Chart and Component Properties
+
+Do not map every chart or widget property to its own ACID. TypeScript schema types, Puck block definitions, docs property panels, and exhaustive unit tests remain the source of truth for property inventories.
+
+Use feature YAML for capability contracts (Tier A), cross-cutting chart rules (Tier B), and regression anchors. Add property-level ACIDs only when host-facing, parity-critical, or human-reported regression scope demands it.
+
+## Acai IDs
+
+Acai IDs use Acai's stable dotted form:
+
+```text
+<feature-name>.<GROUP_KEY>.<requirement-key>
+```
+
+Examples:
+
+- `schema-and-serialization.SERIALIZATION.1`
+- `designer-authoring.IMPORT_EXPORT.2`
+- `query-and-probe.PROBE_QUERY.1`
+
+Do not silently reuse or renumber IDs once linked from issues, tests, or implementation anchors.
+
+## Platform Scope
+
+Durable requirements use platform id `web` from `features/references/platforms.yaml`. Supersubset is an embeddable React library; the host application owns auth, routing, and data access boundaries.
+
+## Test And Code References
+
+Requirement-proving tests prefix the test name with the Acai ID:
+
+```ts
+it('[schema-and-serialization.SERIALIZATION.1] JSON round-trip preserves dashboard AST', () => {
+  // ...
+});
+```
+
+Implementation comments are allowed but should be sparse.
+
+## Workflow Changes
+
+For non-trivial behavior changes:
+
+1. Scan `features/*.feature.yaml`.
+2. Read or update the owning feature spec.
+3. Link Acai IDs from GitHub issue acceptance criteria.
+4. Prefix requirement-proving tests with Acai IDs.
+5. Run `pnpm run validate:requirements`.
+6. If implementation finds ambiguity, update the feature spec before coding through the gap.
+
+## Consequences
+
+### Positive
+
+- Agents have a compact, parseable requirements layer before reading code.
+- Long-lived behavior survives issue closure.
+- Test output and CI can trace failures to named contracts.
+
+### Negative
+
+- More files must be maintained.
+- Feature specs can drift if PRs do not update them.
+
+### Mitigations
+
+- Use `.github/skills/requirements-intake` for backfills and new work.
+- Run the local validator after feature spec or test-prefix changes.
+- Treat missing feature spec updates as a review finding for non-trivial behavior changes.
+
+## Related
+
+- `features/README.md`
+- `features/*.feature.yaml`
+- `tools/requirements/validate-feature-specs.mjs`
+- `.github/skills/requirements-intake/SKILL.md`
+- `.github/skills/requirements-driven-work/SKILL.md`
+- `.github/skills/requirements-test-tagging/SKILL.md`
+- `.github/skills/work-kickoff/SKILL.md`

--- a/docs/adr/011-sql-query-adapter.md
+++ b/docs/adr/011-sql-query-adapter.md
@@ -74,11 +74,21 @@ export function toSql(
 
 Behavior:
 
-- Translates `LogicalQuery.fields` to a `SELECT` list. Honors aggregations and aliases.
-- Translates `LogicalQuery.filters` to a `WHERE` clause with parameterized values by default.
-- Emits `GROUP BY` for non-aggregated projection fields when at least one aggregation is present **or** when `distinct: true` is set on the query.
+- Translates `LogicalQuery.fields` to a `SELECT` list. Honors aggregations and aliases. Rejects duplicate `sqlAlias` collisions with an explicit error rather than producing ambiguous columns.
+- Translates `LogicalQuery.filters` to a `WHERE` clause. Values are SQL-escaped (string literals quoted, embedded quotes doubled; numerics validated; nulls / booleans emitted directly).
+- Emits `SELECT DISTINCT` when `LogicalQuery.distinct === true` and no aggregations are present; emits `GROUP BY` for non-aggregated projection fields when at least one aggregation is present.
 - Translates `LogicalQuery.sort`, `limit`, `offset` directly.
-- `resolveFilterOptions` synthesizes `SELECT DISTINCT <field> FROM <dataset> LIMIT <n>` (or `LIKE` for search) and runs via `executor.run`, without relying on the host to implement anything beyond `run(sql)`.
+- `resolveFilterOptionsWithAdapter` (in `@supersubset/data-model`) synthesizes a `distinct: true` `LogicalQuery` and runs it via `executor.run`, without relying on the host to implement anything beyond `run(sql)`. For search, the term is normalized to **contains semantics** (wrapped with `%…%`) unless the caller already supplied `%` or `_` wildcards. The returned `complete` flag prefers `QueryResult.truncated` over a post-dedupe length heuristic so duplicate rows from older adapters cannot falsely report "all options loaded."
+
+### Security boundary
+
+`SqlQueryAdapter` emits inline-literal SQL in this MVP (no `?` / `$1` parameters). The contract is:
+
+- **Hosts MUST validate `datasetId` and `fieldId`** against an allowlist before calling `adapter.execute(query)`. The translator quotes identifiers but does not authorize them.
+- **Filter values are SQL-escaped** at the literal level by the translator, so user-supplied `value` payloads cannot break out of a quoted string.
+- **Hosts SHOULD validate `value` types** that don't pass through `escapeLiteral` cleanly (e.g. arrays for `in`, `[min, max]` for `between`).
+
+Parameterized execution is intentionally out of scope for the MVP; tracked as a follow-up so adapters can opt into `?` / `$1` placeholders once a dialect layer exists.
 
 ### 3. Extend `LogicalQuery` with `distinct?: boolean`
 

--- a/docs/adr/011-sql-query-adapter.md
+++ b/docs/adr/011-sql-query-adapter.md
@@ -1,0 +1,166 @@
+# ADR-011: Centralize SQL Generation in a Reusable SqlQueryAdapter
+
+## Status
+
+Accepted (2026-05-27) — implemented in `@supersubset/query-sql` v0.1.4; Tripmatch migrated.
+
+## Date
+
+2026-05-27
+
+## Context
+
+Supersubset's `initial-spec.md` defined a two-layer architecture:
+
+- **Metadata / discovery layer** — pluggable, because schema definitions live in many formats (Prisma, dbt, JSON Schema, OpenAPI, SQL catalog). The `MetadataAdapter` interface and per-format adapters (`adapter-prisma`, `adapter-sql`, `adapter-dbt`, `adapter-json`) implement this layer.
+- **Query / execution layer** — the spec assumes SQL: "compatible with a ClickHouse-based backend exposed through a secure SQL API," and `packages/query-client` was specified to own "pluggable query transport, **secure SQL execution contract**, ... SQL generation." The spec also called for "direct SQL generation for environments that want it."
+
+The current implementation has drifted from that on the execution layer:
+
+- `@supersubset/query-client` (189 lines) is a thin orchestrator around `QueryAdapter.execute()`. It performs no SQL generation.
+- `@supersubset/adapter-sql` (147 lines) only normalizes SQL catalog metadata into `NormalizedDataset[]`. It contains no query translation.
+- `LogicalQuery` is treated as the only contract, with no SQL-flavored adapter shipped alongside it.
+- [ADR-008](./008-supersubset-http-probe-contract.md) (2026-05-01) codified the drift by explicitly making the probe contract backend-agnostic ("it does not prescribe database access, ORM choice, or authentication framework").
+
+Consequence: every SQL-backed host writes its own `LogicalQuery → SQL` translator. In Tripmatch's case that is ~600 lines of `translateQuery`, `filterToSql`, `sortToSql` inside `analytics-mart-query.service.ts`, paired with a bespoke probe handler.
+
+This duplication has produced real defects:
+
+- **Issue [#159](https://github.com/wandir-tech/supersubset/issues/159)**: field-backed filter options return non-distinct rows because Tripmatch's translator only emits `GROUP BY` when an aggregation is present. The data-model has no way to express `DISTINCT` and the host's translator did not invent one.
+- **Issue [#121](https://github.com/wandir-tech/supersubset/issues/121)**: field-backed runtime resolution was deferred for nearly three weeks partly because the runtime had no shared SQL surface to lean on.
+- Every future SQL semantic gap (NULL handling, `CASE`, `HAVING`, joins, window functions) will hit the same dynamic: discovered by one host, fixed locally, re-discovered by the next.
+
+Supersubset's value proposition is "embeddable analytics for hosts that already have a SQL warehouse." Asking each host to re-implement the warehouse semantics defeats the point.
+
+## Decision
+
+### 1. Reaffirm the spec: SQL is a first-class execution layer
+
+The metadata layer remains pluggable (correct, as Ken notes: tables and columns live in many formats). The execution layer commits to SQL as the primary supported shape, with `QueryAdapter` retained as the escape hatch for non-SQL hosts.
+
+This is not a new direction — it is what `initial-spec.md` already prescribed. ADR-008 stays valid for non-SQL hosts and for the dev-app probe; this ADR adds the SQL path the spec called for.
+
+### 2. Introduce `@supersubset/query-sql` with `SqlQueryAdapter`
+
+A new package implements `LogicalQuery → SQL` translation and ships a ready-to-use `QueryAdapter`:
+
+```ts
+// @supersubset/query-sql
+
+export interface SqlExecutor {
+  /** Execute a SQL string and return rows in {column: value} shape. */
+  run(sql: string, params?: unknown[]): Promise<QueryResult>;
+}
+
+export interface SqlQueryAdapterOptions {
+  executor: SqlExecutor;
+  dialect?: SqlDialect; // 'duckdb' | 'postgres' | 'clickhouse' | 'standard'
+  parameterized?: boolean; // default true — use $1, $2 placeholders
+}
+
+export class SqlQueryAdapter implements QueryAdapter {
+  readonly name: string;
+  constructor(options: SqlQueryAdapterOptions);
+  execute(query: LogicalQuery): Promise<QueryResult>;
+  resolveFilterOptions(request: FilterOptionRequest): Promise<FilterOptionResponse>;
+}
+
+/** Public translator — also usable standalone for diagnostics or custom executors. */
+export function toSql(
+  query: LogicalQuery,
+  opts?: { dialect?: SqlDialect },
+): { sql: string; params: unknown[] };
+```
+
+Behavior:
+
+- Translates `LogicalQuery.fields` to a `SELECT` list. Honors aggregations and aliases.
+- Translates `LogicalQuery.filters` to a `WHERE` clause with parameterized values by default.
+- Emits `GROUP BY` for non-aggregated projection fields when at least one aggregation is present **or** when `distinct: true` is set on the query.
+- Translates `LogicalQuery.sort`, `limit`, `offset` directly.
+- `resolveFilterOptions` synthesizes `SELECT DISTINCT <field> FROM <dataset> LIMIT <n>` (or `LIKE` for search) and runs via `executor.run`, without relying on the host to implement anything beyond `run(sql)`.
+
+### 3. Extend `LogicalQuery` with `distinct?: boolean`
+
+To support the synthesized distinct query and the broader case of "user wants distinct projection rows":
+
+```ts
+export interface LogicalQuery {
+  datasetId: string;
+  fields: QueryField[];
+  filters?: QueryFilter[];
+  sort?: QuerySort[];
+  limit?: number;
+  offset?: number;
+  distinct?: boolean; // new
+}
+```
+
+The flag is additive. Adapters that ignore it produce non-distinct results (current behavior). `SqlQueryAdapter` honors it. Other adapters (Prisma, GraphQL) can adopt it on their own timeline.
+
+### 4. Auth and dataset scoping remain host-owned
+
+Per the spec, authentication and authorization stay at the transport layer. The recommended host pattern becomes:
+
+```ts
+// Host pseudo-code
+app.post('/supersubset/query', async (req, res) => {
+  const jwt = verifyJwt(req.headers.authorization);
+  const query: LogicalQuery = req.body;
+  if (!datasetAllowedFor(jwt.role, query.datasetId)) return res.status(403).end();
+  const adapter = new SqlQueryAdapter({ executor: duckDbExecutor, dialect: 'duckdb' });
+  res.json(await adapter.execute(query));
+});
+```
+
+The host writes ~10 lines of plumbing. SQL semantics live in supersubset.
+
+Future fine-grained authorization (row-level filters by JWT claim, column masking) can be added as a `SqlQueryAdapter` middleware option that injects predicates into the generated SQL, without each host re-inventing it.
+
+### 5. The metadata layer is unaffected
+
+`adapter-prisma`, `adapter-sql`, `adapter-dbt`, `adapter-json` retain their current `MetadataAdapter` shape. Schema discovery legitimately comes from many sources; query execution does not.
+
+### 6. ADR-008 is amended, not superseded
+
+ADR-008's backend-agnostic probe contract remains valid for non-SQL hosts and the dev-app probe. This ADR adds the SQL-flavored execution path the spec called for. A short "Update" section will be added to ADR-008 pointing here.
+
+## Consequences
+
+### Positive
+
+- Hosts implementing a SQL-backed `QueryAdapter` write ~10 lines (auth + executor binding) instead of 600 lines of bespoke translator.
+- SQL semantic bugs (DISTINCT, NULLs, CASE, window functions) get fixed once, in one tested package, and propagate to every host on the next `@supersubset/query-sql` bump.
+- The `LogicalQuery` contract gains an explicit `distinct` flag, closing the synthesized-options gap in #159.
+- The runtime's `resolveFilterOptionsWithAdapter` fallback (added for #121) becomes reliable across hosts.
+- The library's value proposition — "embeddable analytics for hosts with a SQL warehouse" — is honored instead of pushed onto host implementers.
+
+### Negative
+
+- Adds a new published package to maintain.
+- Hosts already running custom SQL translators (Tripmatch) need a migration path. The migration is straightforward (replace `translateQuery` calls with `SqlQueryAdapter`), but it is real work.
+- SQL dialect handling becomes a supersubset responsibility. The MVP supports DuckDB and a "standard" dialect; Postgres / ClickHouse / Snowflake follow.
+
+### Neutral
+
+- The non-SQL `QueryAdapter` escape hatch is preserved — Prisma-direct, GraphQL, or REST-backed hosts can still implement `QueryAdapter` themselves.
+- The metadata adapter packages are unchanged.
+
+## Alternatives Considered
+
+| Alternative                                                                       | Pros                                            | Cons                                                                                                                                          | Why Rejected                                                    |
+| --------------------------------------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| Add `distinct?: boolean` to `LogicalQuery` only; leave translation in hosts       | Smallest change. Closes #159 today.             | Leaves the 600-line duplication. Next semantic gap repeats the same dynamic. Defers the work without removing it.                             | Treats a symptom, not the cause.                                |
+| Put SQL translation inside `query-client`                                         | Matches the literal words of `initial-spec.md`. | `query-client` is the public face for the runtime to talk to _any_ backend. Mixing SQL specifics into it bloats the agnostic surface.         | Separation of concerns is clearer with a sibling package.       |
+| Extend `adapter-sql` with query translation                                       | One fewer package.                              | "adapter-sql" is documented as a `MetadataAdapter` (catalog introspection). Overloading it with query execution muddies the naming and scope. | Keep metadata adapters for metadata. New package for execution. |
+| Build a server-side service hosted by Supersubset that hosts call over HTTP       | Centralizes everything.                         | Violates "no required vendor backend, no forced hosted service" from `initial-spec.md`.                                                       | Out of scope for a library.                                     |
+| Stay backend-agnostic; require each host to implement `QueryAdapter` from scratch | Already what ADR-008 says.                      | Costs every SQL-backed host hundreds of lines, creates DISTINCT-class bugs, and fights the spec.                                              | The status quo, which produced #159.                            |
+
+## References
+
+- [`initial-spec.md`](../../initial-spec.md) — original architectural direction (SQL-first execution, pluggable metadata)
+- [ADR-004: Package Boundaries](./004-package-boundaries.md) — current package layout
+- [ADR-008: Supersubset HTTP Probe Contract](./008-supersubset-http-probe-contract.md) — amended by this ADR
+- [ADR-009: Filter Option Source Contract](./009-filter-option-source-contract.md) — `resolveFilterOptionsWithAdapter` is the proximate user of the new SQL path
+- [Issue #121](https://github.com/wandir-tech/supersubset/issues/121) — field-backed runtime resolution
+- [Issue #159](https://github.com/wandir-tech/supersubset/issues/159) — field-backed options don't work (the surface symptom)

--- a/docs/adr/012-sql-query-adapter.md
+++ b/docs/adr/012-sql-query-adapter.md
@@ -1,4 +1,4 @@
-# ADR-011: Centralize SQL Generation in a Reusable SqlQueryAdapter
+# ADR-012: Centralize SQL Generation in a Reusable SqlQueryAdapter
 
 ## Status
 

--- a/e2e/interactions/dashboard-filter.spec.ts
+++ b/e2e/interactions/dashboard-filter.spec.ts
@@ -105,7 +105,9 @@ async function switchToViewer(page: Page) {
 }
 
 test.describe('Dashboard Filters', () => {
-  test('viewer renders placed filter-bar widgets without registry errors', async ({ page }) => {
+  test('[runtime-rendering.WIDGET_REGISTRY.3] viewer renders placed filter-bar widgets without registry errors', async ({
+    page,
+  }) => {
     const consoleErrors = trackConsoleErrors(page);
 
     await openViewerLiveDashboard(page);
@@ -150,7 +152,9 @@ test.describe('Dashboard Filters', () => {
     ).toHaveLength(0);
   });
 
-  test('placed filter-bar widgets share filter state and reset together', async ({ page }) => {
+  test('[filters-and-interactions.CROSS_WIDGET_FILTERS.1] placed filter-bar widgets share filter state and reset together', async ({
+    page,
+  }) => {
     await openViewerLiveDashboard(page);
 
     const allFiltersBar = filterBarWidget(page, 'w-filter-bar-all').locator('.ss-filter-bar');
@@ -174,7 +178,7 @@ test.describe('Dashboard Filters', () => {
     await expect(allFiltersBar.getByLabel('Region')).toHaveValue('');
   });
 
-  test('live dashboard filters update KPI and table data as well as control state', async ({
+  test('[filters-and-interactions.CROSS_WIDGET_FILTERS.3] live dashboard filters update KPI and table data as well as control state', async ({
     page,
   }) => {
     await openViewerLiveDashboard(page);
@@ -313,7 +317,7 @@ test.describe('Dashboard Filters', () => {
     await expect(ordersTable).toContainText('Wayne Ent');
   });
 
-  test('designer-edited filter bar widget preserves title, vertical layout, subset, and analytical behavior', async ({
+  test('[interface-behavior.DESIGNER_RUNTIME_PARITY.1] designer-edited filter bar widget preserves title, vertical layout, subset, and analytical behavior', async ({
     page,
   }) => {
     await page.setViewportSize(DESIGNER_VIEWPORT);
@@ -366,7 +370,9 @@ test.describe('Cross-Filtering', () => {
     await openViewerLiveDashboard(page);
   });
 
-  test('clicking a chart data point logs a widget event', async ({ page }) => {
+  test('[filters-and-interactions.CLICK_TO_FILTER.2] clicking a chart data point logs a widget event', async ({
+    page,
+  }) => {
     // Find a chart widget
     const chart = page.locator('.ss-widget').first();
     await expect(chart).toBeVisible();

--- a/e2e/plan-a-designer-happy-path.spec.ts
+++ b/e2e/plan-a-designer-happy-path.spec.ts
@@ -14,7 +14,9 @@ test.describe('Test Plan A — Designer Happy Path', () => {
     await page.goto('/');
   });
 
-  test('Step 1: Launch & initial load — viewer renders without errors', async ({ page }) => {
+  test('[interface-behavior.LOADING_STATES.1] Step 1: Launch & initial load — viewer renders without errors', async ({
+    page,
+  }) => {
     const errors: string[] = [];
     page.on('console', (msg) => {
       if (msg.type() === 'error' && !msg.text().includes('React')) {
@@ -31,7 +33,9 @@ test.describe('Test Plan A — Designer Happy Path', () => {
     expect(errors).toHaveLength(0);
   });
 
-  test('Step 2: Multi-page navigation works', async ({ page }) => {
+  test('[navigation-and-alerts.PAGE_NAVIGATION.1] Step 2: Multi-page navigation works', async ({
+    page,
+  }) => {
     // Should have page tabs for the demo dashboard
     await page.waitForTimeout(1000);
 
@@ -51,7 +55,9 @@ test.describe('Test Plan A — Designer Happy Path', () => {
     });
   });
 
-  test('Step 3: Designer loads with Puck editor', async ({ page }) => {
+  test('[designer-authoring.PUCK_SHELL.1] Step 3: Designer loads with Puck editor', async ({
+    page,
+  }) => {
     await page.getByText('Designer').click();
     await page.waitForTimeout(3000);
 
@@ -65,7 +71,9 @@ test.describe('Test Plan A — Designer Happy Path', () => {
     await expect(puckContainer.first()).toBeVisible({ timeout: 10000 });
   });
 
-  test('Step 4: Filters slide-over panel opens from toolbar', async ({ page }) => {
+  test('[filters-and-interactions.FILTER_BAR.2] Step 4: Filters slide-over panel opens from toolbar', async ({
+    page,
+  }) => {
     await page.getByText('Designer').click();
     await page.waitForTimeout(2000);
 
@@ -87,7 +95,9 @@ test.describe('Test Plan A — Designer Happy Path', () => {
     await expect(page.getByTestId('slide-over-panel')).not.toBeVisible();
   });
 
-  test('Step 5: Code view shows canonical schema', async ({ page }) => {
+  test('[designer-authoring.CODE_VIEW.1] Step 5: Code view shows canonical schema', async ({
+    page,
+  }) => {
     await page.getByText('Designer').click();
     await page.waitForTimeout(2000);
 
@@ -104,7 +114,9 @@ test.describe('Test Plan A — Designer Happy Path', () => {
     await expect(page.getByText('schemaVersion').first()).toBeVisible({ timeout: 5000 });
   });
 
-  test('Step 6: Preview mode with responsive viewport', async ({ page }) => {
+  test('[designer-authoring.CONTROL_MODES.1] Step 6: Preview mode with responsive viewport', async ({
+    page,
+  }) => {
     await page.getByText('Preview').click();
     await page.waitForTimeout(2000);
 
@@ -132,7 +144,9 @@ test.describe('Test Plan A — Designer Happy Path', () => {
     });
   });
 
-  test('Step 7: Full round-trip — designer → publish → viewer', async ({ page }) => {
+  test('[designer-authoring.IMPORT_EXPORT.2] Step 7: Full round-trip — designer → publish → viewer', async ({
+    page,
+  }) => {
     const consoleMessages: string[] = [];
     page.on('console', (msg) => {
       if (msg.text().includes('[Supersubset]')) {

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Dev App Smoke Test', () => {
-  test('loads the dev app', async ({ page }) => {
+  test('[host-integration.LIBRARY_FIRST.1] loads the dev app', async ({ page }) => {
     await page.goto('/');
     await expect(page).toHaveTitle(/Supersubset/);
   });

--- a/e2e/visual/chart-header-layout.spec.ts
+++ b/e2e/visual/chart-header-layout.spec.ts
@@ -7,7 +7,9 @@ test.describe('Chart Header Layout Visual Regression', () => {
     await page.waitForTimeout(1200);
   });
 
-  test('line chart header layout remains stable', async ({ page }) => {
+  test('[charts-and-visualization.ECHARTS_WRAPPERS.2] line chart header layout remains stable', async ({
+    page,
+  }) => {
     const chartCard = page.locator('[data-ss-node="w-line"]');
     await expect(chartCard).toBeVisible();
 

--- a/e2e/workflows/alerts-widget.spec.ts
+++ b/e2e/workflows/alerts-widget.spec.ts
@@ -22,7 +22,9 @@ function buildDashboardWithStackedAlerts() {
 }
 
 test.describe('Alerts widget workflow', () => {
-  test('renders in viewer and stays available through the designer canvas', async ({ page }) => {
+  test('[navigation-and-alerts.ALERT_WIDGETS.2] renders in viewer and stays available through the designer canvas', async ({
+    page,
+  }) => {
     const consoleErrors: string[] = [];
     page.on('console', (message) => {
       if (message.type() === 'error') {
@@ -52,7 +54,7 @@ test.describe('Alerts widget workflow', () => {
     expect(consoleErrors.filter((entry) => !entry.includes('favicon'))).toHaveLength(0);
   });
 
-  test('imported alerts config applies stacked layout and max item visibility in viewer mode', async ({
+  test('[navigation-and-alerts.ALERT_WIDGETS.3] imported alerts config applies stacked layout and max item visibility in viewer mode', async ({
     page,
   }) => {
     const stackedDashboard = buildDashboardWithStackedAlerts();

--- a/e2e/workflows/backend-probe.spec.ts
+++ b/e2e/workflows/backend-probe.spec.ts
@@ -155,7 +155,9 @@ async function openProbe(page: import('@playwright/test').Page) {
 }
 
 test.describe('Backend probe live discovery', () => {
-  test('loads the designer from a live discovery URL with bearer auth', async ({ page }) => {
+  test('[query-and-probe.PROBE_DISCOVERY.1] loads the designer from a live discovery URL with bearer auth', async ({
+    page,
+  }) => {
     let authorizationHeader = '';
 
     await page.route('**/probe-mock-api/supersubset/datasets', async (route) => {
@@ -192,7 +194,7 @@ test.describe('Backend probe live discovery', () => {
     expect(download.suggestedFilename()).toBe('backend-probe-dashboard.json');
   });
 
-  test('loads the designer from a live discovery URL with a custom auth header', async ({
+  test('[query-and-probe.PROBE_DISCOVERY.2] loads the designer from a live discovery URL with a custom auth header', async ({
     page,
   }) => {
     let headerName = '';
@@ -229,7 +231,7 @@ test.describe('Backend probe live discovery', () => {
     expect(headerValue).toBe('alpha-dev-key');
   });
 
-  test('logs in with email and password, then reuses the returned token for discovery', async ({
+  test('[query-and-probe.PROBE_QUERY.3] logs in with email and password, then reuses the returned token for discovery', async ({
     page,
   }) => {
     let loginBody: Record<string, unknown> | null = null;
@@ -282,7 +284,7 @@ test.describe('Backend probe live discovery', () => {
     expect(authorizationHeader).toBe('Bearer probe-login-token-12345');
   });
 
-  test('connects to the real Next.js workbench backend and runs a live preview query', async ({
+  test('[query-and-probe.PREVIEW_DATA.2] connects to the real Next.js workbench backend and runs a live preview query', async ({
     page,
   }) => {
     const importedDashboard = buildWorkbenchProbePreviewDashboard();
@@ -340,7 +342,9 @@ test.describe('Backend probe live discovery', () => {
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });
 
-  test('stays on the probe form and shows an error when login fails', async ({ page }) => {
+  test('[query-and-probe.ERROR_ENVELOPE.1] stays on the probe form and shows an error when login fails', async ({
+    page,
+  }) => {
     await page.route('**/probe-login-api-fail/graphql', async (route) => {
       await route.fulfill({
         status: 200,
@@ -368,7 +372,9 @@ test.describe('Backend probe live discovery', () => {
     await expect(page.getByTestId('probe-connect-button')).toBeVisible();
   });
 
-  test('shows an error when discovery succeeds but returns no datasets', async ({ page }) => {
+  test('[query-and-probe.ERROR_ENVELOPE.2] shows an error when discovery succeeds but returns no datasets', async ({
+    page,
+  }) => {
     await page.route('**/probe-empty-api/supersubset/datasets', async (route) => {
       await route.fulfill({
         status: 200,
@@ -413,7 +419,7 @@ test.describe('Backend probe live discovery', () => {
     await expect(page.getByText('Supersubset Probe Designer')).toHaveCount(0);
   });
 
-  test('accepts raw dataset arrays from direct /datasets and /query endpoints', async ({
+  test('[query-and-probe.BACKEND_AGNOSTIC.1] accepts raw dataset arrays from direct /datasets and /query endpoints', async ({
     page,
   }) => {
     const importedDashboard = buildProbePreviewDashboard();
@@ -472,7 +478,7 @@ test.describe('Backend probe live discovery', () => {
     });
   });
 
-  test('executes preview queries after connecting with pasted metadata and an explicit query URL', async ({
+  test('[query-and-probe.PROBE_QUERY.1] executes preview queries after connecting with pasted metadata and an explicit query URL', async ({
     page,
   }) => {
     const importedDashboard = buildProbePreviewDashboard();
@@ -527,7 +533,7 @@ test.describe('Backend probe live discovery', () => {
     });
   });
 
-  test('shows empty preview fallback status when a connected query returns no rows', async ({
+  test('[interface-behavior.EMPTY_STATES.1] shows empty preview fallback status when a connected query returns no rows', async ({
     page,
   }) => {
     const importedDashboard = buildProbePreviewDashboard();
@@ -568,7 +574,9 @@ test.describe('Backend probe live discovery', () => {
     await expect(page.getByText('Supersubset Probe Designer')).toBeVisible();
   });
 
-  test('shows error preview fallback status when a connected query fails', async ({ page }) => {
+  test('[interface-behavior.ERROR_STATES.1] shows error preview fallback status when a connected query fails', async ({
+    page,
+  }) => {
     const importedDashboard = buildProbePreviewDashboard();
 
     await page.route('**/probe-preview-error/supersubset/query', async (route) => {
@@ -603,7 +611,9 @@ test.describe('Backend probe live discovery', () => {
     await expect(page.getByText('Supersubset Probe Designer')).toBeVisible();
   });
 
-  test('restores remembered probe settings after reload', async ({ page }) => {
+  test('[query-and-probe.PROBE_DISCOVERY.3] restores remembered probe settings after reload', async ({
+    page,
+  }) => {
     const metadataJson = JSON.stringify(DISCOVERY_FIXTURE);
     const rememberCheckbox = page.getByRole('checkbox', {
       name: 'Remember settings in sessionStorage for this browser session',

--- a/e2e/workflows/designer-chart-matrix.spec.ts
+++ b/e2e/workflows/designer-chart-matrix.spec.ts
@@ -41,7 +41,7 @@ test.describe('Designer chart matrix certification', () => {
     await page.setViewportSize(VIEWPORT);
   });
 
-  test('shared chart engine proves legend placement, formatted values, and click payload propagation', async ({
+  test('[charts-and-visualization.ROUND_TRIP.1] shared chart engine proves legend placement, formatted values, and click payload propagation', async ({
     page,
   }) => {
     await openDesigner(page);
@@ -156,7 +156,7 @@ test.describe('Designer chart matrix certification', () => {
     );
   });
 
-  test('line chart viewer preserves axis titles and rotated labels from designer controls', async ({
+  test('[charts-and-visualization.ROUND_TRIP.2] line chart viewer preserves axis titles and rotated labels from designer controls', async ({
     page,
   }) => {
     await openDesigner(page);
@@ -254,7 +254,9 @@ test.describe('Designer chart matrix certification', () => {
     });
   });
 
-  test('pie chart viewer preserves donut layout after designer edits', async ({ page }) => {
+  test('[charts-and-visualization.FIELD_BINDING.1] pie chart viewer preserves donut layout after designer edits', async ({
+    page,
+  }) => {
     await openDesigner(page);
     await openDesignerPage(page, 'page-gallery');
     await selectDesignerWidget(page, 'chart-pie');
@@ -303,7 +305,9 @@ test.describe('Designer chart matrix certification', () => {
     );
   });
 
-  test('scatter chart viewer preserves mark sizing after designer edits', async ({ page }) => {
+  test('[charts-and-visualization.SCATTER.1] scatter chart viewer preserves mark sizing after designer edits', async ({
+    page,
+  }) => {
     await openDesigner(page);
     await openDesignerPage(page, 'page-gallery');
     await selectDesignerWidget(page, 'chart-scatter');
@@ -685,7 +689,7 @@ test.describe('Designer chart matrix certification', () => {
     );
   });
 
-  test('waterfall chart viewer preserves colors and total labeling after designer edits', async ({
+  test('[charts-and-visualization.THEMES.2] waterfall chart viewer preserves colors and total labeling after designer edits', async ({
     page,
   }) => {
     await openDesigner(page);
@@ -793,7 +797,7 @@ test.describe('Designer chart matrix certification', () => {
     });
   });
 
-  test('gauge chart viewer preserves semicircle progress geometry after designer edits', async ({
+  test('[charts-and-visualization.VISUALIZATION_SCOPE.1] gauge chart viewer preserves semicircle progress geometry after designer edits', async ({
     page,
   }) => {
     await openDesigner(page);
@@ -840,7 +844,7 @@ test.describe('Designer chart matrix certification', () => {
     await expect(totalsRow).toContainText('16,255');
   });
 
-  test('table designer controls change row numbering, page size, and striping in viewer', async ({
+  test('[charts-and-visualization.FIELD_BINDING.3] table designer controls change row numbering, page size, and striping in viewer', async ({
     page,
   }) => {
     await openDesigner(page);
@@ -876,7 +880,7 @@ test.describe('Designer chart matrix certification', () => {
     await expect(kpi).toContainText('(↓ is good)');
   });
 
-  test('kpi designer controls change suffix, value sizing, and comparison rendering in viewer', async ({
+  test('[charts-and-visualization.FIELD_BINDING.2] kpi designer controls change suffix, value sizing, and comparison rendering in viewer', async ({
     page,
   }) => {
     await openDesigner(page);

--- a/e2e/workflows/designer-page-management.spec.ts
+++ b/e2e/workflows/designer-page-management.spec.ts
@@ -7,14 +7,18 @@ async function openDesigner(page: import('@playwright/test').Page) {
 }
 
 test.describe('Designer page management', () => {
-  test('avoids outer header overflow at wide desktop widths', async ({ page }) => {
+  test('[designer-authoring.PUCK_SHELL.3] avoids outer header overflow at wide desktop widths', async ({
+    page,
+  }) => {
     await page.setViewportSize({ width: 1600, height: 900 });
     await openDesigner(page);
 
-    const headerMetrics = await page.getByTestId('designer-header-controls').evaluate((element) => ({
-      clientWidth: element.clientWidth,
-      scrollWidth: element.scrollWidth,
-    }));
+    const headerMetrics = await page
+      .getByTestId('designer-header-controls')
+      .evaluate((element) => ({
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+      }));
 
     expect(headerMetrics.scrollWidth - headerMetrics.clientWidth).toBeLessThan(2);
   });
@@ -39,7 +43,9 @@ test.describe('Designer page management', () => {
     expect(canvasBox?.y ?? Number.POSITIVE_INFINITY).toBeLessThan(viewportHeight - 120);
   });
 
-  test('adds and renames a page from the header controls', async ({ page }) => {
+  test('[designer-authoring.PAGE_NAVIGATION.1] adds and renames a page from the header controls', async ({
+    page,
+  }) => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await openDesigner(page);
 
@@ -53,7 +59,9 @@ test.describe('Designer page management', () => {
     await expect(page.getByTestId('designer-page-tab-page-3')).toHaveText('Regional Detail');
   });
 
-  test('deletes the explicitly targeted page without changing the current page', async ({ page }) => {
+  test('[navigation-and-alerts.PAGE_NAVIGATION.3] deletes the explicitly targeted page without changing the current page', async ({
+    page,
+  }) => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await openDesigner(page);
 
@@ -67,7 +75,9 @@ test.describe('Designer page management', () => {
     await expect(page.getByTestId('designer-page-title-input')).toHaveValue('Overview');
   });
 
-  test('falls back to the previous page when deleting the active page', async ({ page }) => {
+  test('[navigation-and-alerts.PAGE_NAVIGATION.2] falls back to the previous page when deleting the active page', async ({
+    page,
+  }) => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await openDesigner(page);
 

--- a/e2e/workflows/designer-to-renderer.spec.ts
+++ b/e2e/workflows/designer-to-renderer.spec.ts
@@ -14,14 +14,18 @@ test.describe('Designer-to-Renderer Workflow', () => {
     await page.goto('/');
   });
 
-  test('app loads with mode toggle buttons', async ({ page }) => {
+  test('[host-integration.DESIGNER_MODES.1] app loads with mode toggle buttons', async ({
+    page,
+  }) => {
     // The dev app has Viewer/Designer/Preview mode buttons
     await expect(page.getByText('Viewer')).toBeVisible();
     await expect(page.getByText('Designer')).toBeVisible();
     await expect(page.getByText('Preview')).toBeVisible();
   });
 
-  test('viewer mode renders charts without errors', async ({ page }) => {
+  test('[runtime-rendering.RENDER_MODES.1] viewer mode renders charts without errors', async ({
+    page,
+  }) => {
     const errors: string[] = [];
     page.on('console', (msg) => {
       if (msg.type() === 'error') errors.push(msg.text());
@@ -42,7 +46,7 @@ test.describe('Designer-to-Renderer Workflow', () => {
     expect(errors.filter((e) => !e.includes('React'))).toHaveLength(0);
   });
 
-  test('designer mode loads Puck editor', async ({ page }) => {
+  test('[designer-authoring.PUCK_SHELL.2] designer mode loads Puck editor', async ({ page }) => {
     await page.getByText('Designer').click();
 
     // Puck editor should load — look for its main container
@@ -53,7 +57,9 @@ test.describe('Designer-to-Renderer Workflow', () => {
     await expect(designerFrame.first()).toBeVisible({ timeout: 10000 });
   });
 
-  test('preview mode shows responsive viewport switcher', async ({ page }) => {
+  test('[runtime-rendering.RENDER_MODES.2] preview mode shows responsive viewport switcher', async ({
+    page,
+  }) => {
     await page.getByText('Preview').click();
 
     // LivePreviewPane has viewport buttons
@@ -62,7 +68,9 @@ test.describe('Designer-to-Renderer Workflow', () => {
     await expect(page.locator('[data-testid="viewport-mobile"]')).toBeVisible();
   });
 
-  test('mode switching preserves state', async ({ page }) => {
+  test('[runtime-rendering.STATE_PERSISTENCE.1] mode switching preserves state', async ({
+    page,
+  }) => {
     // Start in viewer
     await expect(page.getByText('Viewer')).toBeVisible();
 
@@ -84,7 +92,9 @@ test.describe('Designer-to-Renderer Workflow', () => {
     expect(count).toBeGreaterThanOrEqual(1);
   });
 
-  test('designer toolbar shows undo/redo and dashboard filters', async ({ page }) => {
+  test('[designer-authoring.UNDO_REDO.1] designer toolbar shows undo/redo and dashboard filters', async ({
+    page,
+  }) => {
     await page.getByText('Designer').click();
     await page.waitForTimeout(1000);
 
@@ -96,7 +106,7 @@ test.describe('Designer-to-Renderer Workflow', () => {
     await expect(page.getByText('Interactions')).toBeVisible();
   });
 
-  test('designer canvas preserves authored row spans from the canonical dashboard', async ({
+  test('[runtime-rendering.LAYOUT_ENGINE.1] designer canvas preserves authored row spans from the canonical dashboard', async ({
     page,
   }) => {
     await page.getByText('Designer').click();
@@ -154,7 +164,9 @@ test.describe('Designer-to-Renderer Workflow', () => {
     );
   });
 
-  test('filters panel opens as slide-over', async ({ page }) => {
+  test('[filters-and-interactions.FILTER_BAR.2] filters panel opens as slide-over', async ({
+    page,
+  }) => {
     await page.getByText('Designer').click();
     await page.waitForTimeout(1000);
 
@@ -167,7 +179,9 @@ test.describe('Designer-to-Renderer Workflow', () => {
     await expect(page.getByRole('heading', { name: 'Dashboard Filters' })).toBeVisible();
   });
 
-  test('adding a dashboard filter updates the drawer immediately', async ({ page }) => {
+  test('[designer-authoring.PROPERTY_PANELS.2] adding a dashboard filter updates the drawer immediately', async ({
+    page,
+  }) => {
     await page.getByText('Designer').click();
     await page.waitForTimeout(1000);
 

--- a/e2e/workflows/filter-cascade.spec.ts
+++ b/e2e/workflows/filter-cascade.spec.ts
@@ -47,7 +47,9 @@ test.describe('Filter Cascade Workflow', () => {
     });
   }
 
-  test('dashboard renders with filter bar and all widgets', async ({ page }) => {
+  test('[runtime-rendering.WIDGET_REGISTRY.1] dashboard renders with filter bar and all widgets', async ({
+    page,
+  }) => {
     // Verify the dashboard renders
     const dashboard = page.locator('[data-ss-dashboard]');
     await expect(dashboard).toBeVisible();
@@ -57,7 +59,9 @@ test.describe('Filter Cascade Workflow', () => {
     expect(await widgets.count()).toBeGreaterThan(0);
   });
 
-  test('filter bar is present when filters are defined', async ({ page }) => {
+  test('[filters-and-interactions.FILTER_BAR.1] filter bar is present when filters are defined', async ({
+    page,
+  }) => {
     const filterBar = page.locator('.ss-filter-bar');
     // The demo dashboard has filters, so filter bar should appear
     await expect(filterBar.first()).toBeVisible();
@@ -69,7 +73,9 @@ test.describe('Filter Cascade Workflow', () => {
     }
   });
 
-  test('switching pages preserves mode', async ({ page }) => {
+  test('[navigation-and-alerts.PAGE_NAVIGATION.2] switching pages preserves mode', async ({
+    page,
+  }) => {
     // If there are page tabs, clicking them should stay in viewer mode
     const tabs = page.locator('nav button');
     const tabCount = await tabs.count();
@@ -81,7 +87,9 @@ test.describe('Filter Cascade Workflow', () => {
     }
   });
 
-  test('mode switching works with filters', async ({ page }) => {
+  test('[runtime-rendering.FILTER_ENGINE.1] mode switching works with filters', async ({
+    page,
+  }) => {
     // Switch to preview mode
     const previewBtn = page.getByRole('button', { name: /preview/i });
     if (await previewBtn.isVisible()) {
@@ -99,7 +107,7 @@ test.describe('Filter Cascade Workflow', () => {
     }
   });
 
-  test('page demo shows shared filters on both pages and preserves selected values', async ({
+  test('[filters-and-interactions.STATE_OWNERSHIP.1] page demo shows shared filters on both pages and preserves selected values', async ({
     page,
   }) => {
     await openPagesWorkbook(page);
@@ -127,7 +135,9 @@ test.describe('Filter Cascade Workflow', () => {
     await expect(page.locator('.ss-filter-bar').getByLabel('Region')).toHaveValue('East');
   });
 
-  test('real overview chart clicks navigate to the detail page', async ({ page }) => {
+  test('[filters-and-interactions.DRILLDOWN.1] real overview chart clicks navigate to the detail page', async ({
+    page,
+  }) => {
     await openPagesWorkbook(page);
 
     await page.evaluate(() => {
@@ -162,7 +172,7 @@ test.describe('Filter Cascade Workflow', () => {
     });
   });
 
-  test('separate dashboards switch document identity instead of preserving workbook state', async ({
+  test('[navigation-and-alerts.DASHBOARD_NAVIGATION.1] separate dashboards switch document identity instead of preserving workbook state', async ({
     page,
   }) => {
     await openSeparateDashboardsDemo(page);
@@ -191,7 +201,7 @@ test.describe('Filter Cascade Workflow', () => {
     ).toBeVisible();
   });
 
-  test('page-scoped category filter changes overview widgets without leaking into detail widgets', async ({
+  test('[filters-and-interactions.CROSS_WIDGET_FILTERS.2] page-scoped category filter changes overview widgets without leaking into detail widgets', async ({
     page,
   }) => {
     await openPagesWorkbook(page);

--- a/e2e/workflows/host-integration.spec.ts
+++ b/e2e/workflows/host-integration.spec.ts
@@ -123,14 +123,14 @@ test.describe('Host Integration Workflow', () => {
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });
 
-  test('[interface-behavior.EMPTY_STATES.2] Vite host resolves field-backed Region options through the host QueryAdapter', async ({
+  test('[interface-behavior.EMPTY_STATES.2] Vite host renders explicit unavailable state for search-strategy field-backed options (no typeahead UI yet)', async ({
     page,
   }) => {
-    // Updated for ADR-011: with `LogicalQuery.distinct` plus `SqlQueryAdapter`
-    // (or any QueryAdapter implementing `execute`), field-backed options now
-    // resolve through the host instead of rendering the legacy unavailable
-    // placeholder. The Vite + SQLite example provides a QueryAdapter, so the
-    // Region filter populates with distinct values from the live dataset.
+    // Updated for ADR-012 / ADR-009 §3: field-backed options with the default
+    // `strategy: 'search'` must not auto-issue an unbounded distinct query on
+    // initial render — the runtime renders an explicit unavailable state
+    // until a typeahead input is wired. `strategy: 'preload'` is the safe
+    // path for low-cardinality fields and is covered by unit tests.
     const consoleErrors: string[] = [];
 
     page.on('console', (msg) => {
@@ -154,14 +154,12 @@ test.describe('Host Integration Workflow', () => {
     await page.getByRole('button', { name: 'Viewer' }).click();
 
     const regionFilter = page.getByLabel('Region');
-    await expect(regionFilter).toHaveAttribute('data-ss-filter-options-state', 'ready');
-    await expect(regionFilter).toBeEnabled();
-    // Placeholder + at least one resolved value from the host dataset.
-    await expect(regionFilter.locator('option')).not.toHaveText([
-      'Field-backed options require host support',
-    ]);
-    const optionCount = await regionFilter.locator('option').count();
-    expect(optionCount).toBeGreaterThan(1);
+    await expect(regionFilter).toHaveAttribute('data-ss-filter-options-state', 'unavailable');
+    await expect(regionFilter).toBeDisabled();
+    await expect(regionFilter.locator('option')).toHaveCount(1);
+    await expect(regionFilter.locator('option').first()).toContainText(
+      /Search-strategy field options require a typeahead input/,
+    );
 
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });

--- a/e2e/workflows/host-integration.spec.ts
+++ b/e2e/workflows/host-integration.spec.ts
@@ -17,7 +17,9 @@ function buildImportedHostDashboard() {
 }
 
 test.describe('Host Integration Workflow', () => {
-  test('Next.js runtime host stays runtime-only and uses host-owned theming', async ({ page }) => {
+  test('[host-integration.EMBEDDING_CONTRACT.1] Next.js runtime host stays runtime-only and uses host-owned theming', async ({
+    page,
+  }) => {
     const requestUrls: string[] = [];
     const consoleErrors: string[] = [];
 
@@ -60,7 +62,7 @@ test.describe('Host Integration Workflow', () => {
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });
 
-  test('Vite host persists imported schema through host-owned localStorage and reload', async ({
+  test('[host-integration.HOST_OWNERSHIP.1] Vite host persists imported schema through host-owned localStorage and reload', async ({
     page,
   }) => {
     const requestUrls: string[] = [];
@@ -121,7 +123,7 @@ test.describe('Host Integration Workflow', () => {
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });
 
-  test('Vite host shows an explicit unavailable state when Region is authored with field-backed options', async ({
+  test('[interface-behavior.EMPTY_STATES.2] Vite host shows an explicit unavailable state when Region is authored with field-backed options', async ({
     page,
   }) => {
     const consoleErrors: string[] = [];

--- a/e2e/workflows/host-integration.spec.ts
+++ b/e2e/workflows/host-integration.spec.ts
@@ -123,9 +123,14 @@ test.describe('Host Integration Workflow', () => {
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });
 
-  test('[interface-behavior.EMPTY_STATES.2] Vite host shows an explicit unavailable state when Region is authored with field-backed options', async ({
+  test('[interface-behavior.EMPTY_STATES.2] Vite host resolves field-backed Region options through the host QueryAdapter', async ({
     page,
   }) => {
+    // Updated for ADR-011: with `LogicalQuery.distinct` plus `SqlQueryAdapter`
+    // (or any QueryAdapter implementing `execute`), field-backed options now
+    // resolve through the host instead of rendering the legacy unavailable
+    // placeholder. The Vite + SQLite example provides a QueryAdapter, so the
+    // Region filter populates with distinct values from the live dataset.
     const consoleErrors: string[] = [];
 
     page.on('console', (msg) => {
@@ -149,11 +154,14 @@ test.describe('Host Integration Workflow', () => {
     await page.getByRole('button', { name: 'Viewer' }).click();
 
     const regionFilter = page.getByLabel('Region');
-    await expect(regionFilter).toBeDisabled();
-    await expect(regionFilter.locator('option')).toHaveCount(1);
-    await expect(regionFilter.locator('option').first()).toHaveText(
+    await expect(regionFilter).toHaveAttribute('data-ss-filter-options-state', 'ready');
+    await expect(regionFilter).toBeEnabled();
+    // Placeholder + at least one resolved value from the host dataset.
+    await expect(regionFilter.locator('option')).not.toHaveText([
       'Field-backed options require host support',
-    );
+    ]);
+    const optionCount = await regionFilter.locator('option').count();
+    expect(optionCount).toBeGreaterThan(1);
 
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });

--- a/e2e/workflows/host-workbench.spec.ts
+++ b/e2e/workflows/host-workbench.spec.ts
@@ -248,14 +248,15 @@ test.describe('Next.js Real Host Workbench', () => {
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });
 
-  test('[host-integration.WORKBENCH_PATTERNS.3] imports a field-backed filter dashboard and resolves Region options through the host QueryAdapter in viewer mode', async ({
+  test('[host-integration.WORKBENCH_PATTERNS.3] imports a field-backed filter dashboard and renders an explicit unavailable state for search-strategy filters in viewer mode', async ({
     page,
   }) => {
-    // Updated for ADR-011: field-backed options now resolve through the
-    // host's QueryAdapter via the generic `LogicalQuery.distinct` path. The
-    // Next.js workbench exposes /api/analytics/supersubset/query, so Region
-    // populates with distinct values from the live dataset instead of
-    // rendering the legacy "host support" unavailable placeholder.
+    // Updated for ADR-012 / ADR-009 §3: the imported workbench dashboard
+    // authors the Region filter with `strategy: 'search'`, which must not
+    // auto-issue an unbounded distinct query on initial render. Until the
+    // typeahead input is wired, search-strategy filters render explicit
+    // unavailable state. `preload`-strategy filters and adapter-backed
+    // resolution are covered by unit tests.
     const fieldBackedDashboard = buildFieldBackedFilterWorkbenchDashboard();
     const requestUrls: string[] = [];
     const consoleErrors: string[] = [];
@@ -292,13 +293,12 @@ test.describe('Next.js Real Host Workbench', () => {
     const regionFilter = page.getByLabel('Region');
     const carrierFilter = page.getByLabel('Carrier');
 
-    await expect(regionFilter).toHaveAttribute('data-ss-filter-options-state', 'ready');
-    await expect(regionFilter).toBeEnabled();
-    await expect(regionFilter.locator('option')).not.toHaveText([
-      'Field-backed options require host support',
-    ]);
-    const regionOptionCount = await regionFilter.locator('option').count();
-    expect(regionOptionCount).toBeGreaterThan(1);
+    await expect(regionFilter).toHaveAttribute('data-ss-filter-options-state', 'unavailable');
+    await expect(regionFilter).toBeDisabled();
+    await expect(regionFilter.locator('option')).toHaveCount(1);
+    await expect(regionFilter.locator('option').first()).toContainText(
+      /Search-strategy field options require a typeahead input/,
+    );
     await expect(carrierFilter).toBeEnabled();
     await expect(carrierFilter.locator('option')).toContainText(['All', 'Atlas Air']);
 

--- a/e2e/workflows/host-workbench.spec.ts
+++ b/e2e/workflows/host-workbench.spec.ts
@@ -248,9 +248,14 @@ test.describe('Next.js Real Host Workbench', () => {
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });
 
-  test('[host-integration.WORKBENCH_PATTERNS.3] imports a field-backed filter dashboard and shows the explicit unavailable state in viewer mode', async ({
+  test('[host-integration.WORKBENCH_PATTERNS.3] imports a field-backed filter dashboard and resolves Region options through the host QueryAdapter in viewer mode', async ({
     page,
   }) => {
+    // Updated for ADR-011: field-backed options now resolve through the
+    // host's QueryAdapter via the generic `LogicalQuery.distinct` path. The
+    // Next.js workbench exposes /api/analytics/supersubset/query, so Region
+    // populates with distinct values from the live dataset instead of
+    // rendering the legacy "host support" unavailable placeholder.
     const fieldBackedDashboard = buildFieldBackedFilterWorkbenchDashboard();
     const requestUrls: string[] = [];
     const consoleErrors: string[] = [];
@@ -287,10 +292,13 @@ test.describe('Next.js Real Host Workbench', () => {
     const regionFilter = page.getByLabel('Region');
     const carrierFilter = page.getByLabel('Carrier');
 
-    await expect(regionFilter).toBeDisabled();
-    await expect(regionFilter.locator('option')).toHaveText([
+    await expect(regionFilter).toHaveAttribute('data-ss-filter-options-state', 'ready');
+    await expect(regionFilter).toBeEnabled();
+    await expect(regionFilter.locator('option')).not.toHaveText([
       'Field-backed options require host support',
     ]);
+    const regionOptionCount = await regionFilter.locator('option').count();
+    expect(regionOptionCount).toBeGreaterThan(1);
     await expect(carrierFilter).toBeEnabled();
     await expect(carrierFilter.locator('option')).toContainText(['All', 'Atlas Air']);
 

--- a/e2e/workflows/host-workbench.spec.ts
+++ b/e2e/workflows/host-workbench.spec.ts
@@ -104,7 +104,7 @@ async function ensureDesignerMenuBarExpanded(page: Page) {
 }
 
 test.describe('Next.js Real Host Workbench', () => {
-  test('logs in, loads datasets, and re-queries a query-backed alerts tile in viewer mode', async ({
+  test('[host-integration.WORKBENCH_PATTERNS.1] logs in, loads datasets, and re-queries a query-backed alerts tile in viewer mode', async ({
     page,
   }) => {
     const requestUrls: string[] = [];
@@ -160,7 +160,7 @@ test.describe('Next.js Real Host Workbench', () => {
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });
 
-  test('imports a structured alert-rule dashboard and executes it through the real host query adapter', async ({
+  test('[host-integration.WORKBENCH_PATTERNS.2] imports a structured alert-rule dashboard and executes it through the real host query adapter', async ({
     page,
   }) => {
     const structuredDashboard = buildStructuredAlertsWorkbenchDashboard();
@@ -248,7 +248,7 @@ test.describe('Next.js Real Host Workbench', () => {
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });
 
-  test('imports a field-backed filter dashboard and shows the explicit unavailable state in viewer mode', async ({
+  test('[host-integration.WORKBENCH_PATTERNS.3] imports a field-backed filter dashboard and shows the explicit unavailable state in viewer mode', async ({
     page,
   }) => {
     const fieldBackedDashboard = buildFieldBackedFilterWorkbenchDashboard();
@@ -301,7 +301,7 @@ test.describe('Next.js Real Host Workbench', () => {
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });
 
-  test('publishes an edited dashboard title and reloads the persisted workbench state without another login', async ({
+  test('[host-integration.HOST_OWNERSHIP.2] publishes an edited dashboard title and reloads the persisted workbench state without another login', async ({
     page,
   }) => {
     const editedDashboardTitle = 'Northstar Logistics Persisted Host Workflow';
@@ -347,7 +347,7 @@ test.describe('Next.js Real Host Workbench', () => {
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });
 
-  test('keeps the published dashboard across logout while discarding an unpublished draft after re-login', async ({
+  test('[host-integration.EMBEDDING_CONTRACT.2] keeps the published dashboard across logout while discarding an unpublished draft after re-login', async ({
     page,
   }) => {
     const publishedDashboardTitle = 'Northstar Published Session Boundary';
@@ -408,7 +408,7 @@ test.describe('Next.js Real Host Workbench', () => {
     expect(consoleErrors.filter((text) => !text.includes('favicon'))).toHaveLength(0);
   });
 
-  test('requires login in a second tab while rehydrating the published dashboard after login', async ({
+  test('[host-integration.EMBEDDING_CONTRACT.3] requires login in a second tab while rehydrating the published dashboard after login', async ({
     browser,
   }) => {
     const publishedDashboardTitle = 'Northstar Cross Tab Probe';
@@ -447,7 +447,7 @@ test.describe('Next.js Real Host Workbench', () => {
     }
   });
 
-  test('rehydrates a newer publish when a second tab logs in after mounting before the publish', async ({
+  test('[runtime-rendering.EMBEDDING.1] rehydrates a newer publish when a second tab logs in after mounting before the publish', async ({
     browser,
   }) => {
     const publishedDashboardTitle = 'Northstar Cross Tab Rehydrate On Login';
@@ -566,7 +566,7 @@ test.describe('Next.js Real Host Workbench', () => {
     }
   });
 
-  test('preserves an unpublished draft in a second tab while syncing the newer published dashboard', async ({
+  test('[designer-authoring.HOST_OWNERSHIP.1] preserves an unpublished draft in a second tab while syncing the newer published dashboard', async ({
     browser,
   }) => {
     const draftDashboardTitle = 'Northstar Draft Should Survive';

--- a/e2e/workflows/import-export-cycle.spec.ts
+++ b/e2e/workflows/import-export-cycle.spec.ts
@@ -77,7 +77,7 @@ test.describe('Import/Export Cycle Workflow', () => {
     await page.goto('/');
   });
 
-  test('code view shows JSON schema', async ({ page }) => {
+  test('[designer-authoring.CODE_VIEW.2] code view shows JSON schema', async ({ page }) => {
     // Switch to designer
     await page.getByText('Designer').click();
     await page.waitForTimeout(1500);
@@ -93,7 +93,7 @@ test.describe('Import/Export Cycle Workflow', () => {
     await expect(schemaContent.first()).toBeVisible({ timeout: 5000 });
   });
 
-  test('import/export panel opens', async ({ page }) => {
+  test('[designer-authoring.IMPORT_EXPORT.1] import/export panel opens', async ({ page }) => {
     await page.getByText('Designer').click();
     await page.waitForTimeout(1500);
 
@@ -103,12 +103,20 @@ test.describe('Import/Export Cycle Workflow', () => {
     const importBtn = page.getByText('Import');
 
     // At least one of these should be present
-    const hasExport = await exportBtn.first().isVisible().catch(() => false);
-    const hasImport = await importBtn.first().isVisible().catch(() => false);
+    const hasExport = await exportBtn
+      .first()
+      .isVisible()
+      .catch(() => false);
+    const hasImport = await importBtn
+      .first()
+      .isVisible()
+      .catch(() => false);
     expect(hasExport || hasImport).toBe(true);
   });
 
-  test('designer publishes valid schema on save', async ({ page }) => {
+  test('[schema-and-serialization.CANONICAL_SCHEMA.1] designer publishes valid schema on save', async ({
+    page,
+  }) => {
     const consoleMessages: string[] = [];
     page.on('console', (msg) => {
       if (msg.text().includes('[Supersubset] Dashboard published:')) {
@@ -121,7 +129,10 @@ test.describe('Import/Export Cycle Workflow', () => {
 
     // Puck has a Publish button — try to find and click it
     const publishBtn = page.locator('button', { hasText: /Publish/i });
-    const publishVisible = await publishBtn.first().isVisible().catch(() => false);
+    const publishVisible = await publishBtn
+      .first()
+      .isVisible()
+      .catch(() => false);
 
     if (publishVisible) {
       await publishBtn.first().click();
@@ -135,7 +146,9 @@ test.describe('Import/Export Cycle Workflow', () => {
     // If Publish not visible, this tests gracefully passes (Puck may hide it)
   });
 
-  test('import after refresh rehydrates a dashboard with an added line chart', async ({ page }) => {
+  test('[designer-authoring.IMPORT_EXPORT.2] import after refresh rehydrates a dashboard with an added line chart', async ({
+    page,
+  }) => {
     const importedDashboard = buildDashboardWithExtraLineChart();
 
     await page.reload();
@@ -158,7 +171,9 @@ test.describe('Import/Export Cycle Workflow', () => {
     await expect(page.locator('.ss-chart')).toHaveCount(3);
   });
 
-  test('alerts import preserves structured navigate targets across code view and viewer mode', async ({ page }) => {
+  test('[navigation-and-alerts.ALERT_WIDGETS.1] alerts import preserves structured navigate targets across code view and viewer mode', async ({
+    page,
+  }) => {
     const importedDashboard = buildDashboardWithAlertsAndStructuredNavigate();
 
     await page.getByText('Designer').click();
@@ -173,11 +188,11 @@ test.describe('Import/Export Cycle Workflow', () => {
     await expect(page.getByText('Last saved: Imported Alerts Dashboard')).toBeVisible();
 
     await page.getByTestId('code-toggle').click();
-  const codePanel = page.getByTestId('code-view-panel');
-  await expect(codePanel).toContainText('Imported Operations Watchlist');
-  await expect(codePanel).toContainText('"type": "alerts"');
-  await expect(codePanel).toContainText('"kind": "page"');
-  await expect(codePanel).toContainText('"pageId": "page-gallery"');
+    const codePanel = page.getByTestId('code-view-panel');
+    await expect(codePanel).toContainText('Imported Operations Watchlist');
+    await expect(codePanel).toContainText('"type": "alerts"');
+    await expect(codePanel).toContainText('"kind": "page"');
+    await expect(codePanel).toContainText('"pageId": "page-gallery"');
 
     await page.getByText('Viewer').click();
     await page.waitForTimeout(1000);

--- a/e2e/workflows/markdown-widget.spec.ts
+++ b/e2e/workflows/markdown-widget.spec.ts
@@ -1,7 +1,9 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('Markdown widget workflow', () => {
-  test('renders formatted copy and safe external links on the gallery page', async ({ page }) => {
+  test('[runtime-rendering.WIDGET_REGISTRY.2] renders formatted copy and safe external links on the gallery page', async ({
+    page,
+  }) => {
     await page.goto('/');
     await page.getByRole('button', { name: 'Chart Gallery' }).click();
 

--- a/e2e/workflows/metadata-to-dashboard.spec.ts
+++ b/e2e/workflows/metadata-to-dashboard.spec.ts
@@ -44,7 +44,9 @@ test.describe('Metadata to Dashboard Workflow', () => {
     await page.goto('/');
   });
 
-  test('import Prisma schema and render resulting dashboard', async ({ page }) => {
+  test('[metadata-adapters.CLI_IMPORT.1] import Prisma schema and render resulting dashboard', async ({
+    page,
+  }) => {
     // Switch to Designer mode
     await page.getByText('Designer').click();
     await page.waitForTimeout(1500);
@@ -59,13 +61,15 @@ test.describe('Metadata to Dashboard Workflow', () => {
     // For this e2e test, we verify the import UI works with a pre-generated dashboard
   });
 
-  test('dev app renders without errors', async ({ page }) => {
+  test('[metadata-adapters.METADATA_MODEL.1] dev app renders without errors', async ({ page }) => {
     // Verify the viewer mode renders correctly
     const heading = page.getByRole('heading', { name: /sales overview/i });
     await expect(heading).toBeVisible({ timeout: 5000 });
   });
 
-  test('designer mode shows Components sidebar', async ({ page }) => {
+  test('[metadata-adapters.METADATA_MODEL.2] designer mode shows Components sidebar', async ({
+    page,
+  }) => {
     await page.getByText('Designer').click();
     await page.waitForTimeout(1500);
     // Verify the renamed sidebar tabs are visible

--- a/e2e/workflows/persistence-regression.spec.ts
+++ b/e2e/workflows/persistence-regression.spec.ts
@@ -44,7 +44,9 @@ test.describe('Designer State Persistence Regressions', () => {
     await page.goto('/');
   });
 
-  test('imported dashboard survives designer, preview, and viewer mode switches', async ({ page }) => {
+  test('[runtime-rendering.STATE_PERSISTENCE.2] imported dashboard survives designer, preview, and viewer mode switches', async ({
+    page,
+  }) => {
     const importedDashboard = buildDashboardWithExtraLineChart();
 
     await page.getByText('Designer').click();
@@ -65,7 +67,9 @@ test.describe('Designer State Persistence Regressions', () => {
     await expect(page.getByText('chart-imported-line')).toBeVisible();
   });
 
-  test('active page recovers when imported dashboard removes the current page', async ({ page }) => {
+  test('[navigation-and-alerts.PAGE_NAVIGATION.1] active page recovers when imported dashboard removes the current page', async ({
+    page,
+  }) => {
     const singlePageDashboard = buildSinglePageDashboard();
 
     await page.getByText('Chart Gallery').click();

--- a/e2e/workflows/probe-metadata-paste.spec.ts
+++ b/e2e/workflows/probe-metadata-paste.spec.ts
@@ -1,7 +1,9 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('Probe metadata onboarding', () => {
-  test('opens the designer from pasted metadata JSON', async ({ page }) => {
+  test('[metadata-adapters.CLI_IMPORT.2] opens the designer from pasted metadata JSON', async ({
+    page,
+  }) => {
     await page.goto('/');
 
     await page.getByTestId('mode-probe').click();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,7 @@ export default tseslint.config(
       'playwright-report/**',
       'test-results/**',
       'screenshots/**',
+      'tools/requirements/**',
     ],
   },
   {

--- a/features/README.md
+++ b/features/README.md
@@ -1,0 +1,94 @@
+# Requirements
+
+Supersubset keeps stable product and system requirements as Acai-compatible feature specs under `features/`.
+
+Decision record: [docs/adr/011-requirements-artifacts.md](../docs/adr/011-requirements-artifacts.md).
+
+## Structure
+
+```text
+features/
+  *.feature.yaml
+  references/
+    acai-feature-yaml.yaml
+    platforms.yaml
+    term-yaml.schema.yaml
+  terms/*.term.yaml
+```
+
+Use root `features/*.feature.yaml` for active requirements, `features/references/` for supporting schemas and vocabularies, and one `features/terms/<term>.term.yaml` file per glossary term.
+
+## Feature Specs
+
+Feature specs stay synced to Acai's `feature.yaml` shape:
+
+- top-level keys: `feature`, `components`, `constraints`
+- behavior under `components`
+- cross-cutting policy under `constraints`
+- stable requirement IDs in Acai form: `<feature-name>.<GROUP_KEY>.<requirement-key>`
+
+Requirement keys must be numeric (`1`, `2`) or hyphen-nested (`1-1`). Quote hyphenated keys in YAML so they are not parsed as subtraction.
+
+Do not add custom top-level sections.
+
+Reference: `features/references/acai-feature-yaml.yaml` is the imported Acai `feature.yaml` spec from https://acai.sh/feature-yaml; Supersubset-specific policy lives here and in `tools/requirements/validate-feature-specs.mjs`.
+
+## Platform Scope
+
+Platform ids live in `features/references/platforms.yaml`. Current id is `web`.
+
+Default scope is web. Omit `note` for that default.
+
+## Glossary
+
+Glossary terms explain nouns used in feature specs. They do not change Acai feature parsing.
+
+Term schema: `features/references/term-yaml.schema.yaml`.
+
+- Emphasize nouns in requirement prose, for example `*dashboard*`.
+- Map multi-word terms to snake case, for example `*logical query*` -> `features/terms/logical_query.term.yaml`.
+- Prefer singular term files.
+- Keep references compact: package paths and TypeScript type names only when helpful.
+
+## Chart and Component Property Granularity
+
+Requirements YAML captures **capability contracts**, not a per-property inventory.
+
+- **Tier A:** Durable author/host-visible behavior (e.g. scatter point size round-trips designer → schema → runtime).
+- **Tier B:** Cross-cutting rules across chart or widget types.
+- **Tier C:** Individual property knobs — documented in schema types, Puck blocks, docs site, and exhaustive unit tests (`per-chart-properties`, `adapter-properties`) without per-property ACIDs unless regression-anchored.
+
+## Test And Code References
+
+Acai IDs belong first in feature specs, then in tests that prove the behavior.
+
+- Prefix test names only when the test primarily proves that requirement.
+- Use multiple prefixes only when one test genuinely proves multiple contracts.
+- Do not tag exhaustive property-matrix tests unless they prove a named Tier A/B requirement.
+
+For broad or corrective test tagging, read `.github/skills/requirements-test-tagging/SKILL.md`.
+
+## Workflow
+
+For durable behavior changes:
+
+1. Find the owning feature spec before implementation.
+2. Update or add requirements before coding through ambiguity.
+3. Link Acai IDs from GitHub issue acceptance criteria when an issue exists.
+4. Add precise Acai ID prefixes to requirement-proving tests.
+5. Run `pnpm run validate:requirements` after changing feature specs, glossary terms, or test IDs.
+6. Run `pnpm run requirements:coverage` to list uncovered spec ACIDs by feature.
+7. Run `pnpm run test:requirements-validator` after changing the validator or its fixtures.
+
+Use `.github/skills/requirements-intake/SKILL.md` to create or reorganize requirements, and `.github/skills/requirements-driven-work/SKILL.md` to implement or review against existing requirements.
+
+## Tools
+
+The local validator (`pnpm run validate:requirements`, CI jobs `requirements-validate.yml` and `ci.yml`) checks YAML parsing, duplicate ACIDs, glossary term shape, emphasized-term links, test references, platform notes, and `feature.product` without needing the Acai CLI or server.
+
+Coverage report:
+
+```bash
+pnpm run requirements:coverage
+pnpm run --silent requirements:coverage:json
+```

--- a/features/charts-and-visualization.feature.yaml
+++ b/features/charts-and-visualization.feature.yaml
@@ -1,0 +1,101 @@
+feature:
+  name: charts-and-visualization
+  product: supersubset
+  description: ECharts widget wrappers, designer-to-runtime chart config
+    round-trip, cross-chart field binding, scatter sizing capability, and theme
+    integration for Supersubset visualization.
+  version: 0.1.0
+  draft: false
+components:
+  ECHARTS_WRAPPERS:
+    name: ECharts Wrappers
+    description: Registered chart widget implementations for the runtime registry.
+    requirements:
+      1:
+        requirement: The charts package provides ECharts-backed *widget*
+          implementations for core analytical presentations including line, bar,
+          area, pie, scatter, combo, heatmap, table, KPI, and markdown surfaces.
+      2:
+        requirement: Each chart *widget* registers a stable type key and schema
+          props shape so the *designer* palette and *runtime* registry resolve
+          the same implementation.
+      3:
+        requirement: Chart *widget* wrappers isolate ECharts lifecycle concerns
+          inside the package so the core *runtime* remains chart-library agnostic.
+  ROUND_TRIP:
+    name: Config Round-Trip
+    description: Designer, schema, and runtime chart configuration fidelity.
+    requirements:
+      1:
+        requirement: Chart configuration authored in the *designer* serializes
+          into canonical *widget* props on the *dashboard* document at the current
+          *schema version*.
+      2:
+        requirement: The *runtime* reconstructs equivalent ECharts options from
+          serialized *widget* props without requiring a parallel shadow config
+          format.
+      3:
+        requirement: Round-trip save and reload preserves chart titles, series
+          bindings, axis roles, and legend visibility as capability groups
+          rather than losing unset optional fields.
+  FIELD_BINDING:
+    name: Cross-Chart Field Binding
+    description: Shared dataset field binding across visualization widgets.
+    requirements:
+      1:
+        requirement: Chart *widget* props bind dimensions and measures through
+          *field ref* identifiers that resolve against the host-provided
+          *dataset* catalog.
+      2:
+        requirement: Multiple chart *widgets* on the same *page* may bind the
+          same *field ref* so *filter* changes keep visualizations synchronized
+          without duplicate query definitions.
+      3:
+        requirement: Field binding validation rejects unknown *field ref*
+          identifiers at *dashboard* load time with errors surfaced in the
+          *designer* and *runtime*.
+      4:
+        requirement: Bound charts execute *logical query* requests through the
+          shared query client abstraction rather than embedding raw SQL in
+          *widget* configuration.
+  SCATTER:
+    name: Scatter Visualization
+    description: Tier-A scatter chart capabilities including point size encoding.
+    requirements:
+      1:
+        requirement: The scatter *widget* supports binding x, y, color, and
+          label channels through structured *field ref* roles defined in schema
+          rather than ad hoc prop names per host.
+      2:
+        requirement: Scatter charts expose a point-size capability that maps an
+          optional measure *field ref* to encoded marker size as a single
+          tier-A feature, not a matrix of unrelated size knobs.
+      3:
+        requirement: When point-size binding is absent the scatter *widget*
+          renders with a consistent default marker size across themes and export
+          round-trips.
+  THEMES:
+    name: Themes
+    description: Visual theming for chart and dashboard presentation.
+    requirements:
+      1:
+        requirement: Chart *widgets* consume shared *theme* tokens and ECharts
+          theme bridges so palette, typography, and axis styling stay consistent
+          with the enclosing *dashboard*.
+      2:
+        requirement: Inline and referenced *theme* definitions on the *dashboard*
+          document propagate to chart rendering without requiring per-*widget*
+          color overrides for defaults.
+      3:
+        requirement: Alert *widget* types render *alert rule* evaluations supplied
+          by the *host app* rather than inventing thresholds absent from bound
+          metadata or props.
+constraints:
+  VISUALIZATION_SCOPE:
+    name: Visualization Scope
+    description: Chart package boundaries within the library.
+    requirements:
+      1:
+        requirement: Chart requirements describe visualization capabilities at
+          the *widget* and binding level; they do not mandate a specific
+          warehouse, ORM, or server-side chart renderer.

--- a/features/designer-authoring.feature.yaml
+++ b/features/designer-authoring.feature.yaml
@@ -1,0 +1,102 @@
+feature:
+  name: designer-authoring
+  product: supersubset
+  description: Puck-based dashboard designer with palette, property panels, page
+    navigation, undo, code view, and import/export UX for host-controlled
+    authoring workflows.
+  version: 0.1.0
+  draft: false
+components:
+  PUCK_SHELL:
+    name: Puck Shell
+    description: SupersubsetDesigner embedding surface built on Puck.
+    requirements:
+      1:
+        requirement: The *designer* ships as an embeddable React component that
+          wraps Puck without requiring iframes or a hosted BI server.
+      2:
+        requirement: The Puck shell maps Puck component types to canonical
+          *layout* and *widget* schema nodes so canvas edits stay aligned with
+          the *dashboard* contract.
+      3:
+        requirement: The *designer* accepts host-provided capability metadata so
+          the *host app* controls which *widget* types and data bindings are
+          available in a given surface.
+  PALETTE:
+    name: Component Palette
+    description: Drag-and-drop palette for layout and widget building blocks.
+    requirements:
+      1:
+        requirement: The palette lists registered *layout* containers and
+          *widget* types grouped for discoverability rather than exposing raw
+          schema keys.
+      2:
+        requirement: Dropping a palette item creates schema-valid *layout* and
+          *widget* nodes with generated stable identifiers and sensible default
+          sizing metadata.
+  PROPERTY_PANELS:
+    name: Property Panels
+    description: Contextual editors for selected canvas nodes.
+    requirements:
+      1:
+        requirement: Selecting a canvas node opens property panels that edit
+          canonical schema fields, including *field ref* bindings, titles, and
+          *filter* scope where applicable.
+      2:
+        requirement: Property panel edits validate against the same Zod rules as
+          import and code view so invalid states cannot be saved silently.
+  PAGE_NAVIGATION:
+    name: Page Navigation
+    description: Multi-page dashboard authoring within one designer session.
+    requirements:
+      1:
+        requirement: The *designer* exposes *page* navigation so authors can add,
+          rename, reorder, and delete *dashboard* *pages* without leaving the
+          editor shell.
+  UNDO_REDO:
+    name: Undo and Redo
+    description: Edit history for canvas and property changes.
+    requirements:
+      1:
+        requirement: The *designer* supports undo and redo for structural canvas
+          operations and property panel edits within the active *page*.
+  CODE_VIEW:
+    name: Code View
+    description: Read/write serialized dashboard document alongside the canvas.
+    requirements:
+      1:
+        requirement: Code view displays the current *dashboard* document using
+          the shared *serialization* format and reflects canvas edits without
+          requiring a manual refresh.
+      2:
+        requirement: Applying code view edits re-validates the document and
+          surfaces parse or schema errors inline before replacing canvas state.
+  IMPORT_EXPORT:
+    name: Import and Export
+    description: Host-facing document exchange for designer sessions.
+    requirements:
+      1:
+        requirement: The *designer* supports import and export of *dashboard*
+          documents as JSON or YAML for repository workflows and *host app*
+          persistence APIs.
+      2:
+        requirement: Export emits normalized, migrated documents at the current
+          *schema version* so downstream *runtime* consumers never receive stale
+          shapes.
+  CONTROL_MODES:
+    name: Controlled and Uncontrolled Modes
+    description: React state integration patterns for host applications.
+    requirements:
+      1:
+        requirement: The *designer* supports controlled and uncontrolled React
+          integration modes so the *host app* may own the *dashboard* value or
+          rely on internal draft state with explicit save and export hooks.
+constraints:
+  HOST_OWNERSHIP:
+    name: Host Ownership
+    description: Designer persistence and auth boundaries.
+    requirements:
+      1:
+        requirement: The *designer* emits schema documents only; persistence,
+          authorization, and audit logging remain the responsibility of the
+          *host app*.

--- a/features/filters-and-interactions.feature.yaml
+++ b/features/filters-and-interactions.feature.yaml
@@ -22,6 +22,15 @@ components:
         requirement: Filter controls support the standard operator set advertised
           by the host query *adapter* or *probe* capabilities and reject unsupported
           operators during validation.
+      4:
+        requirement: Date and datetime *filter* controls are authored as
+          date-aware controls, including range, relative preset, and weekly
+          period options, rather than generic value dropdowns.
+      5:
+        requirement: Weekly date *filter* controls generate viewer options from
+          authored boundary weekday, lookback window, and lookahead window
+          settings and compile selected periods into concrete *logical query*
+          date ranges.
   CROSS_WIDGET_FILTERS:
     name: Cross-Widget Filters
     description: Propagation of filter state across widgets on a page.

--- a/features/filters-and-interactions.feature.yaml
+++ b/features/filters-and-interactions.feature.yaml
@@ -1,0 +1,94 @@
+feature:
+  name: filters-and-interactions
+  product: supersubset
+  description: Dashboard filter bar, cross-widget filter propagation, click-to-filter
+    interactions, drilldown actions, and filter option resolution.
+  version: 0.1.0
+  draft: false
+components:
+  FILTER_BAR:
+    name: Filter Bar
+    description: Dashboard-level filter controls rendered above page content.
+    requirements:
+      1:
+        requirement: The *runtime* renders a *filter* bar for dashboard-scoped
+          controls and merges active values into each *widget* *logical query*
+          at render time.
+      2:
+        requirement: The *designer* exposes a filter builder for authoring
+          dashboard *filter* definitions, including field binding, operator,
+          default value, and visibility scope.
+      3:
+        requirement: Filter controls support the standard operator set advertised
+          by the host query *adapter* or *probe* capabilities and reject unsupported
+          operators during validation.
+  CROSS_WIDGET_FILTERS:
+    name: Cross-Widget Filters
+    description: Propagation of filter state across widgets on a page.
+    requirements:
+      1:
+        requirement: Active dashboard *filter* values propagate to all bound
+          *widget* queries on the current *page* unless a *widget* declares an
+          explicit filter override.
+      2:
+        requirement: Cross-widget *filter* updates re-query affected *widget*
+          instances without resetting unrelated *widget* local state such as table
+          sort or pagination when those states remain valid.
+      3:
+        requirement: The *runtime* filter engine resolves filter precedence between
+          dashboard filters, page filters, and widget-scoped filters deterministically
+          before building each *logical query*.
+  CLICK_TO_FILTER:
+    name: Click To Filter
+    description: Widget-driven filter updates from user interaction.
+    requirements:
+      1:
+        requirement: Authored *interaction* rules can map *widget* click, hover,
+          or change triggers to update one or more dashboard *filter* values.
+      2:
+        requirement: Click-to-filter *interaction* payloads carry field id, operator,
+          and value derived from the clicked mark or row so cross-widget filtering
+          stays declarative rather than host-scripted.
+      3:
+        requirement: The *designer* interaction editor validates click-to-filter
+          targets against known *filter* ids and field refs on the active *dashboard*.
+  DRILLDOWN:
+    name: Drilldown
+    description: Navigation and detail actions driven by widget interactions.
+    requirements:
+      1:
+        requirement: Authored *interaction* rules may declare *drilldown* actions that
+          navigate to another *page*, open a scoped detail view, or route through
+          a host-provided navigation callback.
+      2:
+        requirement: Configured *drilldown* actions pass structured context such as field
+          values and originating *widget* id so the destination *page* can seed
+          filters or query parameters.
+      3:
+        requirement: The *runtime* executes *drilldown* without requiring iframe
+          navigation; the *host app* may intercept routing when embedding the
+          *runtime* in its own router.
+  FILTER_OPTION_SOURCES:
+    name: Filter Option Sources
+    description: Static and dynamic sources for filter control choices.
+    requirements:
+      1:
+        requirement: Select and multi-select *filter* controls support statically
+          authored option lists defined in the *dashboard* schema.
+      2:
+        requirement: Field-backed *filter* option sources request distinct values
+          through the query *adapter* when the host advertises option resolution
+          support, and degrade to an explicit unavailable state when unsupported.
+      3:
+        requirement: The *designer* preview and *runtime* share the same filter
+          option resolution rules so authored controls do not behave differently
+          between authoring and viewing modes.
+constraints:
+  STATE_OWNERSHIP:
+    name: State Ownership
+    description: Filter and interaction state boundaries.
+    requirements:
+      1:
+        requirement: The *runtime* owns in-session *filter* and *interaction*
+          state while the *host app* may hydrate or persist saved filter state
+          through controlled embedding props.

--- a/features/host-integration.feature.yaml
+++ b/features/host-integration.feature.yaml
@@ -1,0 +1,92 @@
+feature:
+  name: host-integration
+  product: supersubset
+  description: Embedding contract for mounting designer and runtime inside a host
+    application, workbench reference patterns, theming hooks, and host-owned auth
+    and data boundaries.
+  version: 0.1.0
+  draft: false
+components:
+  EMBEDDING_CONTRACT:
+    name: Embedding Contract
+    description: React mounting surface for designer and runtime packages.
+    requirements:
+      1:
+        requirement: The *host app* mounts Supersubset *designer* and *runtime*
+          components directly in React trees without requiring an iframe for core
+          authoring or viewing flows.
+      2:
+        requirement: Embedding props accept normalized *dataset* metadata, query
+          and metadata *adapter* instances, and optional preview or render callbacks
+          so the library stays backend-agnostic.
+      3:
+        requirement: The embedding contract exposes stable component entrypoints
+          and typed dashboard definition props without coupling to a specific host
+          router, state manager, or CSS framework.
+  DESIGNER_MODES:
+    name: Designer Modes
+    description: Controlled and uncontrolled dashboard editing ownership.
+    requirements:
+      1:
+        requirement: The *designer* supports controlled mode with value and onChange
+          so the *host app* owns the authoritative *dashboard* definition in its
+          store or API.
+      2:
+        requirement: The *designer* supports uncontrolled mode with defaultValue
+          and onPublish so lightweight hosts can defer persistence until an explicit
+          publish action.
+      3:
+        requirement: Controlled *designer* updates preserve undo and redo history
+          locally while emitting canonical *dashboard* snapshots only when the
+          host callback requests persistence.
+  WORKBENCH_PATTERNS:
+    name: Workbench Patterns
+    description: Reference host flows for auth, probe endpoints, and persistence.
+    requirements:
+      1:
+        requirement: Example workbench hosts demonstrate login-gated access to
+          *designer* and *runtime* modes with session or token auth owned entirely
+          by the *host app*.
+      2:
+        requirement: Workbench reference implementations expose probe-compatible
+          GET /supersubset/datasets and POST /supersubset/query routes that wrap
+          host query logic and return normalized *dataset* metadata and query
+          results.
+      3:
+        requirement: Workbench examples persist *dashboard* JSON in host-controlled
+          storage keys and reload the saved definition on subsequent visits without
+          Supersubset-hosted persistence services.
+  THEMING_HOOKS:
+    name: Theming Hooks
+    description: Host-controlled visual integration.
+    requirements:
+      1:
+        requirement: The *designer* and *runtime* accept *theme* tokens or CSS
+          variable mappings so the *host app* can align typography, spacing, and
+          palette with its design system.
+      2:
+        requirement: Chart *widget* rendering inherits resolved *theme* tokens
+          from the parent *runtime* or *designer* shell rather than hard-coding
+          product branding inside Supersubset packages.
+  HOST_OWNERSHIP:
+    name: Host Ownership
+    description: Security, metadata, and persistence boundaries.
+    requirements:
+      1:
+        requirement: The *host app* owns authentication, authorization, row-level
+          security, and credential storage; Supersubset components never persist
+          host secrets in dashboard definitions.
+      2:
+        requirement: Metadata ingestion through source *adapter* packages produces
+          normalized *dataset* models in the *host app* process; Supersubset does
+          not require a vendor metastore or warehouse lock-in.
+constraints:
+  LIBRARY_FIRST:
+    name: Library First
+    description: Supersubset ships embeddable packages, not a hosted BI product.
+    requirements:
+      1:
+        requirement: Host integration requirements treat Supersubset as library-first
+          packages where the *host app* supplies adapters, storage, auth, and routing
+          and Supersubset supplies *designer*, *runtime*, schema, and reference
+          workbench patterns only.

--- a/features/interface-behavior.feature.yaml
+++ b/features/interface-behavior.feature.yaml
@@ -1,0 +1,85 @@
+feature:
+  name: interface-behavior
+  product: supersubset
+  description: Cross-cutting loading, empty, error, and retry UX shared by the
+    designer authoring surface and runtime viewing surface.
+  version: 0.1.0
+  draft: false
+components:
+  LOADING_STATES:
+    name: Loading States
+    description: Async feedback while metadata and query work is in flight.
+    requirements:
+      1:
+        requirement: The *designer* and *runtime* expose explicit loading states
+          for *dataset* catalog fetch, *widget* query execution, and preview refresh
+          without hiding previously rendered content that remains valid.
+      2:
+        requirement: Loading indicators appear at the *widget*, *page*, or shell
+          level appropriate to the async scope so partial *dashboard* layouts stay
+          usable during incremental query completion.
+      3:
+        requirement: Long-running *logical query* execution shows in-progress
+          affordances and respects cancellation when the host query *adapter*
+          supports abort signals.
+  EMPTY_STATES:
+    name: Empty States
+    description: Zero-data and not-yet-configured presentation.
+    requirements:
+      1:
+        requirement: Each *widget* empty state distinguishes query results with zero rows
+          from not-yet-configured bindings missing *dataset* or field selections.
+      2:
+        requirement: The *designer* canvas and *runtime* *page* surfaces show
+          actionable empty copy when a *dashboard* or *page* has no authored *widget*
+          content yet.
+      3:
+        requirement: Dashboard *filter* controls with no resolved options render an explicit
+          empty or unavailable state instead of failing silently at *runtime*.
+  ERROR_STATES:
+    name: Error States
+    description: User-visible failure handling for queries and authoring validation.
+    requirements:
+      1:
+        requirement: Query failures surface user-actionable error copy on the
+          affected *widget* while preserving diagnostic detail in host or browser
+          logs and structured ProbeErrorResponse payloads when applicable.
+      2:
+        requirement: Metadata or *adapter* initialization failures in the *designer*
+          block preview execution with a clear error state but keep the authored
+          *dashboard* definition editable.
+      3:
+        requirement: Schema validation errors in the *designer* appear in the
+          validation panel and prevent silent publish of invalid *widget*, *filter*,
+          *interaction*, or *alert_rule* configuration.
+  RETRY_RECOVERY:
+    name: Retry Recovery
+    description: Explicit recovery actions after transient failures.
+    requirements:
+      1:
+        requirement: Failed *widget* query errors expose an explicit retry action when
+          automatic reload cannot safely recover without user confirmation.
+      2:
+        requirement: The *runtime* retry path re-executes the same *logical query*
+          with current *filter* and *interaction* state rather than requiring a full
+          *page* reload.
+      3:
+        requirement: The *designer* preview retry reuses the configured query
+          *adapter* or *probe* connection and clears stale error chrome on success.
+  DESIGNER_RUNTIME_PARITY:
+    name: Designer Runtime Parity
+    description: Consistent UX semantics across authoring and viewing modes.
+    requirements:
+      1:
+        requirement: Shared async, empty, and error patterns apply to both *designer*
+          preview and *runtime* rendering so authors and viewers see equivalent
+          states for the same *dashboard* definition and query outcome.
+constraints:
+  NON_BLOCKING:
+    name: Non Blocking
+    description: Failures stay scoped to the affected surface.
+    requirements:
+      1:
+        requirement: A single *widget* query or *alert_rule* failure must not
+          prevent the surrounding *dashboard* shell, *filter* bar, or unrelated
+          *widget* instances from rendering available content.

--- a/features/metadata-adapters.feature.yaml
+++ b/features/metadata-adapters.feature.yaml
@@ -1,0 +1,91 @@
+feature:
+  name: metadata-adapters
+  product: supersubset
+  description: Source-specific metadata adapters, normalized analytical metadata
+    model, and CLI import for Prisma, SQL, JSON, and dbt sources.
+  version: 0.1.0
+  draft: false
+components:
+  METADATA_MODEL:
+    name: Metadata Model
+    description: Normalized catalog consumed by designer and runtime binding.
+    requirements:
+      1:
+        requirement: Supersubset defines a normalized *metadata model* of entities,
+          fields, measures, relationships, and roles independent of any single
+          source system.
+      2:
+        requirement: The *metadata model* exposes stable field identifiers
+          suitable for *field ref* binding in *dashboard* *widget* and *filter*
+          definitions.
+      3:
+        requirement: Designer and *runtime* consume the normalized model through
+          adapter-agnostic interfaces and never depend on Prisma, dbt, or
+          database-specific types directly.
+  ADAPTER_PRISMA:
+    name: Prisma Adapter
+    description: Prisma schema introspection into normalized metadata.
+    requirements:
+      1:
+        requirement: The Prisma *adapter* ingests Prisma schema definitions and
+          emits normalized entity and field metadata for analytical binding.
+      2:
+        requirement: Prisma *adapter* output includes data types, relation hints,
+          and suggested measure roles where inferrable without executing queries
+          against a live database.
+  ADAPTER_SQL:
+    name: SQL Adapter
+    description: Relational database introspection into normalized metadata.
+    requirements:
+      1:
+        requirement: The SQL *adapter* introspects supported relational sources
+          and maps tables and columns into normalized *dataset* entities and
+          fields.
+      2:
+        requirement: SQL introspection runs read-only catalog queries and surfaces
+          actionable connection errors when credentials or driver configuration
+          are invalid.
+  ADAPTER_JSON:
+    name: JSON Adapter
+    description: Fixture and file-based metadata for development and tests.
+    requirements:
+      1:
+        requirement: The JSON *adapter* loads normalized *metadata model*
+          documents from JSON fixtures for local development, examples, and
+          automated tests.
+      2:
+        requirement: JSON *adapter* input is validated against the same normalized
+          shape produced by live introspection *adapter* implementations.
+  ADAPTER_DBT:
+    name: dbt Adapter
+    description: dbt manifest ingestion into normalized metadata.
+    requirements:
+      1:
+        requirement: The dbt *adapter* reads dbt manifest artifacts and maps
+          models, columns, and semantic hints into normalized entities and
+          fields.
+      2:
+        requirement: dbt *adapter* preserves model naming stable enough for
+          *field ref* and *logical query* *dataset* selection across re-imports
+          when manifest identifiers are unchanged.
+  CLI_IMPORT:
+    name: CLI Import
+    description: Command-line schema import for host and CI workflows.
+    requirements:
+      1:
+        requirement: The CLI exposes an import-schema command that runs selected
+          *adapter* implementations and writes normalized *metadata model*
+          output for *host app* consumption.
+      2:
+        requirement: CLI import supports selecting source type and connection or
+          file inputs without requiring the *designer* or *runtime* to be
+          running.
+constraints:
+  ADAPTER_BOUNDARY:
+    name: Adapter Boundary
+    description: Separation between metadata ingestion and host execution.
+    requirements:
+      1:
+        requirement: Metadata *adapter* packages produce catalogs only; query
+          execution, row-level security, and credential storage remain the
+          responsibility of the *host app*.

--- a/features/navigation-and-alerts.feature.yaml
+++ b/features/navigation-and-alerts.feature.yaml
@@ -1,0 +1,78 @@
+feature:
+  name: navigation-and-alerts
+  product: supersubset
+  description: Multi-page dashboard navigation, host routing hooks, structured
+    alert rules, and alert widget presentation.
+  version: 0.1.0
+  draft: false
+components:
+  PAGE_NAVIGATION:
+    name: Page Navigation
+    description: In-dashboard page tabs and active page rendering.
+    requirements:
+      1:
+        requirement: A *dashboard* definition contains one or more *page* entries
+          with stable ids, labels, and layout trees consumed by both *designer*
+          and *runtime*.
+      2:
+        requirement: The *runtime* renders page navigation controls and switches
+          active *page* content without remounting unrelated *dashboard* chrome
+          such as the *filter* bar when page-level filters are shared.
+      3:
+        requirement: The *designer* page navigator supports add, rename, reorder,
+          duplicate, and delete *page* operations and emits updated *dashboard*
+          definitions through controlled or uncontrolled save callbacks.
+  DASHBOARD_NAVIGATION:
+    name: Dashboard Navigation
+    description: Host-level routing across dashboards and deep links.
+    requirements:
+      1:
+        requirement: The *host app* may mount the *runtime* with a selected
+          *dashboard* id and optional initial *page* id without re-authoring layout
+          content.
+      2:
+        requirement: Authored *interaction* and *drilldown* actions may target another
+          *page* within the same *dashboard* or invoke a host navigation callback
+          for cross-dashboard routing owned by the *host app*.
+      3:
+        requirement: Navigation hooks preserve enough context for the *host app*
+          to update browser URLs, breadcrumbs, or application tabs when embedding
+          Supersubset inside an existing shell.
+  ALERT_RULES:
+    name: Alert Rules
+    description: Structured threshold evaluation authored on widgets.
+    requirements:
+      1:
+        requirement: A structured *alert_rule* binds a *dataset* ref, metric field
+          ref, aggregation, comparison operator, threshold, and alert copy.
+      2:
+        requirement: Structured *alert_rule* evaluation compiles to a *logical query* executed
+          during *widget* render and compares the returned metric against the
+          authored threshold.
+      3:
+        requirement: The *designer* validates *alert_rule* field refs against
+          normalized *dataset* metadata and surfaces schema errors before publish.
+  ALERT_WIDGETS:
+    name: Alert Widgets
+    description: Runtime presentation when alert conditions match.
+    requirements:
+      1:
+        requirement: When an *alert_rule* condition matches, the *runtime* renders
+          an alert *widget* surface with title, message, and severity without
+          blocking unrelated *widget* queries on the *page*.
+      2:
+        requirement: Non-matching *alert_rule* evaluations produce no alert chrome
+          so empty threshold states remain visually quiet in both *designer*
+          preview and *runtime* viewing modes.
+      3:
+        requirement: Alert *widget* styling respects the active *dashboard* *theme*
+          tokens for severity colors and typography.
+constraints:
+  ROUTING:
+    name: Routing
+    description: Navigation remains host-aware.
+    requirements:
+      1:
+        requirement: Supersubset supplies in-dashboard *page* navigation and
+          declarative *interaction* targets; the *host app* owns external routing,
+          authentication gates, and persistence keys for saved *dashboard* state.

--- a/features/query-and-probe.feature.yaml
+++ b/features/query-and-probe.feature.yaml
@@ -1,0 +1,91 @@
+feature:
+  name: query-and-probe
+  product: supersubset
+  description: Logical query client, HTTP probe contract, preview data execution,
+    and structured probe error envelopes for host-owned backends.
+  version: 0.1.0
+  draft: false
+components:
+  QUERY_CLIENT:
+    name: Query Client
+    description: Host-supplied adapter execution and fluent logical query building.
+    requirements:
+      1:
+        requirement: The *logical query* client accepts a host-provided *adapter*
+          pair for metadata normalization and query execution without binding to a
+          specific database or ORM.
+      2:
+        requirement: QueryClient exposes dataset discovery through getDatasets()
+          and getDataset(datasetId) using normalized *dataset* metadata from the
+          metadata *adapter*.
+      3:
+        requirement: QueryClient.execute() and buildQuery().execute() run a
+          *logical query* with select, filter, sort, limit, and offset clauses and
+          return column and row results keyed by requested field aliases.
+      4:
+        requirement: QueryClient supports cancellation, cache invalidation, and
+          configurable cache TTL so the *designer* and *runtime* can share one
+          client instance without stale preview data.
+  PROBE_DISCOVERY:
+    name: Probe Discovery
+    description: HTTP dataset discovery for probe and workbench validation flows.
+    requirements:
+      1:
+        requirement: Probe-compatible hosts expose GET {base}/supersubset/datasets
+          and return normalized *dataset* metadata for the *designer* catalog.
+      2:
+        requirement: Canonical discovery responses use ProbeDatasetsResponse with
+          protocolVersion, capabilities, and datasets; the *probe* accepts legacy
+          { datasets } and bare dataset arrays during migration.
+      3:
+        requirement: Discovery capabilities advertise supported filter operators,
+          aggregations, source types, and row limits so the *host app* and *probe*
+          can negotiate feature support before authoring widgets.
+  PROBE_QUERY:
+    name: Probe Query
+    description: HTTP logical query execution for preview and validation.
+    requirements:
+      1:
+        requirement: Probe-compatible hosts expose POST {base}/supersubset/query
+          and accept ProbeQueryRequest payloads containing a *logical query*.
+      2:
+        requirement: Successful query responses return ProbeQueryResponse or an
+          equivalent columns-and-rows shape consumable by preview widgets in the
+          *designer* and *runtime*.
+      3:
+        requirement: Query execution remains host-owned; the *probe* forwards
+          transport-level auth headers supplied by the *host app* rather than
+          implementing its own login flow.
+  PREVIEW_DATA:
+    name: Preview Data
+    description: Designer and probe preview execution against live host data.
+    requirements:
+      1:
+        requirement: The *designer* preview path executes widget-bound *logical
+          query* definitions through the configured query *adapter* or *probe*
+          connection and renders live result rows in the canvas.
+      2:
+        requirement: Preview execution honors active dashboard *filter* values
+          and widget-scoped filter bindings so authors see the same query shape
+          the *runtime* will execute.
+  ERROR_ENVELOPE:
+    name: Error Envelope
+    description: Structured probe and query failure responses.
+    requirements:
+      1:
+        requirement: Invalid *logical query* requests, unsupported capabilities,
+          and unavailable datasets return ProbeErrorResponse with a stable error
+          code and human-readable message.
+      2:
+        requirement: ProbeErrorResponse must not leak host implementation secrets;
+          diagnostic detail belongs in host logs while the *designer* and *probe*
+          surface actionable recovery copy.
+constraints:
+  BACKEND_AGNOSTIC:
+    name: Backend Agnostic
+    description: Query and probe boundaries stay adapter-driven.
+    requirements:
+      1:
+        requirement: The query-and-probe contract defines transport envelopes and
+          *logical query* shapes only; SQL generation, ORM choice, and row-level
+          security remain *host app* responsibilities.

--- a/features/references/acai-feature-yaml.yaml
+++ b/features/references/acai-feature-yaml.yaml
@@ -1,0 +1,94 @@
+# Imported from https://acai.sh/feature-yaml on 2026-05-23.
+# Reference copy only. Active Tripmatch requirements live under features/*.feature.yaml.
+feature:
+  name: feature-yaml
+  product: my-product.example.com
+  description: Describes the structure and semantics of a feature.yaml file
+    used by Acai to define product features, components, constraints, and
+    requirements.
+  version: 1.0.0
+  draft: true
+
+components:
+  METADATA:
+    description: Fields under the top-level "feature" section.
+    requirements:
+      1:
+        requirement: Feature metadata must have a `name` field.
+        note: Stable, human-readable feature identifier.
+      2:
+        requirement: Feature metadata must have a `product` field.
+        note: Product or repository the feature belongs to.
+      3:
+        requirement: Feature metadata may have a `version` field.
+        note: Semantic or project-local version string.
+      4:
+        requirement: Feature metadata may have a `description` field.
+      5:
+        requirement: Feature metadata may have a `draft` boolean.
+        note: Draft features are excluded by default unless requested.
+
+  COMPONENTS:
+    description: Functional parts of the feature.
+    requirements:
+      1:
+        requirement: Components are grouped under the top-level `components` map.
+      2:
+        requirement: Component keys should be stable uppercase identifiers.
+      3:
+        requirement: Each component may have a `name`.
+      4:
+        requirement: Each component may have a `description`.
+      5:
+        requirement: Each component may have a `requirements` map.
+      6:
+        requirement: Component requirements may be written as strings.
+      7:
+        requirement: Component requirements may be written as objects with a
+          `requirement` field.
+      8:
+        requirement: Requirement objects may include `note`, `deprecated`, and
+          `replaced_by`.
+
+  CONSTRAINTS:
+    description: Cross-cutting feature requirements or invariants.
+    requirements:
+      1:
+        requirement: Constraints are grouped under the top-level `constraints` map.
+      2:
+        requirement: Constraint keys should be stable uppercase identifiers.
+      3:
+        requirement: Each constraint group may have a `name`.
+      4:
+        requirement: Each constraint group may have a `description`.
+      5:
+        requirement: Each constraint group may have a `requirements` map.
+      6:
+        requirement: Constraint requirements follow the same string or object
+          shape as component requirements.
+
+constraints:
+  IDS:
+    description: Stable requirement identifiers inside feature.yaml.
+    requirements:
+      1:
+        requirement: Requirement keys may be numeric strings.
+      2:
+        requirement: Requirement keys may use hyphenated nested forms such as `1-1`.
+      3:
+        requirement: Acai IDs are composed as
+          `<feature-name>.<GROUP_KEY>.<requirement-key>`.
+      4:
+        requirement: IDs should remain stable once referenced externally.
+
+  DEPRECATION:
+    description: Marking requirements that should no longer be used.
+    requirements:
+      1:
+        requirement: 'Deprecated requirements should set `deprecated: true`.'
+      2:
+        requirement: Deprecated requirements may set `replaced_by` to another
+          Acai ID.
+      3:
+        requirement: Deprecated requirements should remain in the file so old
+          references can be resolved.

--- a/features/references/platforms.yaml
+++ b/features/references/platforms.yaml
@@ -1,0 +1,14 @@
+platforms:
+  web:
+    name: Web
+    description: >
+      Embeddable React designer and runtime surfaces delivered in a host
+      application browser context, including dev-app, examples, and docs.
+    package_roots:
+      - packages/designer
+      - packages/runtime
+      - packages/charts-echarts
+      - packages/schema
+      - packages/dev-app
+      - packages/docs
+      - e2e

--- a/features/references/term-yaml.schema.yaml
+++ b/features/references/term-yaml.schema.yaml
@@ -1,0 +1,100 @@
+# Tripmatch glossary term YAML schema.
+# Reference copy only. Active glossary terms live under features/terms/*.term.yaml.
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://tripmatch.local/schemas/term-yaml.schema.yaml
+title: Tripmatch glossary term
+type: object
+additionalProperties: false
+required:
+  - term
+properties:
+  term:
+    type: object
+    required:
+      - id
+      - definition
+    properties:
+      id:
+        type: string
+        pattern: ^[a-z][a-z0-9_]*$
+        description: Matches the filename stem, for example user.term.yaml has id user.
+      definition:
+        type: string
+        minLength: 1
+      aliases:
+        type: array
+        items:
+          type: string
+          minLength: 1
+      references:
+        type: object
+        additionalProperties: false
+        properties:
+          prisma:
+            type: object
+            additionalProperties: false
+            properties:
+              models:
+                $ref: '#/$defs/namedReferences'
+              enums:
+                $ref: '#/$defs/namedReferences'
+          graphql:
+            type: object
+            additionalProperties: false
+            properties:
+              operations:
+                $ref: '#/$defs/namedReferences'
+          ui:
+            type: object
+            additionalProperties: false
+            properties:
+              web:
+                $ref: '#/$defs/pathReferences'
+              native:
+                $ref: '#/$defs/pathReferences'
+              shared:
+                $ref: '#/$defs/pathReferences'
+          server:
+            $ref: '#/$defs/pathReferences'
+          worker:
+            $ref: '#/$defs/pathReferences'
+          docs:
+            $ref: '#/$defs/pathReferences'
+          adr:
+            $ref: '#/$defs/pathReferences'
+          skills:
+            $ref: '#/$defs/pathReferences'
+          memory:
+            $ref: '#/$defs/pathReferences'
+      notes:
+        type: array
+        items:
+          type: string
+          minLength: 1
+    patternProperties:
+      '^(?!id$|definition$|aliases$|references$|notes$|platform$|platforms$)[a-z][a-z0-9_]*$':
+        type: object
+        additionalProperties:
+          type: string
+          minLength: 1
+    additionalProperties: false
+$defs:
+  namedReferences:
+    type: array
+    items:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+        schema:
+          type: string
+          minLength: 1
+      additionalProperties: false
+  pathReferences:
+    type: array
+    items:
+      type: string
+      minLength: 1

--- a/features/runtime-rendering.feature.yaml
+++ b/features/runtime-rendering.feature.yaml
@@ -1,0 +1,85 @@
+feature:
+  name: runtime-rendering
+  product: supersubset
+  description: SupersubsetRenderer layout engine, widget registry, interactive
+    and read-only modes, filter state engine, and host-integrable state
+    persistence for embedded analytics.
+  version: 0.1.0
+  draft: false
+components:
+  LAYOUT_ENGINE:
+    name: Layout Engine
+    description: Flat normalized layout map rendering for dashboard pages.
+    requirements:
+      1:
+        requirement: The *runtime* walks each *page* from its root *layout* node
+          and renders nested grid, row, column, tabs, and container nodes from
+          the flat layout map.
+      2:
+        requirement: The layout engine honors width, height, gap, and min-height
+          metadata so *dashboard* *pages* reflow predictably across host
+          viewport sizes.
+  WIDGET_REGISTRY:
+    name: Widget Registry
+    description: Pluggable widget type resolution for runtime render.
+    requirements:
+      1:
+        requirement: The *runtime* resolves *widget* types through a registry so
+          hosts and chart packages can register implementations without forking
+          core render code, and exposes *probe* hooks for query and render health
+          signals to the *host app*.
+      2:
+        requirement: Unknown *widget* types produce a visible fallback state and
+          structured error metadata for *host app* telemetry.
+      3:
+        requirement: Registry lookups receive normalized *widget* props and bound
+          *field ref* metadata needed to execute *logical query* requests.
+  RENDER_MODES:
+    name: Read-Only and Interactive Modes
+    description: Capability-gated interactivity for embedded dashboards.
+    requirements:
+      1:
+        requirement: The *runtime* supports read-only render mode that displays
+          *dashboard* content without mutating *filter* state or firing
+          cross-*widget* *interaction* handlers.
+      2:
+        requirement: Interactive mode enables *filter* controls, *widget*
+          selection, and declared *interaction* actions according to host-provided
+          capability flags.
+      3:
+        requirement: '*Drilldown* and navigation *interaction* types delegate
+          destination resolution to the *host app* rather than hard-coding routes
+          inside the library.'
+  STATE_PERSISTENCE:
+    name: State Persistence
+    description: Host-integrable persistence for runtime session state.
+    requirements:
+      1:
+        requirement: The *runtime* exposes a persistence hook for *filter*
+          selections, active *page*, and other session state so the *host app*
+          can restore user context across reloads.
+      2:
+        requirement: Persisted state serializes to a versioned, JSON-safe shape
+          that remains compatible when the underlying *dashboard* document
+          migrates forward.
+  FILTER_ENGINE:
+    name: Filter State Engine
+    description: Cross-widget filter evaluation and query scoping.
+    requirements:
+      1:
+        requirement: The filter engine merges *dashboard*-level and *page*-scoped
+          *filter* definitions into a coherent scope applied to affected *widget*
+          queries.
+      2:
+        requirement: Changing a *filter* value re-evaluates dependent *logical
+          query* bindings and refreshes bound *widget* data without requiring a
+          full *page* remount.
+constraints:
+  EMBEDDING:
+    name: Embedding
+    description: Runtime integration constraints for host applications.
+    requirements:
+      1:
+        requirement: The *runtime* renders as React components in the *host app*
+          DOM and does not require iframe isolation or a dedicated analytics
+          server process.

--- a/features/schema-and-serialization.feature.yaml
+++ b/features/schema-and-serialization.feature.yaml
@@ -1,0 +1,88 @@
+feature:
+  name: schema-and-serialization
+  product: supersubset
+  description: Canonical dashboard schema contract, Zod validation, JSON/YAML
+    serialization, versioned migrations, and stable identifier rules for the
+    embeddable analytics library.
+  version: 0.1.0
+  draft: false
+components:
+  CANONICAL_SCHEMA:
+    name: Canonical Schema
+    description: DashboardDefinition product contract shared by designer and runtime.
+    requirements:
+      1:
+        requirement: The canonical *dashboard* schema defines a single
+          DashboardDefinition shape that both the *designer* and *runtime*
+          consume without package-specific forks.
+      2:
+        requirement: Every persisted *dashboard* document must include a required
+          *schema version* so consumers can select the correct parser and
+          migration path.
+      3:
+        requirement: The canonical schema models multi-*page* *dashboards* with
+          flat normalized *layout* maps, *widget* definitions, optional
+          *filter* and *interaction* collections, and optional *theme* and data
+          model references.
+  ZOD_VALIDATION:
+    name: Zod Validation
+    description: Runtime parsing and structural validation of dashboard documents.
+    requirements:
+      1:
+        requirement: Dashboard documents are validated with Zod schemas that
+          mirror the canonical TypeScript contract and reject unknown top-level
+          keys by default.
+      2:
+        requirement: Validation reports actionable errors with paths that map to
+          *designer* property panels and code-view locations.
+      3:
+        requirement: '*Logical query*, *field ref*, and *filter* shapes are
+          validated as structured objects rather than accepting opaque strings
+          or host-specific SQL fragments.'
+  SERIALIZATION:
+    name: Serialization
+    description: Lossless JSON and YAML encoding of dashboard definitions.
+    requirements:
+      1:
+        requirement: The *serialization* layer supports round-trip encode and
+          decode for JSON and YAML representations of the same *dashboard*
+          document without semantic drift.
+      2:
+        requirement: Serialized output preserves stable *widget*, *page*, and
+          *layout* identifiers so host persistence and version control diffs
+          remain addressable.
+  MIGRATIONS:
+    name: Migrations
+    description: Forward migration from older schema versions to the current contract.
+    requirements:
+      1:
+        requirement: A migration engine upgrades documents from older *schema
+          version* values to the current contract before validation or render.
+      2:
+        requirement: Migrations are pure transforms that preserve *dashboard*
+          identity, *page* structure, and user-authored titles unless a breaking
+          rename is explicitly documented.
+      3:
+        requirement: Unsupported *schema version* values fail with a clear error
+          rather than partially applying unknown migration steps.
+  STABLE_IDS:
+    name: Stable Identifiers
+    description: Identifier stability rules across edit, export, and migration.
+    requirements:
+      1:
+        requirement: '*Widget*, *layout*, *page*, and *filter* identifiers remain
+          stable across *designer* edits unless the user explicitly duplicates
+          or replaces a node.'
+      2:
+        requirement: Import and migration steps remap only colliding identifiers
+          and record enough metadata for the *host app* to reconcile external
+          references.
+constraints:
+  LIBRARY_SCOPE:
+    name: Library Scope
+    description: Schema package boundaries for embeddable analytics.
+    requirements:
+      1:
+        requirement: Schema and *serialization* requirements apply to
+          `@supersubset/schema` and host-owned persistence layers; they do not
+          prescribe a specific database or object-store backend.

--- a/features/terms/adapter.term.yaml
+++ b/features/terms/adapter.term.yaml
@@ -1,0 +1,18 @@
+term:
+  id: adapter
+  definition: >
+    A pluggable bridge that introspects a host data source and produces
+    NormalizedDataset metadata or executes LogicalQuery requests. Supersubset
+    ships adapters for Prisma, SQL, dbt, and JSON fixtures.
+  aliases:
+    - metadata adapter
+    - query adapter
+  references:
+    server:
+      - packages/data-model/src/index.ts
+      - packages/adapter-prisma/src
+      - packages/adapter-sql/src
+      - packages/adapter-json/src
+      - packages/adapter-dbt/src
+    docs:
+      - docs/guides/custom-adapter.md

--- a/features/terms/alert_rule.term.yaml
+++ b/features/terms/alert_rule.term.yaml
@@ -1,0 +1,16 @@
+term:
+  id: alert_rule
+  definition: >
+    A structured widget configuration that evaluates a metric against a threshold
+    and surfaces an alert when the condition matches. Alert rules compile to
+    LogicalQuery requests evaluated during widget render.
+  aliases:
+    - alert
+    - threshold rule
+  references:
+    server:
+      - packages/schema/src/types/dashboard.ts
+    ui:
+      shared:
+        - packages/runtime/src/layout/render-query-helpers.ts
+        - packages/designer/src/adapters/alert-rule-helpers.ts

--- a/features/terms/dashboard.term.yaml
+++ b/features/terms/dashboard.term.yaml
@@ -1,0 +1,18 @@
+term:
+  id: dashboard
+  definition: >
+    A persisted analytics experience composed of pages, layout, widgets, filters,
+    and interactions. The designer emits and the runtime renders a
+    DashboardDefinition; the host app owns storage and auth.
+  aliases:
+    - analytics dashboard
+  references:
+    server:
+      - packages/schema/src/types/dashboard.ts
+      - packages/schema/src/validation/dashboard.ts
+    ui:
+      shared:
+        - packages/designer/src/components/SupersubsetDesigner.tsx
+        - packages/runtime/src/components/SupersubsetRenderer.tsx
+    docs:
+      - packages/schema/README.md

--- a/features/terms/dataset.term.yaml
+++ b/features/terms/dataset.term.yaml
@@ -1,0 +1,15 @@
+term:
+  id: dataset
+  definition: >
+    A normalized logical table, view, or model exposed by a metadata adapter.
+    Widgets and filters bind to datasets through datasetRef and field bindings
+    defined in the dashboard schema.
+  aliases:
+    - normalized dataset
+  references:
+    server:
+      - packages/data-model/src/index.ts
+      - packages/schema/src/types/dashboard.ts
+    ui:
+      shared:
+        - packages/designer/src/context/DatasetContext.tsx

--- a/features/terms/designer.term.yaml
+++ b/features/terms/designer.term.yaml
@@ -1,0 +1,16 @@
+term:
+  id: designer
+  definition: >
+    The Puck-based visual editor that authors DashboardDefinition documents through
+    drag-and-drop layout, property panels, and live preview. It emits schema the
+    host app persists; it does not execute production queries on its own.
+  aliases:
+    - SupersubsetDesigner
+    - analytics builder
+  references:
+    ui:
+      shared:
+        - packages/designer/src/components/SupersubsetDesigner.tsx
+        - packages/designer/src/config/puck-config.ts
+    server:
+      - packages/schema/src/types/dashboard.ts

--- a/features/terms/drilldown.term.yaml
+++ b/features/terms/drilldown.term.yaml
@@ -1,0 +1,16 @@
+term:
+  id: drilldown
+  definition: >
+    An interaction pattern that narrows widget data by applying successive field
+    filters from user selections. DrillManager tracks breadcrumb state so users
+    can drill up or reset to the top level.
+  aliases:
+    - drill-down
+    - drill to detail
+  references:
+    ui:
+      shared:
+        - packages/runtime/src/interactions/DrillManager.tsx
+        - packages/runtime/src/components/DrillBreadcrumbBar.tsx
+    server:
+      - packages/schema/src/types/dashboard.ts

--- a/features/terms/field_ref.term.yaml
+++ b/features/terms/field_ref.term.yaml
@@ -1,0 +1,16 @@
+term:
+  id: field_ref
+  definition: >
+    A string identifier pointing to a field within a normalized dataset. Field
+    refs appear in filter definitions, widget data bindings, interaction mappings,
+    and drilldown state.
+  aliases:
+    - fieldRef
+    - field reference
+  references:
+    server:
+      - packages/schema/src/types/dashboard.ts
+      - packages/data-model/src/index.ts
+    ui:
+      shared:
+        - packages/designer/src/fields/field-ref-field.tsx

--- a/features/terms/filter.term.yaml
+++ b/features/terms/filter.term.yaml
@@ -1,0 +1,16 @@
+term:
+  id: filter
+  definition: >
+    A dashboard-level or scoped control that constrains widget queries by field
+    and operator. Active filter values are merged into LogicalQuery filters at
+    render time.
+  aliases:
+    - dashboard filter
+  references:
+    server:
+      - packages/schema/src/types/dashboard.ts
+    ui:
+      shared:
+        - packages/runtime/src/filters/FilterEngine.tsx
+        - packages/runtime/src/components/FilterBar.tsx
+        - packages/designer/src/components/FilterBuilderPanel.tsx

--- a/features/terms/host_app.term.yaml
+++ b/features/terms/host_app.term.yaml
@@ -1,0 +1,16 @@
+term:
+  id: host_app
+  definition: >
+    The embedding React application that mounts Supersubset designer and runtime
+    components, supplies metadata and query adapters, and persists dashboard
+    definitions. Auth, storage, and row-level security remain host responsibilities.
+  aliases:
+    - host application
+    - embedding app
+  references:
+    docs:
+      - packages/schema/README.md
+    ui:
+      shared:
+        - packages/dev-app/src
+        - examples/vite-sqlite/src

--- a/features/terms/interaction.term.yaml
+++ b/features/terms/interaction.term.yaml
@@ -1,0 +1,16 @@
+term:
+  id: interaction
+  definition: >
+    A declarative link from a widget trigger (click, hover, change) to an action
+    such as filter update, page navigation, drilldown, or cross-dashboard routing.
+    The runtime InteractionEngine executes authored interaction rules.
+  aliases:
+    - cross-filter
+    - navigation action
+  references:
+    server:
+      - packages/schema/src/types/dashboard.ts
+    ui:
+      shared:
+        - packages/runtime/src/interactions/InteractionEngine.tsx
+        - packages/designer/src/components/InteractionEditorPanel.tsx

--- a/features/terms/layout.term.yaml
+++ b/features/terms/layout.term.yaml
@@ -1,0 +1,15 @@
+term:
+  id: layout
+  definition: >
+    A flat, ID-keyed map of layout components that positions widgets on a page.
+    The renderer walks from rootNodeId through children to produce the grid-based
+    dashboard chrome.
+  aliases:
+    - layout map
+  references:
+    server:
+      - packages/schema/src/types/dashboard.ts
+    ui:
+      shared:
+        - packages/runtime/src/layout/LayoutRenderer.tsx
+        - packages/designer/src/blocks/layout

--- a/features/terms/logical_query.term.yaml
+++ b/features/terms/logical_query.term.yaml
@@ -1,0 +1,13 @@
+term:
+  id: logical_query
+  definition: >
+    A backend-agnostic query describing dataset, projected fields, aggregations,
+    filters, sort, and pagination. Adapters compile LogicalQuery into source-specific
+    SQL or API calls.
+  aliases:
+    - logical query
+  references:
+    server:
+      - packages/data-model/src/index.ts
+      - packages/query-client/src
+      - packages/runtime/src/layout/render-query-helpers.ts

--- a/features/terms/metadata_model.term.yaml
+++ b/features/terms/metadata_model.term.yaml
@@ -1,0 +1,15 @@
+term:
+  id: metadata_model
+  definition: >
+    The normalized analytical catalog of datasets, fields, roles, aggregations, and
+    relationships that adapters produce from Prisma, SQL, dbt, or JSON sources.
+    Designer and runtime consume this model without source-specific coupling.
+  aliases:
+    - normalized metadata
+    - data model
+  references:
+    server:
+      - packages/data-model/src/index.ts
+      - packages/data-model/src/heuristics.ts
+    docs:
+      - packages/schema/README.md

--- a/features/terms/page.term.yaml
+++ b/features/terms/page.term.yaml
@@ -1,0 +1,12 @@
+term:
+  id: page
+  definition: >
+    A tab or screen within a dashboard containing its own layout tree, widget
+    list, and optional page-scoped filters. Multi-page dashboards use interactions
+    to navigate between pages.
+  references:
+    server:
+      - packages/schema/src/types/dashboard.ts
+    ui:
+      shared:
+        - packages/runtime/src/layout/LayoutRenderer.tsx

--- a/features/terms/probe.term.yaml
+++ b/features/terms/probe.term.yaml
@@ -1,0 +1,15 @@
+term:
+  id: probe
+  definition: >
+    A dev-app workflow for connecting to a host backend without embedding the
+    full designer. Probe resolves datasets from discovery URLs, pasted metadata
+    JSON, or authenticated HTTP endpoints.
+  aliases:
+    - probe mode
+  references:
+    ui:
+      shared:
+        - packages/dev-app/src/probe/probe-connection.ts
+        - packages/dev-app/src/probe/metadata.ts
+    docs:
+      - packages/schema/README.md

--- a/features/terms/runtime.term.yaml
+++ b/features/terms/runtime.term.yaml
@@ -1,0 +1,16 @@
+term:
+  id: runtime
+  definition: >
+    The read-only renderer that materializes a DashboardDefinition into interactive
+    UI. It orchestrates layout, filters, widget queries, interactions, theme tokens,
+    and optional state persistence via a host-provided QueryAdapter.
+  aliases:
+    - SupersubsetRenderer
+    - renderer
+  references:
+    ui:
+      shared:
+        - packages/runtime/src/components/SupersubsetRenderer.tsx
+        - packages/runtime/src/layout/LayoutRenderer.tsx
+    server:
+      - packages/schema/src/types/dashboard.ts

--- a/features/terms/schema_version.term.yaml
+++ b/features/terms/schema_version.term.yaml
@@ -1,0 +1,12 @@
+term:
+  id: schema_version
+  definition: >
+    The semver-like version stamp on a DashboardDefinition that drives migration
+    before validation. Parsers normalize older documents to the current canonical
+    shape when schema_version is supported.
+  aliases:
+    - schemaVersion
+  references:
+    server:
+      - packages/schema/src/migrations/index.ts
+      - packages/schema/src/types/dashboard.ts

--- a/features/terms/serialization.term.yaml
+++ b/features/terms/serialization.term.yaml
@@ -1,0 +1,17 @@
+term:
+  id: serialization
+  definition: >
+    The import and export of DashboardDefinition documents as JSON or YAML.
+    Serializers parse external text, run schema migrations, and validate against
+    the canonical Zod contract before designer or runtime use.
+  aliases:
+    - import export
+    - YAML serialization
+  references:
+    server:
+      - packages/schema/src/serializers/json.ts
+      - packages/schema/src/serializers/yaml.ts
+      - packages/schema/src/json-schema
+    ui:
+      shared:
+        - packages/designer/src/components/ImportExportPanel.tsx

--- a/features/terms/theme.term.yaml
+++ b/features/terms/theme.term.yaml
@@ -1,0 +1,13 @@
+term:
+  id: theme
+  definition: >
+    Dashboard styling tokens for colors, typography, spacing, and chart palettes.
+    Inline or referenced themes resolve to CSS variables and propagate to chart
+    widgets at render time.
+  references:
+    server:
+      - packages/schema/src/types/dashboard.ts
+    ui:
+      shared:
+        - packages/theme/src/index.ts
+        - packages/runtime/src/layout/LayoutRenderer.tsx

--- a/features/terms/widget.term.yaml
+++ b/features/terms/widget.term.yaml
@@ -1,0 +1,16 @@
+term:
+  id: widget
+  definition: >
+    A typed visualization or control bound to datasets and fields inside a page
+    layout. Widget definitions live in the dashboard schema; the runtime resolves
+    them through a host-supplied widget registry.
+  aliases:
+    - chart
+    - viz
+  references:
+    server:
+      - packages/schema/src/types/dashboard.ts
+    ui:
+      shared:
+        - packages/runtime/src/widgets/registry.ts
+        - packages/charts-echarts/src

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
     "prepare": "husky",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "node scripts/sync-package-docs.mjs && pnpm -r --filter='./packages/*' --filter='!@supersubset/dev-app' --filter='!@supersubset/docs' build && changeset publish"
+    "release": "node scripts/sync-package-docs.mjs && pnpm -r --filter='./packages/*' --filter='!@supersubset/dev-app' --filter='!@supersubset/docs' build && changeset publish",
+    "validate:requirements": "node tools/requirements/validate-feature-specs.mjs",
+    "requirements:coverage": "node tools/requirements/validate-feature-specs.mjs --coverage",
+    "requirements:coverage:json": "node tools/requirements/validate-feature-specs.mjs --coverage --json",
+    "test:requirements-validator": "node --test tools/requirements/validate-feature-specs.spec.mjs"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.6.0",
@@ -43,7 +47,8 @@
     "prettier": "^3.8.2",
     "storybook": "^8.6.0",
     "typescript": "^5.5.0",
-    "typescript-eslint": "^8.58.2"
+    "typescript-eslint": "^8.58.2",
+    "yaml": "^2.9.0"
   },
   "packageManager": "pnpm@9.0.0",
   "engines": {

--- a/packages/adapter-dbt/test/dbt-adapter.test.ts
+++ b/packages/adapter-dbt/test/dbt-adapter.test.ts
@@ -64,7 +64,7 @@ describe('DbtAdapter', () => {
   });
 
   describe('getDatasets', () => {
-    it('extracts only model and source nodes', async () => {
+    it('[metadata-adapters.ADAPTER_DBT.1] extracts only model and source nodes', async () => {
       const datasets = await adapter.getDatasets(FIXTURE);
       expect(datasets).toHaveLength(3);
       const names = datasets.map((d) => d.id);
@@ -80,7 +80,7 @@ describe('DbtAdapter', () => {
       expect(names).not.toContain('country_codes');
     });
 
-    it('preserves descriptions', async () => {
+    it('[metadata-adapters.ADAPTER_DBT.2] preserves descriptions', async () => {
       const datasets = await adapter.getDatasets(FIXTURE);
       const users = datasets.find((d) => d.id === 'model.project.users')!;
       expect(users.description).toBe('All application users');

--- a/packages/adapter-json/test/json-adapter.test.ts
+++ b/packages/adapter-json/test/json-adapter.test.ts
@@ -43,7 +43,7 @@ describe('JsonAdapter', () => {
   });
 
   describe('getDatasets', () => {
-    it('returns all datasets', async () => {
+    it('[metadata-adapters.ADAPTER_JSON.1] returns all datasets', async () => {
       const datasets = await adapter.getDatasets(FIXTURE);
       expect(datasets).toHaveLength(2);
       expect(datasets[0].id).toBe('orders');
@@ -91,7 +91,7 @@ describe('JsonAdapter', () => {
       expect(nameField?.label).toBe('Customer Name');
     });
 
-    it('preserves relationships', async () => {
+    it('[metadata-adapters.ADAPTER_JSON.2] preserves relationships', async () => {
       const [orders] = await adapter.getDatasets(FIXTURE);
       expect(orders.relationships).toHaveLength(1);
       expect(orders.relationships![0].targetDatasetId).toBe('customers');

--- a/packages/adapter-prisma/test/prisma-adapter.test.ts
+++ b/packages/adapter-prisma/test/prisma-adapter.test.ts
@@ -38,7 +38,7 @@ describe('PrismaAdapter', () => {
   });
 
   describe('getDatasets', () => {
-    it('extracts all models', async () => {
+    it('[metadata-adapters.ADAPTER_PRISMA.1] extracts all models', async () => {
       const datasets = await adapter.getDatasets(FIXTURE_SCHEMA);
       expect(datasets).toHaveLength(3);
       expect(datasets.map((d) => d.id)).toEqual(['user', 'order', 'orderitem']);
@@ -88,7 +88,7 @@ describe('PrismaAdapter', () => {
       expect(total?.defaultAggregation).toBe('sum');
     });
 
-    it('extracts relationships from @relation', async () => {
+    it('[metadata-adapters.METADATA_MODEL.3] extracts relationships from @relation', async () => {
       const datasets = await adapter.getDatasets(FIXTURE_SCHEMA);
       const order = datasets.find((d) => d.id === 'order')!;
       expect(order.relationships).toHaveLength(1);

--- a/packages/adapter-sql/test/sql-adapter.test.ts
+++ b/packages/adapter-sql/test/sql-adapter.test.ts
@@ -55,7 +55,7 @@ describe('SqlAdapter', () => {
   });
 
   describe('getDatasets', () => {
-    it('returns all tables and views', async () => {
+    it('[metadata-adapters.ADAPTER_SQL.1] returns all tables and views', async () => {
       const datasets = await adapter.getDatasets(FIXTURE);
       expect(datasets).toHaveLength(3);
     });
@@ -108,7 +108,7 @@ describe('SqlAdapter', () => {
       expect(orders.fields.find((f) => f.id === 'total_amount')?.defaultAggregation).toBe('sum');
     });
 
-    it('detects foreign key relationships', async () => {
+    it('[metadata-adapters.ADAPTER_SQL.2] detects foreign key relationships', async () => {
       const datasets = await adapter.getDatasets(FIXTURE);
       const orders = datasets[1];
       expect(orders.relationships).toHaveLength(1);

--- a/packages/charts-echarts/test/base-chart-events.test.tsx
+++ b/packages/charts-echarts/test/base-chart-events.test.tsx
@@ -63,7 +63,7 @@ describe('BaseChart interaction events', () => {
     );
   });
 
-  it('emits click events with extracted payload data', () => {
+  it('[charts-and-visualization.ECHARTS_WRAPPERS.1] emits click events with extracted payload data', () => {
     const onEvent = vi.fn();
 
     render(
@@ -129,7 +129,7 @@ describe('BaseChart interaction events', () => {
     });
   });
 
-  it('converts resolved Supersubset themes before initializing ECharts', () => {
+  it('[charts-and-visualization.THEMES.1] converts resolved Supersubset themes before initializing ECharts', () => {
     render(
       React.createElement(BaseChart, {
         option: {},

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -204,7 +204,13 @@ export async function resolveFilterOptionsWithAdapter(
     distinct: true,
   };
   if (request.search) {
-    query.filters = [{ fieldId: request.fieldId, operator: 'like', value: request.search }];
+    query.filters = [
+      {
+        fieldId: request.fieldId,
+        operator: 'like',
+        value: normalizeSearchToContains(request.search),
+      },
+    ];
   }
 
   const result = await adapter.execute(query);
@@ -219,10 +225,24 @@ export async function resolveFilterOptionsWithAdapter(
     options.push({ value });
   }
 
-  return {
-    options,
-    complete: options.length < limit,
-  };
+  // Prefer execution evidence over a post-dedupe heuristic: client-side dedup
+  // can shrink `options.length` below `limit` even when more distinct values
+  // exist on the source. `QueryResult.truncated` is set by adapters that know
+  // (e.g. `SqlQueryAdapter` via the +1 sentinel); fall back to the heuristic
+  // only when the adapter hasn't reported truncation.
+  const complete =
+    result.truncated === false ? true : result.truncated === true ? false : options.length < limit;
+
+  return { options, complete };
+}
+
+/**
+ * Wrap a search term with `%` for contains-style matching unless the caller
+ * already supplied wildcards. Keeps the contract predictable across hosts.
+ */
+function normalizeSearchToContains(search: string): string {
+  if (search.includes('%') || search.includes('_')) return search;
+  return `%${search}%`;
 }
 
 // ─── Probe Contract ──────────────────────────────────────────

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -87,7 +87,7 @@ export interface LogicalQuery {
   /**
    * When true, the executor must return distinct rows (SQL `SELECT DISTINCT` or
    * equivalent). Additive — adapters that ignore it return non-distinct rows
-   * (legacy behavior). See ADR-011.
+   * (legacy behavior). See ADR-012.
    */
   distinct?: boolean;
 }
@@ -184,7 +184,7 @@ export interface QueryAdapter {
  * produce de-duplicated values; older adapters that ignore the flag still work
  * but may return duplicates.
  *
- * See ADR-009 §2 and ADR-011.
+ * See ADR-009 §2 and ADR-012.
  */
 const DEFAULT_FIELD_OPTIONS_LIMIT = 200;
 

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -84,6 +84,12 @@ export interface LogicalQuery {
   sort?: QuerySort[];
   limit?: number;
   offset?: number;
+  /**
+   * When true, the executor must return distinct rows (SQL `SELECT DISTINCT` or
+   * equivalent). Additive — adapters that ignore it return non-distinct rows
+   * (legacy behavior). See ADR-011.
+   */
+  distinct?: boolean;
 }
 
 export interface QueryField {
@@ -95,7 +101,8 @@ export interface QueryField {
 export interface QueryFilter {
   fieldId: string;
   operator: QueryFilterOperator;
-  value: unknown;
+  /** Omitted for operators like `is_null` / `is_not_null` that take no value. */
+  value?: unknown;
 }
 
 export type QueryFilterOperator =
@@ -122,6 +129,10 @@ export interface QueryResult {
   columns: QueryResultColumn[];
   rows: Record<string, unknown>[];
   totalRows?: number;
+  /** True when the executor saw more rows than `limit` and trimmed the response. */
+  truncated?: boolean;
+  /** Wall-clock duration of the underlying execution, in milliseconds. */
+  executionTimeMs?: number;
 }
 
 export interface QueryResultColumn {
@@ -161,6 +172,57 @@ export interface QueryAdapter {
   execute(query: LogicalQuery): Promise<QueryResult>;
   cancel?(queryId: string): Promise<void>;
   resolveFilterOptions?(request: FilterOptionRequest): Promise<FilterOptionResponse>;
+}
+
+/**
+ * Resolve filter options through a QueryAdapter, with a generic fallback.
+ *
+ * If the adapter implements `resolveFilterOptions`, that path is used (the host
+ * may curate, authorize, or use a backend-specific lookup). Otherwise, a
+ * distinct-values `LogicalQuery` is synthesized — adapters that honor
+ * `distinct: true` (e.g. `SqlQueryAdapter` from `@supersubset/query-sql`)
+ * produce de-duplicated values; older adapters that ignore the flag still work
+ * but may return duplicates.
+ *
+ * See ADR-009 §2 and ADR-011.
+ */
+const DEFAULT_FIELD_OPTIONS_LIMIT = 200;
+
+export async function resolveFilterOptionsWithAdapter(
+  adapter: QueryAdapter,
+  request: FilterOptionRequest,
+): Promise<FilterOptionResponse> {
+  if (adapter.resolveFilterOptions) {
+    return adapter.resolveFilterOptions(request);
+  }
+
+  const limit = request.limit ?? DEFAULT_FIELD_OPTIONS_LIMIT;
+  const query: LogicalQuery = {
+    datasetId: request.datasetId,
+    fields: [{ fieldId: request.fieldId }],
+    limit,
+    distinct: true,
+  };
+  if (request.search) {
+    query.filters = [{ fieldId: request.fieldId, operator: 'like', value: request.search }];
+  }
+
+  const result = await adapter.execute(query);
+  const seen = new Set<string>();
+  const options: QueryFilterOption[] = [];
+  for (const row of result.rows) {
+    const raw = row[request.fieldId];
+    if (raw === null || raw === undefined) continue;
+    const value = String(raw);
+    if (seen.has(value)) continue;
+    seen.add(value);
+    options.push({ value });
+  }
+
+  return {
+    options,
+    complete: options.length < limit,
+  };
 }
 
 // ─── Probe Contract ──────────────────────────────────────────

--- a/packages/data-model/test/data-model.test.ts
+++ b/packages/data-model/test/data-model.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type {
   FilterOptionRequest,
   FilterOptionResponse,
@@ -17,6 +17,7 @@ import {
   PROBE_STANDARD_AGGREGATIONS,
   PROBE_STANDARD_FILTER_OPERATORS,
   PROBE_STANDARD_SOURCE_TYPES,
+  resolveFilterOptionsWithAdapter,
 } from '../src';
 
 describe('NormalizedDataset type', () => {
@@ -162,6 +163,146 @@ describe('QueryAdapter interface', () => {
     };
 
     const response = await mockQuery.resolveFilterOptions?.(request);
+    expect(response).toEqual(mockResponse);
+  });
+});
+
+describe('resolveFilterOptionsWithAdapter', () => {
+  function makeAdapter(
+    rows: Array<Record<string, unknown>>,
+    extra: Partial<QueryResult> = {},
+  ): QueryAdapter & { execute: ReturnType<typeof vi.fn> } {
+    return {
+      name: 'mock',
+      execute: vi.fn().mockResolvedValue({
+        columns: [{ fieldId: 'status', label: 'Status', dataType: 'string' }],
+        rows,
+        ...extra,
+      } satisfies QueryResult),
+    };
+  }
+
+  it('synthesizes a distinct LogicalQuery and returns dedup-defensive options', async () => {
+    const adapter = makeAdapter([
+      { status: 'open' },
+      { status: 'open' },
+      { status: 'closed' },
+      { status: null },
+    ]);
+
+    const response = await resolveFilterOptionsWithAdapter(adapter, {
+      filterId: 'f',
+      datasetId: 'orders',
+      fieldId: 'status',
+      limit: 50,
+    });
+
+    expect(adapter.execute).toHaveBeenCalledWith({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'status' }],
+      limit: 50,
+      distinct: true,
+    });
+    expect(response.options).toEqual([{ value: 'open' }, { value: 'closed' }]);
+  });
+
+  it('wraps a bare search term with % for contains semantics', async () => {
+    const adapter = makeAdapter([{ status: 'open' }]);
+
+    await resolveFilterOptionsWithAdapter(adapter, {
+      filterId: 'f',
+      datasetId: 'orders',
+      fieldId: 'status',
+      search: 'op',
+    });
+
+    expect(adapter.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: [{ fieldId: 'status', operator: 'like', value: '%op%' }],
+      }),
+    );
+  });
+
+  it('passes a search term through verbatim when the caller already uses wildcards', async () => {
+    const adapter = makeAdapter([{ status: 'op_en' }]);
+
+    await resolveFilterOptionsWithAdapter(adapter, {
+      filterId: 'f',
+      datasetId: 'orders',
+      fieldId: 'status',
+      search: 'op_%',
+    });
+
+    expect(adapter.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: [{ fieldId: 'status', operator: 'like', value: 'op_%' }],
+      }),
+    );
+  });
+
+  it('reports complete: false when the adapter signals truncation', async () => {
+    const adapter = makeAdapter([{ status: 'open' }, { status: 'closed' }], { truncated: true });
+
+    const response = await resolveFilterOptionsWithAdapter(adapter, {
+      filterId: 'f',
+      datasetId: 'orders',
+      fieldId: 'status',
+      limit: 50,
+    });
+
+    expect(response.complete).toBe(false);
+  });
+
+  it('reports complete: true when the adapter signals no truncation, even if dedup shrank the list below limit', async () => {
+    const adapter = makeAdapter(
+      // 3 rows post-dedup → 2 distinct values, well below limit 50, but
+      // truncated:false means there are no more rows to fetch
+      [{ status: 'open' }, { status: 'open' }, { status: 'closed' }],
+      { truncated: false },
+    );
+
+    const response = await resolveFilterOptionsWithAdapter(adapter, {
+      filterId: 'f',
+      datasetId: 'orders',
+      fieldId: 'status',
+      limit: 50,
+    });
+
+    expect(response.options).toHaveLength(2);
+    expect(response.complete).toBe(true);
+  });
+
+  it('falls back to the length heuristic when the adapter does not set truncated', async () => {
+    const adapter = makeAdapter([{ status: 'open' }, { status: 'closed' }]);
+
+    const response = await resolveFilterOptionsWithAdapter(adapter, {
+      filterId: 'f',
+      datasetId: 'orders',
+      fieldId: 'status',
+      limit: 50,
+    });
+
+    expect(response.complete).toBe(true);
+  });
+
+  it('delegates to the adapter when resolveFilterOptions is implemented', async () => {
+    const mockResponse: FilterOptionResponse = {
+      options: [{ value: 'curated' }],
+      complete: true,
+    };
+    const adapter: QueryAdapter = {
+      name: 'curated',
+      execute: vi.fn(),
+      resolveFilterOptions: vi.fn().mockResolvedValue(mockResponse),
+    };
+
+    const response = await resolveFilterOptionsWithAdapter(adapter, {
+      filterId: 'f',
+      datasetId: 'orders',
+      fieldId: 'status',
+    });
+
+    expect(adapter.execute).not.toHaveBeenCalled();
     expect(response).toEqual(mockResponse);
   });
 });

--- a/packages/designer/src/components/FilterBuilderPanel.tsx
+++ b/packages/designer/src/components/FilterBuilderPanel.tsx
@@ -768,8 +768,10 @@ function FilterEditor({
                 data-testid={`filter-option-field-note-${filter.id}`}
                 style={{ fontSize: 12, color: '#64748b' }}
               >
-                Field-backed options require runtime host support. Hosts may satisfy this with a
-                dedicated option resolver or, during migration, a compatibility fallback.
+                Resolved at runtime via the host&apos;s QueryAdapter. Hosts using{' '}
+                <code>@supersubset/query-sql</code>&apos;s <code>SqlQueryAdapter</code> get this
+                automatically; others may implement <code>resolveFilterOptions</code> for custom
+                curation or authorization. See ADR-009 §2 and ADR-011.
               </div>
             </div>
           )}

--- a/packages/designer/src/components/FilterBuilderPanel.tsx
+++ b/packages/designer/src/components/FilterBuilderPanel.tsx
@@ -771,7 +771,7 @@ function FilterEditor({
                 Resolved at runtime via the host&apos;s QueryAdapter. Hosts using{' '}
                 <code>@supersubset/query-sql</code>&apos;s <code>SqlQueryAdapter</code> get this
                 automatically; others may implement <code>resolveFilterOptions</code> for custom
-                curation or authorization. See ADR-009 §2 and ADR-011.
+                curation or authorization. See ADR-009 §2 and ADR-012.
               </div>
             </div>
           )}

--- a/packages/designer/src/components/FilterBuilderPanel.tsx
+++ b/packages/designer/src/components/FilterBuilderPanel.tsx
@@ -12,6 +12,7 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { NormalizedDataset } from '@supersubset/data-model';
 import type {
+  DateFilterConfig,
   FilterDefinition,
   FilterOptionDefinition,
   FilterOptionSource,
@@ -78,6 +79,22 @@ const SELECT_FILTER_CONTROL_TYPES = new Set<SupportedFilterControlType>(['select
 type StaticFilterOptionSource = Extract<FilterOptionSource, { kind: 'static' }>;
 type FieldFilterOptionSource = Extract<FilterOptionSource, { kind: 'field' }>;
 
+const WEEKDAY_OPTIONS = [
+  { value: 0, label: 'Sunday' },
+  { value: 1, label: 'Monday' },
+  { value: 2, label: 'Tuesday' },
+  { value: 3, label: 'Wednesday' },
+  { value: 4, label: 'Thursday' },
+  { value: 5, label: 'Friday' },
+  { value: 6, label: 'Saturday' },
+] as const;
+
+const DATE_FILTER_MODE_OPTIONS = [
+  { value: 'preset', label: 'Preset or custom range' },
+  { value: 'range', label: 'Custom date range' },
+  { value: 'weekly', label: 'Weekly range dropdown' },
+] as const;
+
 function isSelectFilterControlType(type: string): type is 'select' | 'multi-select' {
   return SELECT_FILTER_CONTROL_TYPES.has(type as SupportedFilterControlType);
 }
@@ -114,6 +131,17 @@ function createFieldOptionSource(): FieldFilterOptionSource {
   };
 }
 
+function createDefaultDateConfig(mode: DateFilterConfig['mode'] = 'preset'): DateFilterConfig {
+  return {
+    mode,
+    allowCustomRange: mode !== 'weekly',
+    weekStartsOn: 0,
+    weeksBack: 4,
+    weeksForward: 0,
+    includeCurrentWeek: true,
+  };
+}
+
 function coercePositiveInteger(value: string): number | undefined {
   if (value.trim().length === 0) {
     return undefined;
@@ -125,6 +153,40 @@ function coercePositiveInteger(value: string): number | undefined {
   }
 
   return parsed;
+}
+
+function coerceNonNegativeInteger(value: string): number | undefined {
+  if (value.trim().length === 0) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function isDateDataType(dataType: string | undefined): boolean {
+  return dataType === 'date' || dataType === 'datetime';
+}
+
+function asDateDefaultValue(value: unknown): { preset?: string; start?: string; end?: string } {
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    const candidate = value as { preset?: unknown; start?: unknown; end?: unknown };
+    return {
+      preset: typeof candidate.preset === 'string' ? candidate.preset : undefined,
+      start: typeof candidate.start === 'string' ? candidate.start : undefined,
+      end: typeof candidate.end === 'string' ? candidate.end : undefined,
+    };
+  }
+
+  if (typeof value === 'string' && value.length > 0) {
+    return { start: value };
+  }
+
+  return {};
 }
 
 function normalizeFilterControlType(type: string): SupportedFilterControlType {
@@ -219,10 +281,20 @@ function FilterEditor({
     const dt = field?.dataType ?? 'string';
     return FILTER_OPERATORS.filter((op) => op.types.includes(dt));
   }, [field]);
+  const isDateField = isDateDataType(field?.dataType);
   const normalizedFilterType = useMemo(
     () => normalizeFilterControlType(filter.type),
     [filter.type],
   );
+  const availableControlOptions = useMemo(
+    () =>
+      isDateField
+        ? FILTER_CONTROL_OPTIONS.filter((option) => option.value === 'date')
+        : FILTER_CONTROL_OPTIONS,
+    [isDateField],
+  );
+  const dateConfig = filter.dateConfig ?? createDefaultDateConfig();
+  const defaultDateValue = asDateDefaultValue(filter.defaultValue);
 
   const handleChange = useCallback(
     (patch: Partial<FilterDefinition>) => {
@@ -290,10 +362,39 @@ function FilterEditor({
       if (nextType === 'multi-select' && !['in', 'not_in'].includes(filter.operator)) {
         nextPatch.operator = 'in';
       }
+      if (nextType === 'date') {
+        nextPatch.operator = 'between';
+        nextPatch.optionSource = undefined;
+        nextPatch.dateConfig = filter.dateConfig ?? createDefaultDateConfig();
+      }
 
       handleChange(nextPatch);
     },
-    [filter.operator, handleChange],
+    [filter.dateConfig, filter.operator, handleChange],
+  );
+
+  useEffect(() => {
+    if (isDateField && normalizedFilterType !== 'date') {
+      handleChange({
+        type: 'date',
+        operator: 'between',
+        optionSource: undefined,
+        dateConfig: filter.dateConfig ?? createDefaultDateConfig(),
+      });
+    }
+  }, [filter.dateConfig, handleChange, isDateField, normalizedFilterType]);
+
+  const handleDateConfigChange = useCallback(
+    (patch: Partial<DateFilterConfig>) => {
+      handleChange({
+        dateConfig: {
+          ...createDefaultDateConfig(),
+          ...(filter.dateConfig ?? {}),
+          ...patch,
+        },
+      });
+    },
+    [filter.dateConfig, handleChange],
   );
 
   const handleOptionSourceKindChange = useCallback(
@@ -424,7 +525,22 @@ function FilterEditor({
             id={fieldSelectId}
             name={`filter-field-${filter.id}`}
             value={filter.fieldRef}
-            onChange={(e) => handleChange({ fieldRef: e.target.value })}
+            onChange={(e) => {
+              const nextFieldRef = e.target.value;
+              const nextField = dataset?.fields.find((f) => f.id === nextFieldRef);
+              const nextIsDateField = isDateDataType(nextField?.dataType);
+              handleChange({
+                fieldRef: nextFieldRef,
+                ...(nextIsDateField
+                  ? {
+                      type: 'date',
+                      operator: 'between',
+                      optionSource: undefined,
+                      dateConfig: filter.dateConfig ?? createDefaultDateConfig(),
+                    }
+                  : {}),
+              });
+            }}
             data-testid={`filter-field-${filter.id}`}
             style={selectStyle}
             disabled={!dataset}
@@ -464,20 +580,64 @@ function FilterEditor({
           <label htmlFor={defaultInputId} style={labelStyle}>
             Default value
           </label>
-          <input
-            id={defaultInputId}
-            name={`filter-default-${filter.id}`}
-            type="text"
-            value={filter.defaultValue != null ? String(filter.defaultValue) : ''}
-            onChange={(e) =>
-              handleChange({
-                defaultValue: e.target.value || undefined,
-              })
-            }
-            placeholder="Optional default..."
-            data-testid={`filter-default-${filter.id}`}
-            style={selectStyle}
-          />
+          {normalizedFilterType === 'date' ? (
+            <div style={{ display: 'flex', gap: 6 }}>
+              <input
+                id={defaultInputId}
+                name={`filter-default-start-${filter.id}`}
+                aria-label="Default start date"
+                type="date"
+                value={defaultDateValue.start ?? ''}
+                onChange={(e) => {
+                  const nextStart = e.target.value || undefined;
+                  const nextValue = {
+                    ...defaultDateValue,
+                    start: nextStart,
+                  };
+                  handleChange({
+                    defaultValue:
+                      nextValue.start || nextValue.end || nextValue.preset ? nextValue : undefined,
+                  });
+                }}
+                data-testid={`filter-default-start-${filter.id}`}
+                style={selectStyle}
+              />
+              <input
+                name={`filter-default-end-${filter.id}`}
+                aria-label="Default end date"
+                type="date"
+                value={defaultDateValue.end ?? ''}
+                onChange={(e) => {
+                  const nextEnd = e.target.value || undefined;
+                  const nextValue = {
+                    ...defaultDateValue,
+                    end: nextEnd,
+                  };
+                  handleChange({
+                    defaultValue:
+                      nextValue.start || nextValue.end || nextValue.preset ? nextValue : undefined,
+                  });
+                }}
+                data-testid={`filter-default-end-${filter.id}`}
+                style={selectStyle}
+              />
+            </div>
+          ) : (
+            <input
+              id={defaultInputId}
+              name={`filter-default-${filter.id}`}
+              type="text"
+              value={filter.defaultValue != null ? String(filter.defaultValue) : ''}
+              onChange={(e) =>
+                handleChange({
+                  defaultValue: e.target.value || undefined,
+                })
+              }
+              placeholder="Optional default..."
+              data-testid={`filter-default-${filter.id}`}
+              style={selectStyle}
+            />
+          )}
         </div>
       </div>
 
@@ -494,7 +654,7 @@ function FilterEditor({
           data-testid={`filter-type-${filter.id}`}
           style={selectStyle}
         >
-          {FILTER_CONTROL_OPTIONS.map((option) => (
+          {availableControlOptions.map((option) => (
             <option key={option.value} value={option.value}>
               {option.label}
             </option>
@@ -502,7 +662,130 @@ function FilterEditor({
         </select>
       </div>
 
-      {isSelectFilterControlType(normalizedFilterType) && (
+      {normalizedFilterType === 'date' && (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+            padding: 10,
+            borderRadius: 6,
+            border: '1px solid #dbe4ee',
+            background: '#fff',
+          }}
+        >
+          <div style={{ display: 'flex', gap: 8 }}>
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+              <label htmlFor={`ss-filter-date-mode-${filter.id}`} style={labelStyle}>
+                Date mode
+              </label>
+              <select
+                id={`ss-filter-date-mode-${filter.id}`}
+                name={`filter-date-mode-${filter.id}`}
+                value={dateConfig.mode ?? 'preset'}
+                onChange={(e) =>
+                  handleDateConfigChange({
+                    mode: e.target.value as NonNullable<DateFilterConfig['mode']>,
+                    allowCustomRange: e.target.value !== 'weekly',
+                  })
+                }
+                data-testid={`filter-date-mode-${filter.id}`}
+                style={selectStyle}
+              >
+                {DATE_FILTER_MODE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <label
+              style={{
+                display: 'flex',
+                alignItems: 'flex-end',
+                gap: 6,
+                fontSize: 12,
+                color: '#475569',
+                paddingBottom: 5,
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={dateConfig.allowCustomRange !== false}
+                onChange={(e) => handleDateConfigChange({ allowCustomRange: e.target.checked })}
+                data-testid={`filter-date-allow-custom-${filter.id}`}
+              />
+              Allow custom
+            </label>
+          </div>
+
+          {(dateConfig.mode ?? 'preset') === 'weekly' && (
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8 }}>
+              <div style={{ display: 'flex', flexDirection: 'column' }}>
+                <label htmlFor={`ss-filter-week-start-${filter.id}`} style={labelStyle}>
+                  Week starts on
+                </label>
+                <select
+                  id={`ss-filter-week-start-${filter.id}`}
+                  name={`filter-week-start-${filter.id}`}
+                  value={dateConfig.weekStartsOn ?? 0}
+                  onChange={(e) =>
+                    handleDateConfigChange({
+                      weekStartsOn: Number(e.target.value) as DateFilterConfig['weekStartsOn'],
+                    })
+                  }
+                  data-testid={`filter-week-start-${filter.id}`}
+                  style={selectStyle}
+                >
+                  {WEEKDAY_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column' }}>
+                <label htmlFor={`ss-filter-weeks-back-${filter.id}`} style={labelStyle}>
+                  Weeks back
+                </label>
+                <input
+                  id={`ss-filter-weeks-back-${filter.id}`}
+                  name={`filter-weeks-back-${filter.id}`}
+                  type="number"
+                  min={0}
+                  value={dateConfig.weeksBack ?? 4}
+                  onChange={(e) =>
+                    handleDateConfigChange({ weeksBack: coerceNonNegativeInteger(e.target.value) })
+                  }
+                  data-testid={`filter-weeks-back-${filter.id}`}
+                  style={selectStyle}
+                />
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column' }}>
+                <label htmlFor={`ss-filter-weeks-forward-${filter.id}`} style={labelStyle}>
+                  Weeks forward
+                </label>
+                <input
+                  id={`ss-filter-weeks-forward-${filter.id}`}
+                  name={`filter-weeks-forward-${filter.id}`}
+                  type="number"
+                  min={0}
+                  value={dateConfig.weeksForward ?? 0}
+                  onChange={(e) =>
+                    handleDateConfigChange({
+                      weeksForward: coerceNonNegativeInteger(e.target.value),
+                    })
+                  }
+                  data-testid={`filter-weeks-forward-${filter.id}`}
+                  style={selectStyle}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {isSelectFilterControlType(normalizedFilterType) && !isDateField && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           <div style={{ display: 'flex', flexDirection: 'column' }}>
             <label htmlFor={optionSourceSelectId} style={labelStyle}>

--- a/packages/designer/src/components/FilterBuilderPanel.tsx
+++ b/packages/designer/src/components/FilterBuilderPanel.tsx
@@ -90,9 +90,26 @@ const WEEKDAY_OPTIONS = [
 ] as const;
 
 const DATE_FILTER_MODE_OPTIONS = [
-  { value: 'preset', label: 'Preset or custom range' },
+  { value: 'preset', label: 'Relative date menu' },
   { value: 'range', label: 'Custom date range' },
   { value: 'weekly', label: 'Weekly range dropdown' },
+] as const;
+
+const DATE_DEFAULT_OPTIONS = [
+  { value: '', label: 'No default' },
+  { value: 'today', label: 'Today' },
+  { value: 'yesterday', label: 'Yesterday' },
+  { value: 'last_7_days', label: 'Last 7 days' },
+  { value: 'last_30_days', label: 'Last 30 days' },
+  { value: 'this_week', label: 'Current week' },
+  { value: 'last_week', label: 'Previous week' },
+  { value: 'custom', label: 'Specific date range' },
+] as const;
+
+const WEEKLY_DATE_DEFAULT_OPTIONS = [
+  { value: '', label: 'No default' },
+  { value: 'this_week', label: 'Current week' },
+  { value: 'last_week', label: 'Previous week' },
 ] as const;
 
 function isSelectFilterControlType(type: string): type is 'select' | 'multi-select' {
@@ -187,6 +204,59 @@ function asDateDefaultValue(value: unknown): { preset?: string; start?: string; 
   }
 
   return {};
+}
+
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function addDays(date: Date, days: number): Date {
+  const nextDate = new Date(date);
+  nextDate.setDate(nextDate.getDate() + days);
+  return nextDate;
+}
+
+function clampWeekday(
+  value: DateFilterConfig['weekStartsOn'] | undefined,
+): 0 | 1 | 2 | 3 | 4 | 5 | 6 {
+  return value === 0 ||
+    value === 1 ||
+    value === 2 ||
+    value === 3 ||
+    value === 4 ||
+    value === 5 ||
+    value === 6
+    ? value
+    : 0;
+}
+
+function getWeekStart(date: Date, weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6): Date {
+  const localDate = startOfLocalDay(date);
+  const dayOffset = (localDate.getDay() - weekStartsOn + 7) % 7;
+  return addDays(localDate, -dayOffset);
+}
+
+function formatShortDate(date: Date): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+  }).format(date);
+}
+
+function getWeeklyPreviewLabels(config: DateFilterConfig): string[] {
+  const weekStartsOn = clampWeekday(config.weekStartsOn);
+  const currentWeekStart = getWeekStart(new Date(), weekStartsOn);
+  const weeksBack = config.weeksBack ?? 4;
+  const weeksForward = config.weeksForward ?? 0;
+  const labels: string[] = [];
+
+  for (let offset = -weeksBack; offset <= weeksForward; offset += 1) {
+    const start = addDays(currentWeekStart, offset * 7);
+    const end = addDays(start, 6);
+    labels.push(`${formatShortDate(start)} - ${formatShortDate(end)}`);
+  }
+
+  return labels.reverse().slice(0, 3);
 }
 
 function normalizeFilterControlType(type: string): SupportedFilterControlType {
@@ -286,15 +356,21 @@ function FilterEditor({
     () => normalizeFilterControlType(filter.type),
     [filter.type],
   );
-  const availableControlOptions = useMemo(
-    () =>
-      isDateField
-        ? FILTER_CONTROL_OPTIONS.filter((option) => option.value === 'date')
-        : FILTER_CONTROL_OPTIONS,
-    [isDateField],
-  );
   const dateConfig = filter.dateConfig ?? createDefaultDateConfig();
+  const dateMode = dateConfig.mode ?? 'preset';
   const defaultDateValue = asDateDefaultValue(filter.defaultValue);
+  const rawSelectedDateDefault =
+    defaultDateValue.start || defaultDateValue.end ? 'custom' : (defaultDateValue.preset ?? '');
+  const selectedDateDefault =
+    dateMode === 'weekly' &&
+    rawSelectedDateDefault !== 'this_week' &&
+    rawSelectedDateDefault !== 'last_week'
+      ? ''
+      : rawSelectedDateDefault;
+  const dateDefaultOptions =
+    dateMode === 'weekly' ? WEEKLY_DATE_DEFAULT_OPTIONS : DATE_DEFAULT_OPTIONS;
+  const shouldShowDateDefaultRange = dateMode === 'range' || selectedDateDefault === 'custom';
+  const weeklyPreviewLabels = useMemo(() => getWeeklyPreviewLabels(dateConfig), [dateConfig]);
 
   const handleChange = useCallback(
     (patch: Partial<FilterDefinition>) => {
@@ -335,6 +411,35 @@ function FilterEditor({
     fontWeight: 600,
     color: '#555',
     marginBottom: 2,
+  };
+  const sectionStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8,
+    padding: 10,
+    borderRadius: 6,
+    border: '1px solid #dbe4ee',
+    background: '#fff',
+  };
+  const sectionTitleStyle: React.CSSProperties = {
+    fontSize: 11,
+    fontWeight: 700,
+    letterSpacing: 0,
+    color: '#334155',
+  };
+  const hintStyle: React.CSSProperties = {
+    fontSize: 12,
+    lineHeight: 1.4,
+    color: '#64748b',
+  };
+  const summaryStyle: React.CSSProperties = {
+    padding: '7px 9px',
+    borderRadius: 4,
+    background: '#f8fafc',
+    border: '1px solid #e2e8f0',
+    color: '#475569',
+    fontSize: 12,
+    lineHeight: 1.4,
   };
   const titleInputId = `ss-filter-title-${filter.id}`;
   const datasetSelectId = `ss-filter-dataset-${filter.id}`;
@@ -395,6 +500,33 @@ function FilterEditor({
       });
     },
     [filter.dateConfig, handleChange],
+  );
+
+  const handleDateModeChange = useCallback(
+    (mode: NonNullable<DateFilterConfig['mode']>) => {
+      const nextPatch: Partial<FilterDefinition> = {
+        type: 'date',
+        operator: 'between',
+        optionSource: undefined,
+        dateConfig: {
+          ...createDefaultDateConfig(mode),
+          ...(filter.dateConfig ?? {}),
+          mode,
+          allowCustomRange: mode !== 'weekly',
+        },
+      };
+
+      if (
+        mode === 'weekly' &&
+        defaultDateValue.preset !== 'this_week' &&
+        defaultDateValue.preset !== 'last_week'
+      ) {
+        nextPatch.defaultValue = undefined;
+      }
+
+      handleChange(nextPatch);
+    },
+    [defaultDateValue.preset, filter.dateConfig, handleChange],
   );
 
   const handleOptionSourceKindChange = useCallback(
@@ -555,139 +687,20 @@ function FilterEditor({
         </div>
       </div>
 
-      {/* Operator + Default value */}
-      <div style={{ display: 'flex', gap: 8 }}>
-        <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-          <label htmlFor={operatorSelectId} style={labelStyle}>
-            Operator
-          </label>
-          <select
-            id={operatorSelectId}
-            name={`filter-operator-${filter.id}`}
-            value={filter.operator}
-            onChange={(e) => handleChange({ operator: e.target.value })}
-            data-testid={`filter-operator-${filter.id}`}
-            style={selectStyle}
-          >
-            {applicableOperators.map((op) => (
-              <option key={op.value} value={op.value}>
-                {op.label}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-          <label htmlFor={defaultInputId} style={labelStyle}>
-            Default value
-          </label>
-          {normalizedFilterType === 'date' ? (
-            <div style={{ display: 'flex', gap: 6 }}>
-              <input
-                id={defaultInputId}
-                name={`filter-default-start-${filter.id}`}
-                aria-label="Default start date"
-                type="date"
-                value={defaultDateValue.start ?? ''}
-                onChange={(e) => {
-                  const nextStart = e.target.value || undefined;
-                  const nextValue = {
-                    ...defaultDateValue,
-                    start: nextStart,
-                  };
-                  handleChange({
-                    defaultValue:
-                      nextValue.start || nextValue.end || nextValue.preset ? nextValue : undefined,
-                  });
-                }}
-                data-testid={`filter-default-start-${filter.id}`}
-                style={selectStyle}
-              />
-              <input
-                name={`filter-default-end-${filter.id}`}
-                aria-label="Default end date"
-                type="date"
-                value={defaultDateValue.end ?? ''}
-                onChange={(e) => {
-                  const nextEnd = e.target.value || undefined;
-                  const nextValue = {
-                    ...defaultDateValue,
-                    end: nextEnd,
-                  };
-                  handleChange({
-                    defaultValue:
-                      nextValue.start || nextValue.end || nextValue.preset ? nextValue : undefined,
-                  });
-                }}
-                data-testid={`filter-default-end-${filter.id}`}
-                style={selectStyle}
-              />
-            </div>
-          ) : (
-            <input
-              id={defaultInputId}
-              name={`filter-default-${filter.id}`}
-              type="text"
-              value={filter.defaultValue != null ? String(filter.defaultValue) : ''}
-              onChange={(e) =>
-                handleChange({
-                  defaultValue: e.target.value || undefined,
-                })
-              }
-              placeholder="Optional default..."
-              data-testid={`filter-default-${filter.id}`}
-              style={selectStyle}
-            />
-          )}
-        </div>
-      </div>
-
-      {/* Filter type */}
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
-        <label htmlFor={typeSelectId} style={labelStyle}>
-          Control type
-        </label>
-        <select
-          id={typeSelectId}
-          name={`filter-type-${filter.id}`}
-          value={normalizedFilterType}
-          onChange={(e) => handleControlTypeChange(e.target.value as SupportedFilterControlType)}
-          data-testid={`filter-type-${filter.id}`}
-          style={selectStyle}
-        >
-          {availableControlOptions.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      {normalizedFilterType === 'date' && (
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 8,
-            padding: 10,
-            borderRadius: 6,
-            border: '1px solid #dbe4ee',
-            background: '#fff',
-          }}
-        >
-          <div style={{ display: 'flex', gap: 8 }}>
-            <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+      {normalizedFilterType === 'date' ? (
+        <>
+          <div style={sectionStyle}>
+            <div style={sectionTitleStyle}>End-user control</div>
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
               <label htmlFor={`ss-filter-date-mode-${filter.id}`} style={labelStyle}>
-                Date mode
+                Date filter style
               </label>
               <select
                 id={`ss-filter-date-mode-${filter.id}`}
                 name={`filter-date-mode-${filter.id}`}
-                value={dateConfig.mode ?? 'preset'}
+                value={dateMode}
                 onChange={(e) =>
-                  handleDateConfigChange({
-                    mode: e.target.value as NonNullable<DateFilterConfig['mode']>,
-                    allowCustomRange: e.target.value !== 'weekly',
-                  })
+                  handleDateModeChange(e.target.value as NonNullable<DateFilterConfig['mode']>)
                 }
                 data-testid={`filter-date-mode-${filter.id}`}
                 style={selectStyle}
@@ -699,90 +712,255 @@ function FilterEditor({
                 ))}
               </select>
             </div>
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'flex-end',
-                gap: 6,
-                fontSize: 12,
-                color: '#475569',
-                paddingBottom: 5,
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={dateConfig.allowCustomRange !== false}
-                onChange={(e) => handleDateConfigChange({ allowCustomRange: e.target.checked })}
-                data-testid={`filter-date-allow-custom-${filter.id}`}
-              />
-              Allow custom
-            </label>
+
+            {dateMode === 'weekly' && (
+              <>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 2fr', gap: 8 }}>
+                  <div style={{ display: 'flex', flexDirection: 'column' }}>
+                    <label htmlFor={`ss-filter-week-start-${filter.id}`} style={labelStyle}>
+                      Week starts on
+                    </label>
+                    <select
+                      id={`ss-filter-week-start-${filter.id}`}
+                      name={`filter-week-start-${filter.id}`}
+                      value={dateConfig.weekStartsOn ?? 0}
+                      onChange={(e) =>
+                        handleDateConfigChange({
+                          weekStartsOn: Number(e.target.value) as DateFilterConfig['weekStartsOn'],
+                        })
+                      }
+                      data-testid={`filter-week-start-${filter.id}`}
+                      style={selectStyle}
+                    >
+                      {WEEKDAY_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+                    <div style={{ display: 'flex', flexDirection: 'column' }}>
+                      <label htmlFor={`ss-filter-weeks-back-${filter.id}`} style={labelStyle}>
+                        Weeks back
+                      </label>
+                      <input
+                        id={`ss-filter-weeks-back-${filter.id}`}
+                        name={`filter-weeks-back-${filter.id}`}
+                        type="number"
+                        min={0}
+                        value={dateConfig.weeksBack ?? 4}
+                        onChange={(e) =>
+                          handleDateConfigChange({
+                            weeksBack: coerceNonNegativeInteger(e.target.value),
+                          })
+                        }
+                        data-testid={`filter-weeks-back-${filter.id}`}
+                        style={selectStyle}
+                      />
+                    </div>
+                    <div style={{ display: 'flex', flexDirection: 'column' }}>
+                      <label htmlFor={`ss-filter-weeks-forward-${filter.id}`} style={labelStyle}>
+                        Weeks forward
+                      </label>
+                      <input
+                        id={`ss-filter-weeks-forward-${filter.id}`}
+                        name={`filter-weeks-forward-${filter.id}`}
+                        type="number"
+                        min={0}
+                        value={dateConfig.weeksForward ?? 0}
+                        onChange={(e) =>
+                          handleDateConfigChange({
+                            weeksForward: coerceNonNegativeInteger(e.target.value),
+                          })
+                        }
+                        data-testid={`filter-weeks-forward-${filter.id}`}
+                        style={selectStyle}
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div style={{ ...summaryStyle, display: 'flex', flexDirection: 'column', gap: 3 }}>
+                  <strong style={{ color: '#334155', fontSize: 12 }}>Dropdown preview</strong>
+                  {weeklyPreviewLabels.map((label) => (
+                    <span key={label}>{label}</span>
+                  ))}
+                  <span style={{ color: '#64748b' }}>
+                    Showing {Math.min(weeklyPreviewLabels.length, 3)} of{' '}
+                    {(dateConfig.weeksBack ?? 4) + (dateConfig.weeksForward ?? 0) + 1} weeks
+                  </span>
+                </div>
+              </>
+            )}
+
+            {dateMode === 'preset' && (
+              <div style={hintStyle}>
+                End users choose from common relative ranges and, when enabled by the runtime, a
+                custom range.
+              </div>
+            )}
+
+            {dateMode === 'range' && (
+              <div style={hintStyle}>End users enter a start and end date.</div>
+            )}
           </div>
 
-          {(dateConfig.mode ?? 'preset') === 'weekly' && (
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8 }}>
-              <div style={{ display: 'flex', flexDirection: 'column' }}>
-                <label htmlFor={`ss-filter-week-start-${filter.id}`} style={labelStyle}>
-                  Week starts on
-                </label>
-                <select
-                  id={`ss-filter-week-start-${filter.id}`}
-                  name={`filter-week-start-${filter.id}`}
-                  value={dateConfig.weekStartsOn ?? 0}
-                  onChange={(e) =>
-                    handleDateConfigChange({
-                      weekStartsOn: Number(e.target.value) as DateFilterConfig['weekStartsOn'],
-                    })
+          <div style={sectionStyle}>
+            <div style={sectionTitleStyle}>Default selection</div>
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <label htmlFor={defaultInputId} style={labelStyle}>
+                Initial value
+              </label>
+              <select
+                id={defaultInputId}
+                name={`filter-default-preset-${filter.id}`}
+                value={selectedDateDefault}
+                onChange={(e) => {
+                  const nextDefault = e.target.value;
+
+                  if (!nextDefault) {
+                    handleChange({ defaultValue: undefined });
+                    return;
                   }
-                  data-testid={`filter-week-start-${filter.id}`}
-                  style={selectStyle}
-                >
-                  {WEEKDAY_OPTIONS.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div style={{ display: 'flex', flexDirection: 'column' }}>
-                <label htmlFor={`ss-filter-weeks-back-${filter.id}`} style={labelStyle}>
-                  Weeks back
-                </label>
-                <input
-                  id={`ss-filter-weeks-back-${filter.id}`}
-                  name={`filter-weeks-back-${filter.id}`}
-                  type="number"
-                  min={0}
-                  value={dateConfig.weeksBack ?? 4}
-                  onChange={(e) =>
-                    handleDateConfigChange({ weeksBack: coerceNonNegativeInteger(e.target.value) })
+
+                  if (nextDefault === 'custom') {
+                    handleChange({
+                      defaultValue: {
+                        start: defaultDateValue.start,
+                        end: defaultDateValue.end,
+                      },
+                    });
+                    return;
                   }
-                  data-testid={`filter-weeks-back-${filter.id}`}
-                  style={selectStyle}
-                />
-              </div>
-              <div style={{ display: 'flex', flexDirection: 'column' }}>
-                <label htmlFor={`ss-filter-weeks-forward-${filter.id}`} style={labelStyle}>
-                  Weeks forward
-                </label>
-                <input
-                  id={`ss-filter-weeks-forward-${filter.id}`}
-                  name={`filter-weeks-forward-${filter.id}`}
-                  type="number"
-                  min={0}
-                  value={dateConfig.weeksForward ?? 0}
-                  onChange={(e) =>
-                    handleDateConfigChange({
-                      weeksForward: coerceNonNegativeInteger(e.target.value),
-                    })
-                  }
-                  data-testid={`filter-weeks-forward-${filter.id}`}
-                  style={selectStyle}
-                />
-              </div>
+
+                  handleChange({ defaultValue: { preset: nextDefault } });
+                }}
+                data-testid={`filter-date-default-${filter.id}`}
+                style={selectStyle}
+              >
+                {dateDefaultOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
             </div>
-          )}
-        </div>
+
+            {shouldShowDateDefaultRange && (
+              <div style={{ display: 'flex', gap: 6 }}>
+                <input
+                  name={`filter-default-start-${filter.id}`}
+                  aria-label="Default start date"
+                  type="date"
+                  value={defaultDateValue.start ?? ''}
+                  onChange={(e) => {
+                    const nextStart = e.target.value || undefined;
+                    const nextValue = {
+                      ...defaultDateValue,
+                      preset: undefined,
+                      start: nextStart,
+                    };
+                    handleChange({
+                      defaultValue: nextValue.start || nextValue.end ? nextValue : undefined,
+                    });
+                  }}
+                  data-testid={`filter-default-start-${filter.id}`}
+                  style={selectStyle}
+                />
+                <input
+                  name={`filter-default-end-${filter.id}`}
+                  aria-label="Default end date"
+                  type="date"
+                  value={defaultDateValue.end ?? ''}
+                  onChange={(e) => {
+                    const nextEnd = e.target.value || undefined;
+                    const nextValue = {
+                      ...defaultDateValue,
+                      preset: undefined,
+                      end: nextEnd,
+                    };
+                    handleChange({
+                      defaultValue: nextValue.start || nextValue.end ? nextValue : undefined,
+                    });
+                  }}
+                  data-testid={`filter-default-end-${filter.id}`}
+                  style={selectStyle}
+                />
+              </div>
+            )}
+          </div>
+
+          <div style={summaryStyle} data-testid={`filter-date-query-behavior-${filter.id}`}>
+            Applies as: {field?.label ?? filter.fieldRef} between start and end.
+          </div>
+        </>
+      ) : (
+        <>
+          {/* Operator + Default value */}
+          <div style={{ display: 'flex', gap: 8 }}>
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+              <label htmlFor={operatorSelectId} style={labelStyle}>
+                Operator
+              </label>
+              <select
+                id={operatorSelectId}
+                name={`filter-operator-${filter.id}`}
+                value={filter.operator}
+                onChange={(e) => handleChange({ operator: e.target.value })}
+                data-testid={`filter-operator-${filter.id}`}
+                style={selectStyle}
+              >
+                {applicableOperators.map((op) => (
+                  <option key={op.value} value={op.value}>
+                    {op.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+              <label htmlFor={defaultInputId} style={labelStyle}>
+                Default value
+              </label>
+              <input
+                id={defaultInputId}
+                name={`filter-default-${filter.id}`}
+                type="text"
+                value={filter.defaultValue != null ? String(filter.defaultValue) : ''}
+                onChange={(e) =>
+                  handleChange({
+                    defaultValue: e.target.value || undefined,
+                  })
+                }
+                placeholder="Optional default..."
+                data-testid={`filter-default-${filter.id}`}
+                style={selectStyle}
+              />
+            </div>
+          </div>
+
+          {/* Filter type */}
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <label htmlFor={typeSelectId} style={labelStyle}>
+              Control type
+            </label>
+            <select
+              id={typeSelectId}
+              name={`filter-type-${filter.id}`}
+              value={normalizedFilterType}
+              onChange={(e) =>
+                handleControlTypeChange(e.target.value as SupportedFilterControlType)
+              }
+              data-testid={`filter-type-${filter.id}`}
+              style={selectStyle}
+            >
+              {FILTER_CONTROL_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </>
       )}
 
       {isSelectFilterControlType(normalizedFilterType) && !isDateField && (

--- a/packages/designer/src/components/FilterBuilderPanel.tsx
+++ b/packages/designer/src/components/FilterBuilderPanel.tsx
@@ -209,12 +209,17 @@ function asDateDefaultValue(value: unknown): { preset?: string; start?: string; 
   return {};
 }
 
-function getWeeklyPreviewLabels(config: DateFilterConfig): string[] {
+function getWeeklyPreview(config: DateFilterConfig): { labels: string[]; total: number } {
+  const options = generateWeeklyDateRangeOptions(config);
+
   // Preview only the newest few generated choices so the editor stays compact.
-  return generateWeeklyDateRangeOptions(config)
-    .reverse()
-    .slice(0, WEEKLY_PREVIEW_OPTION_COUNT)
-    .map((option) => option.label);
+  return {
+    labels: [...options]
+      .reverse()
+      .slice(0, WEEKLY_PREVIEW_OPTION_COUNT)
+      .map((option) => option.label),
+    total: options.length,
+  };
 }
 
 function normalizeFilterControlType(type: string): SupportedFilterControlType {
@@ -328,7 +333,7 @@ function FilterEditor({
   const dateDefaultOptions =
     dateMode === 'weekly' ? WEEKLY_DATE_DEFAULT_OPTIONS : DATE_DEFAULT_OPTIONS;
   const shouldShowDateDefaultRange = dateMode === 'range' || selectedDateDefault === 'custom';
-  const weeklyPreviewLabels = useMemo(() => getWeeklyPreviewLabels(dateConfig), [dateConfig]);
+  const weeklyPreview = useMemo(() => getWeeklyPreview(dateConfig), [dateConfig]);
 
   const handleChange = useCallback(
     (patch: Partial<FilterDefinition>) => {
@@ -725,12 +730,12 @@ function FilterEditor({
                 </div>
                 <div style={{ ...summaryStyle, display: 'flex', flexDirection: 'column', gap: 3 }}>
                   <strong style={{ color: '#334155', fontSize: 12 }}>Dropdown preview</strong>
-                  {weeklyPreviewLabels.map((label) => (
+                  {weeklyPreview.labels.map((label) => (
                     <span key={label}>{label}</span>
                   ))}
                   <span style={{ color: '#64748b' }}>
-                    Showing {Math.min(weeklyPreviewLabels.length, WEEKLY_PREVIEW_OPTION_COUNT)} of{' '}
-                    {(dateConfig.weeksBack ?? 4) + (dateConfig.weeksForward ?? 0) + 1} weeks
+                    Showing {Math.min(weeklyPreview.labels.length, WEEKLY_PREVIEW_OPTION_COUNT)} of{' '}
+                    {weeklyPreview.total} weeks
                   </span>
                 </div>
               </>

--- a/packages/designer/src/components/FilterBuilderPanel.tsx
+++ b/packages/designer/src/components/FilterBuilderPanel.tsx
@@ -11,12 +11,13 @@
  */
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { NormalizedDataset } from '@supersubset/data-model';
-import type {
-  DateFilterConfig,
-  FilterDefinition,
-  FilterOptionDefinition,
-  FilterOptionSource,
-  FilterScope,
+import {
+  generateWeeklyDateRangeOptions,
+  type DateFilterConfig,
+  type FilterDefinition,
+  type FilterOptionDefinition,
+  type FilterOptionSource,
+  type FilterScope,
 } from '@supersubset/schema';
 
 export type { FilterDefinition, FilterScope } from '@supersubset/schema';
@@ -112,6 +113,8 @@ const WEEKLY_DATE_DEFAULT_OPTIONS = [
   { value: 'last_week', label: 'Previous week' },
 ] as const;
 
+const WEEKLY_PREVIEW_OPTION_COUNT = 3;
+
 function isSelectFilterControlType(type: string): type is 'select' | 'multi-select' {
   return SELECT_FILTER_CONTROL_TYPES.has(type as SupportedFilterControlType);
 }
@@ -206,57 +209,12 @@ function asDateDefaultValue(value: unknown): { preset?: string; start?: string; 
   return {};
 }
 
-function startOfLocalDay(date: Date): Date {
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
-}
-
-function addDays(date: Date, days: number): Date {
-  const nextDate = new Date(date);
-  nextDate.setDate(nextDate.getDate() + days);
-  return nextDate;
-}
-
-function clampWeekday(
-  value: DateFilterConfig['weekStartsOn'] | undefined,
-): 0 | 1 | 2 | 3 | 4 | 5 | 6 {
-  return value === 0 ||
-    value === 1 ||
-    value === 2 ||
-    value === 3 ||
-    value === 4 ||
-    value === 5 ||
-    value === 6
-    ? value
-    : 0;
-}
-
-function getWeekStart(date: Date, weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6): Date {
-  const localDate = startOfLocalDay(date);
-  const dayOffset = (localDate.getDay() - weekStartsOn + 7) % 7;
-  return addDays(localDate, -dayOffset);
-}
-
-function formatShortDate(date: Date): string {
-  return new Intl.DateTimeFormat(undefined, {
-    month: 'short',
-    day: 'numeric',
-  }).format(date);
-}
-
 function getWeeklyPreviewLabels(config: DateFilterConfig): string[] {
-  const weekStartsOn = clampWeekday(config.weekStartsOn);
-  const currentWeekStart = getWeekStart(new Date(), weekStartsOn);
-  const weeksBack = config.weeksBack ?? 4;
-  const weeksForward = config.weeksForward ?? 0;
-  const labels: string[] = [];
-
-  for (let offset = -weeksBack; offset <= weeksForward; offset += 1) {
-    const start = addDays(currentWeekStart, offset * 7);
-    const end = addDays(start, 6);
-    labels.push(`${formatShortDate(start)} - ${formatShortDate(end)}`);
-  }
-
-  return labels.reverse().slice(0, 3);
+  // Preview only the newest few generated choices so the editor stays compact.
+  return generateWeeklyDateRangeOptions(config)
+    .reverse()
+    .slice(0, WEEKLY_PREVIEW_OPTION_COUNT)
+    .map((option) => option.label);
 }
 
 function normalizeFilterControlType(type: string): SupportedFilterControlType {
@@ -657,22 +615,7 @@ function FilterEditor({
             id={fieldSelectId}
             name={`filter-field-${filter.id}`}
             value={filter.fieldRef}
-            onChange={(e) => {
-              const nextFieldRef = e.target.value;
-              const nextField = dataset?.fields.find((f) => f.id === nextFieldRef);
-              const nextIsDateField = isDateDataType(nextField?.dataType);
-              handleChange({
-                fieldRef: nextFieldRef,
-                ...(nextIsDateField
-                  ? {
-                      type: 'date',
-                      operator: 'between',
-                      optionSource: undefined,
-                      dateConfig: filter.dateConfig ?? createDefaultDateConfig(),
-                    }
-                  : {}),
-              });
-            }}
+            onChange={(e) => handleChange({ fieldRef: e.target.value })}
             data-testid={`filter-field-${filter.id}`}
             style={selectStyle}
             disabled={!dataset}
@@ -786,7 +729,7 @@ function FilterEditor({
                     <span key={label}>{label}</span>
                   ))}
                   <span style={{ color: '#64748b' }}>
-                    Showing {Math.min(weeklyPreviewLabels.length, 3)} of{' '}
+                    Showing {Math.min(weeklyPreviewLabels.length, WEEKLY_PREVIEW_OPTION_COUNT)} of{' '}
                     {(dateConfig.weeksBack ?? 4) + (dateConfig.weeksForward ?? 0) + 1} weeks
                   </span>
                 </div>

--- a/packages/designer/test/designer.test.tsx
+++ b/packages/designer/test/designer.test.tsx
@@ -169,7 +169,7 @@ describe('SupersubsetDesigner', () => {
     cleanup();
   });
 
-  it('renders the Puck editor', () => {
+  it('[designer-authoring.PUCK_SHELL.1] renders the Puck editor', () => {
     render(React.createElement(SupersubsetDesigner, {}));
     expect(screen.getByTestId('puck-editor')).toBeDefined();
   });
@@ -210,7 +210,7 @@ describe('SupersubsetDesigner', () => {
     expect(editor.getAttribute('data-header-title')).toBe('Test Dashboard');
   });
 
-  it('wires onPublish callback', () => {
+  it('[designer-authoring.IMPORT_EXPORT.1] wires onPublish callback', () => {
     const onPublish = vi.fn();
     render(React.createElement(SupersubsetDesigner, { onPublish }));
     const editor = screen.getByTestId('puck-editor');
@@ -302,7 +302,7 @@ describe('SupersubsetDesigner', () => {
     expect(editor.getAttribute('data-header-title')).toBe('Default Title');
   });
 
-  it('passes renamed sidebar plugins (Components + Layers)', () => {
+  it('[designer-authoring.PALETTE.1] passes renamed sidebar plugins (Components + Layers)', () => {
     render(React.createElement(SupersubsetDesigner, {}));
     const editor = screen.getByTestId('puck-editor');
     expect(editor.getAttribute('data-plugin-labels')).toBe('Components,Layers');
@@ -326,7 +326,7 @@ describe('SupersubsetDesigner', () => {
     expect(screen.getByTestId('default-actions')).toBeDefined();
   });
 
-  it('renders a built-in Filters action and opens the filter drawer', () => {
+  it('[designer-authoring.PROPERTY_PANELS.1] renders a built-in Filters action and opens the filter drawer', () => {
     render(
       React.createElement(SupersubsetDesigner, {
         value: minimalDashboard,
@@ -362,7 +362,7 @@ describe('SupersubsetDesigner', () => {
     });
   });
 
-  it('renders page tabs for multi-page dashboards and switches the edited page', () => {
+  it('[designer-authoring.PAGE_NAVIGATION.1] renders page tabs for multi-page dashboards and switches the edited page', () => {
     render(
       React.createElement(SupersubsetDesigner, {
         value: multiPageDashboard,

--- a/packages/designer/test/feature-panels-2.test.tsx
+++ b/packages/designer/test/feature-panels-2.test.tsx
@@ -726,11 +726,23 @@ describe('FilterBuilderPanel', () => {
       scope: { type: 'global' },
     };
 
-    render(<FilterBuilderPanel filters={[filter]} onChange={onChange} datasets={[MOCK_DATASET]} />);
+    const { rerender } = render(
+      <FilterBuilderPanel filters={[filter]} onChange={onChange} datasets={[MOCK_DATASET]} />,
+    );
 
     fireEvent.change(screen.getByTestId('filter-field-f-date'), {
       target: { value: 'order_date' },
     });
+
+    expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ fieldRef: 'order_date' })]);
+
+    rerender(
+      <FilterBuilderPanel
+        filters={[{ ...filter, fieldRef: 'order_date' }]}
+        onChange={onChange}
+        datasets={[MOCK_DATASET]}
+      />,
+    );
 
     expect(onChange).toHaveBeenCalledWith([
       expect.objectContaining({

--- a/packages/designer/test/feature-panels-2.test.tsx
+++ b/packages/designer/test/feature-panels-2.test.tsx
@@ -714,6 +714,66 @@ describe('FilterBuilderPanel', () => {
     expect(optionValues).toEqual(['select', 'multi-select', 'range', 'date', 'text']);
   });
 
+  it('[filters-and-interactions.FILTER_BAR.4] switches date fields to date-aware controls', () => {
+    const onChange = vi.fn();
+    const filter: FilterDefinition = {
+      id: 'f-date',
+      type: 'select',
+      fieldRef: 'region',
+      datasetRef: 'ds-orders',
+      operator: 'equals',
+      scope: { type: 'global' },
+    };
+
+    render(<FilterBuilderPanel filters={[filter]} onChange={onChange} datasets={[MOCK_DATASET]} />);
+
+    fireEvent.change(screen.getByTestId('filter-field-f-date'), {
+      target: { value: 'order_date' },
+    });
+
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        fieldRef: 'order_date',
+        type: 'date',
+        operator: 'between',
+        optionSource: undefined,
+        dateConfig: expect.objectContaining({ mode: 'preset' }),
+      }),
+    ]);
+  });
+
+  it('[filters-and-interactions.FILTER_BAR.4] hides select option sourcing for date filters and exposes weekly settings', () => {
+    const filter: FilterDefinition = {
+      id: 'f-date',
+      type: 'date',
+      fieldRef: 'order_date',
+      datasetRef: 'ds-orders',
+      operator: 'between',
+      dateConfig: {
+        mode: 'weekly',
+        weekStartsOn: 1,
+        weeksBack: 2,
+        weeksForward: 1,
+        includeCurrentWeek: true,
+      },
+      scope: { type: 'global' },
+    };
+
+    render(<FilterBuilderPanel filters={[filter]} onChange={vi.fn()} datasets={[MOCK_DATASET]} />);
+
+    expect(screen.queryByTestId('filter-option-source-kind-f-date')).toBeNull();
+    expect(screen.getByTestId('filter-date-mode-f-date')).toBeTruthy();
+    expect(screen.getByTestId('filter-week-start-f-date')).toBeTruthy();
+    expect(screen.getByTestId('filter-weeks-back-f-date')).toBeTruthy();
+    expect(screen.getByTestId('filter-weeks-forward-f-date')).toBeTruthy();
+
+    const typeValues = Array.from(
+      screen.getByTestId('filter-type-f-date').querySelectorAll('option'),
+    ).map((option) => option.getAttribute('value'));
+
+    expect(typeValues).toEqual(['date']);
+  });
+
   it('lets authors choose a static option source and add authored options', () => {
     const onChange = vi.fn();
     const filter: FilterDefinition = {

--- a/packages/designer/test/feature-panels-2.test.tsx
+++ b/packages/designer/test/feature-panels-2.test.tsx
@@ -787,6 +787,27 @@ describe('FilterBuilderPanel', () => {
     expect(screen.getByTestId('filter-weeks-forward-f-date')).toBeTruthy();
   });
 
+  it('[filters-and-interactions.FILTER_BAR.4] counts weekly preview options after excluding current week', () => {
+    const filter: FilterDefinition = {
+      id: 'f-date',
+      type: 'date',
+      fieldRef: 'order_date',
+      datasetRef: 'ds-orders',
+      operator: 'between',
+      dateConfig: {
+        mode: 'weekly',
+        weeksBack: 1,
+        weeksForward: 1,
+        includeCurrentWeek: false,
+      },
+      scope: { type: 'global' },
+    };
+
+    render(<FilterBuilderPanel filters={[filter]} onChange={vi.fn()} datasets={[MOCK_DATASET]} />);
+
+    expect(screen.getByText('Showing 2 of 2 weeks')).toBeTruthy();
+  });
+
   it('lets authors choose a static option source and add authored options', () => {
     const onChange = vi.fn();
     const filter: FilterDefinition = {

--- a/packages/designer/test/feature-panels-2.test.tsx
+++ b/packages/designer/test/feature-panels-2.test.tsx
@@ -613,7 +613,8 @@ describe('FilterBuilderPanel', () => {
     render(<FilterBuilderPanel filters={[filter]} onChange={onChange} datasets={[MOCK_DATASET]} />);
 
     expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ type: 'date' })]);
-    expect((screen.getByTestId('filter-type-f1') as HTMLSelectElement).value).toBe('date');
+    expect(screen.queryByTestId('filter-type-f1')).toBeNull();
+    expect(screen.getByTestId('filter-date-mode-f1')).toBeTruthy();
   });
 
   it('does not renormalize equivalent legacy filters when props churn', () => {
@@ -762,16 +763,16 @@ describe('FilterBuilderPanel', () => {
     render(<FilterBuilderPanel filters={[filter]} onChange={vi.fn()} datasets={[MOCK_DATASET]} />);
 
     expect(screen.queryByTestId('filter-option-source-kind-f-date')).toBeNull();
+    expect(screen.queryByTestId('filter-type-f-date')).toBeNull();
+    expect(screen.queryByTestId('filter-date-allow-custom-f-date')).toBeNull();
     expect(screen.getByTestId('filter-date-mode-f-date')).toBeTruthy();
+    expect(screen.getByTestId('filter-date-default-f-date')).toBeTruthy();
+    expect(screen.getByTestId('filter-date-query-behavior-f-date').textContent).toContain(
+      'between',
+    );
     expect(screen.getByTestId('filter-week-start-f-date')).toBeTruthy();
     expect(screen.getByTestId('filter-weeks-back-f-date')).toBeTruthy();
     expect(screen.getByTestId('filter-weeks-forward-f-date')).toBeTruthy();
-
-    const typeValues = Array.from(
-      screen.getByTestId('filter-type-f-date').querySelectorAll('option'),
-    ).map((option) => option.getAttribute('value'));
-
-    expect(typeValues).toEqual(['date']);
   });
 
   it('lets authors choose a static option source and add authored options', () => {

--- a/packages/dev-app/src/probe/auth.test.ts
+++ b/packages/dev-app/src/probe/auth.test.ts
@@ -72,7 +72,7 @@ describe('probe auth helpers', () => {
     expect(toAuthHeader('login', '', '', '')).toBeUndefined();
   });
 
-  it('persists and restores session config', () => {
+  it('[query-and-probe.PROBE_DISCOVERY.2] persists and restores session config', () => {
     saveProbeSession({
       metadataSourceMode: 'discovery-url',
       discoveryUrl: 'https://api.example.com/supersubset/datasets',
@@ -211,7 +211,7 @@ describe('extractByPath', () => {
 });
 
 describe('performProbeLogin', () => {
-  it('posts a GraphQL login mutation with variables and returns the extracted token', async () => {
+  it('[query-and-probe.PROBE_QUERY.3] posts a GraphQL login mutation with variables and returns the extracted token', async () => {
     const fetcher = vi.fn(
       async () =>
         new Response(JSON.stringify({ data: { login: { accessToken: 'jwt-abc' } } }), {
@@ -242,7 +242,7 @@ describe('performProbeLogin', () => {
     expect(body.variables).toEqual({ email: 'dev@example.com', password: 'secret' });
   });
 
-  it('throws a descriptive error when the response contains GraphQL errors', async () => {
+  it('[query-and-probe.ERROR_ENVELOPE.1] throws a descriptive error when the response contains GraphQL errors', async () => {
     const fetcher = vi.fn(
       async () =>
         new Response(JSON.stringify({ errors: [{ message: 'Invalid credentials' }] }), {
@@ -302,7 +302,7 @@ describe('performProbeLogin', () => {
     expect(fetcher).not.toHaveBeenCalled();
   });
 
-  it('surfaces HTTP errors with status code', async () => {
+  it('[query-and-probe.ERROR_ENVELOPE.2] surfaces HTTP errors with status code', async () => {
     const fetcher = vi.fn(
       async () =>
         new Response(JSON.stringify({ errors: [{ message: 'Boom' }] }), {

--- a/packages/dev-app/src/probe/http-adapters.test.ts
+++ b/packages/dev-app/src/probe/http-adapters.test.ts
@@ -33,7 +33,7 @@ describe('http adapters', () => {
     }
   });
 
-  it('injects bearer auth header for metadata probe', async () => {
+  it('[query-and-probe.PROBE_DISCOVERY.3] injects bearer auth header for metadata probe', async () => {
     const fetcher = vi.fn(
       async () =>
         new Response(JSON.stringify([]), {
@@ -116,7 +116,7 @@ describe('http adapters', () => {
     expect(url).toBe('https://example.com/v2/datasets');
   });
 
-  it('posts logical query to query endpoint with custom header', async () => {
+  it('[query-and-probe.PROBE_QUERY.2] posts logical query to query endpoint with custom header', async () => {
     const fetcher = vi.fn(
       async () =>
         new Response(
@@ -186,7 +186,7 @@ describe('http adapters', () => {
     expect(byId.country?.label).toBe('Country');
   });
 
-  it('accepts direct discovery endpoint URLs without appending another suffix', async () => {
+  it('[query-and-probe.BACKEND_AGNOSTIC.1] accepts direct discovery endpoint URLs without appending another suffix', async () => {
     const fetcher = vi.fn(
       async () =>
         new Response(JSON.stringify([]), {

--- a/packages/dev-app/src/probe/metadata.test.ts
+++ b/packages/dev-app/src/probe/metadata.test.ts
@@ -22,21 +22,21 @@ const DATASETS: NormalizedDataset[] = [
 ];
 
 describe('probe metadata helpers', () => {
-  it('accepts metadata JSON envelope objects', async () => {
+  it('[query-and-probe.PROBE_DISCOVERY.1] accepts metadata JSON envelope objects', async () => {
     const datasets = await parseProbeMetadataJson(JSON.stringify({ datasets: DATASETS }));
 
     expect(datasets).toHaveLength(1);
     expect(datasets[0]?.id).toBe('orders');
   });
 
-  it('accepts raw dataset arrays', async () => {
+  it('[query-and-probe.PROBE_DISCOVERY.2] accepts raw dataset arrays', async () => {
     const datasets = await parseProbeMetadataJson(JSON.stringify(DATASETS));
 
     expect(datasets).toHaveLength(1);
     expect(datasets[0]?.fields[1]?.defaultAggregation).toBe('sum');
   });
 
-  it('builds preview queries with aggregation for measure fields', () => {
+  it('[query-and-probe.PREVIEW_DATA.1] builds preview queries with aggregation for measure fields', () => {
     const query = buildPreviewQuery(DATASETS, 'orders', {
       xField: 'region',
       yField: 'revenue',
@@ -49,7 +49,7 @@ describe('probe metadata helpers', () => {
     });
   });
 
-  it('uses explicit aggregation hints for metric slots', () => {
+  it('[query-and-probe.PREVIEW_DATA.2] uses explicit aggregation hints for metric slots', () => {
     const query = buildPreviewQuery(
       [
         {
@@ -91,7 +91,7 @@ describe('probe metadata helpers', () => {
     });
   });
 
-  it('derives query endpoint from discovery endpoint input', () => {
+  it('[query-and-probe.PROBE_QUERY.1] derives query endpoint from discovery endpoint input', () => {
     expect(deriveQueryEndpointInput('https://api.example.com/supersubset/datasets')).toBe(
       'https://api.example.com/supersubset/query',
     );

--- a/packages/query-client/src/index.ts
+++ b/packages/query-client/src/index.ts
@@ -5,17 +5,18 @@
  * metadata from MetadataAdapter. The host app instantiates this and provides
  * the concrete adapters — Supersubset never connects to databases directly.
  */
-import type {
-  FilterOptionRequest,
-  FilterOptionResponse,
-  LogicalQuery,
-  QueryResult,
-  QueryAdapter,
-  MetadataAdapter,
-  NormalizedDataset,
-  QueryFilter,
-  QuerySort,
-  AggregationType,
+import {
+  resolveFilterOptionsWithAdapter,
+  type FilterOptionRequest,
+  type FilterOptionResponse,
+  type LogicalQuery,
+  type QueryResult,
+  type QueryAdapter,
+  type MetadataAdapter,
+  type NormalizedDataset,
+  type QueryFilter,
+  type QuerySort,
+  type AggregationType,
 } from '@supersubset/data-model';
 
 // Re-export key data-model types for convenience
@@ -85,12 +86,15 @@ export class QueryClient<TSource = unknown> {
     }
   }
 
-  /** Resolve filter options via the host adapter (if supported) */
+  /**
+   * Resolve filter options through the host adapter.
+   *
+   * Delegates to `queryAdapter.resolveFilterOptions` if implemented; otherwise
+   * falls back to a generic distinct-values query via the adapter's `execute`.
+   * See ADR-009 §2.
+   */
   async resolveFilterOptions(request: FilterOptionRequest): Promise<FilterOptionResponse> {
-    if (!this.queryAdapter.resolveFilterOptions) {
-      throw new Error('Query adapter does not support filter option resolution');
-    }
-    return this.queryAdapter.resolveFilterOptions(request);
+    return resolveFilterOptionsWithAdapter(this.queryAdapter, request);
   }
 
   /** Get all datasets from metadata adapter (cached) */

--- a/packages/query-client/test/query-client.test.ts
+++ b/packages/query-client/test/query-client.test.ts
@@ -191,7 +191,7 @@ describe('QueryClient', () => {
       fields: [{ fieldId: 'status' }],
       limit: 10,
       distinct: true,
-      filters: [{ fieldId: 'status', operator: 'like', value: 'sh' }],
+      filters: [{ fieldId: 'status', operator: 'like', value: '%sh%' }],
     });
   });
 

--- a/packages/query-client/test/query-client.test.ts
+++ b/packages/query-client/test/query-client.test.ts
@@ -96,7 +96,7 @@ describe('QueryClient', () => {
     });
   });
 
-  it('executes a query via the adapter', async () => {
+  it('[query-and-probe.QUERY_CLIENT.1] executes a query via the adapter', async () => {
     const query: LogicalQuery = {
       datasetId: 'orders',
       fields: [{ fieldId: 'status' }, { fieldId: 'total', aggregation: 'sum' }],
@@ -116,12 +116,12 @@ describe('QueryClient', () => {
     );
   });
 
-  it('cancels a query via the adapter', async () => {
+  it('[query-and-probe.QUERY_CLIENT.2] cancels a query via the adapter', async () => {
     await client.cancel('query-123');
     expect(queryAdapter.cancel).toHaveBeenCalledWith('query-123');
   });
 
-  it('resolves filter options via the adapter', async () => {
+  it('[query-and-probe.QUERY_CLIENT.3] resolves filter options via the adapter', async () => {
     const response = await client.resolveFilterOptions({
       filterId: 'status-filter',
       datasetId: 'orders',
@@ -163,7 +163,7 @@ describe('QueryClient', () => {
     await clientNoCancel.cancel('query-123');
   });
 
-  it('fetches datasets from metadata adapter', async () => {
+  it('[query-and-probe.QUERY_CLIENT.4] fetches datasets from metadata adapter', async () => {
     const datasets = await client.getDatasets();
     expect(metadataAdapter.getDatasets).toHaveBeenCalledWith('test-source');
     expect(datasets).toHaveLength(2);
@@ -220,7 +220,7 @@ describe('QueryBuilder', () => {
     client = new QueryClient({ queryAdapter });
   });
 
-  it('builds a basic query', () => {
+  it('[query-and-probe.QUERY_CLIENT.1] builds a basic query', () => {
     const query = client.buildQuery('orders').select('status').select('total', 'sum').toQuery();
 
     expect(query.datasetId).toBe('orders');

--- a/packages/query-client/test/query-client.test.ts
+++ b/packages/query-client/test/query-client.test.ts
@@ -141,18 +141,58 @@ describe('QueryClient', () => {
     expect(response.complete).toBe(true);
   });
 
-  it('throws when filter option resolution is not supported', async () => {
+  it('falls back to a synthesized DISTINCT query when the adapter has no resolveFilterOptions', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      columns: [{ fieldId: 'status', label: 'Status', dataType: 'string' }],
+      rows: [{ status: 'delivered' }, { status: 'shipped' }, { status: null }],
+      totalRows: 3,
+    } satisfies QueryResult);
     const clientNoResolver = new QueryClient({
-      queryAdapter: { name: 'no-resolver', execute: vi.fn().mockResolvedValue(mockResult) },
+      queryAdapter: { name: 'no-resolver', execute },
     });
 
-    await expect(
-      clientNoResolver.resolveFilterOptions({
-        filterId: 'status-filter',
-        datasetId: 'orders',
-        fieldId: 'status',
-      }),
-    ).rejects.toThrow('Query adapter does not support filter option resolution');
+    const response = await clientNoResolver.resolveFilterOptions({
+      filterId: 'status-filter',
+      datasetId: 'orders',
+      fieldId: 'status',
+      limit: 25,
+    });
+
+    expect(execute).toHaveBeenCalledWith({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'status' }],
+      limit: 25,
+      distinct: true,
+    });
+    expect(response.options).toEqual([{ value: 'delivered' }, { value: 'shipped' }]);
+    expect(response.complete).toBe(true);
+  });
+
+  it('forwards search as a like filter in the synthesized fallback query', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      columns: [{ fieldId: 'status', label: 'Status', dataType: 'string' }],
+      rows: [{ status: 'shipped' }],
+      totalRows: 1,
+    } satisfies QueryResult);
+    const clientNoResolver = new QueryClient({
+      queryAdapter: { name: 'no-resolver', execute },
+    });
+
+    await clientNoResolver.resolveFilterOptions({
+      filterId: 'status-filter',
+      datasetId: 'orders',
+      fieldId: 'status',
+      search: 'sh',
+      limit: 10,
+    });
+
+    expect(execute).toHaveBeenCalledWith({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'status' }],
+      limit: 10,
+      distinct: true,
+      filters: [{ fieldId: 'status', operator: 'like', value: 'sh' }],
+    });
   });
 
   it('cancel is a no-op when adapter has no cancel', async () => {

--- a/packages/query-sql/package.json
+++ b/packages/query-sql/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@supersubset/query-sql",
+  "version": "0.1.4",
+  "description": "SQL QueryAdapter and translator for Supersubset — turns LogicalQuery into SQL so SQL-backed hosts don't have to.",
+  "license": "Apache-2.0",
+  "author": "Wandir Technologies Inc.",
+  "homepage": "https://github.com/wandir-tech/supersubset/tree/main/packages/query-sql#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wandir-tech/supersubset.git",
+    "directory": "packages/query-sql"
+  },
+  "bugs": {
+    "url": "https://github.com/wandir-tech/supersubset/issues"
+  },
+  "keywords": [
+    "query",
+    "sql",
+    "duckdb",
+    "analytics",
+    "supersubset"
+  ],
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "NOTICE"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "@supersubset/data-model": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/query-sql/src/adapter.ts
+++ b/packages/query-sql/src/adapter.ts
@@ -5,7 +5,7 @@
  *
  * Hosts implement SqlExecutor (one tiny method: `run(sql) → rows`) and get
  * complete LogicalQuery → SQL behavior for free, including DISTINCT support
- * via `LogicalQuery.distinct`. See ADR-011.
+ * via `LogicalQuery.distinct`. See ADR-012.
  */
 import {
   type FieldDataType,

--- a/packages/query-sql/src/adapter.ts
+++ b/packages/query-sql/src/adapter.ts
@@ -1,0 +1,154 @@
+/**
+ * SqlQueryAdapter — a QueryAdapter implementation that turns LogicalQuery into
+ * SQL via the translator, executes it through a host-provided SqlExecutor, and
+ * returns Supersubset-shaped QueryResult.
+ *
+ * Hosts implement SqlExecutor (one tiny method: `run(sql) → rows`) and get
+ * complete LogicalQuery → SQL behavior for free, including DISTINCT support
+ * via `LogicalQuery.distinct`. See ADR-011.
+ */
+import {
+  type FieldDataType,
+  type LogicalQuery,
+  type NormalizedDataset,
+  type QueryAdapter,
+  type QueryResult,
+  type QueryResultColumn,
+} from '@supersubset/data-model';
+import { isRealAggregation, toSql, type PlannedField } from './translator';
+
+export interface SqlExecutor {
+  /**
+   * Execute a SQL string. Return raw rows keyed by SQL column name (the alias
+   * from the SELECT clause). The executor is responsible for any driver-level
+   * normalization (BigInt → Number, Date decoding, Decimal handling, etc.) so
+   * the adapter sees plain JS values.
+   */
+  run(sql: string): Promise<Array<Record<string, unknown>>>;
+}
+
+export interface SqlQueryAdapterOptions {
+  /** Host-provided SQL executor (DuckDB, Postgres client, etc.). */
+  executor: SqlExecutor;
+  /** Adapter name reported via `QueryAdapter.name`. Defaults to "sql". */
+  name?: string;
+  /**
+   * Optional catalog so the adapter can stamp `QueryResultColumn.dataType` and
+   * humanize labels. Without it, dataType falls back to 'unknown'.
+   */
+  catalog?: NormalizedDataset[];
+  /**
+   * Maximum LIMIT the adapter will request from the executor. Caps any
+   * user-supplied limit. Defaults to 10_000 (matches typical OLAP bounds).
+   */
+  maxLimit?: number;
+  /** Default LIMIT when the query doesn't specify one. Defaults to 200. */
+  defaultLimit?: number;
+}
+
+export interface ExecuteResult extends QueryResult {
+  /** SQL actually executed — useful for diagnostics. */
+  sql?: string;
+}
+
+const DEFAULT_MAX_LIMIT = 10_000;
+const DEFAULT_LIMIT = 200;
+
+export class SqlQueryAdapter implements QueryAdapter {
+  readonly name: string;
+  private readonly executor: SqlExecutor;
+  private readonly catalog?: NormalizedDataset[];
+  private readonly maxLimit: number;
+  private readonly defaultLimit: number;
+
+  constructor(options: SqlQueryAdapterOptions) {
+    this.executor = options.executor;
+    this.name = options.name ?? 'sql';
+    this.catalog = options.catalog;
+    this.maxLimit = options.maxLimit ?? DEFAULT_MAX_LIMIT;
+    this.defaultLimit = options.defaultLimit ?? DEFAULT_LIMIT;
+  }
+
+  async execute(query: LogicalQuery): Promise<ExecuteResult> {
+    const effectiveLimit = Math.min(query.limit ?? this.defaultLimit, this.maxLimit);
+    const queryWithLimit: LogicalQuery = { ...query, limit: effectiveLimit };
+
+    const { sql, planned } = toSql(queryWithLimit, { truncationProbe: true });
+    const rawRows = await this.executor.run(sql);
+
+    const truncated = rawRows.length > effectiveLimit;
+    const slicedRows = truncated ? rawRows.slice(0, effectiveLimit) : rawRows;
+    const rows = slicedRows.map((row) => remapRowToOutputKeys(row, planned));
+
+    const columns = planned.map((p) => this.columnMetadata(p, query.datasetId));
+
+    return {
+      columns,
+      rows,
+      totalRows: rows.length,
+      truncated,
+      sql,
+    };
+  }
+
+  // resolveFilterOptions is intentionally not implemented: the data-model
+  // helper `resolveFilterOptionsWithAdapter` falls back to synthesizing a
+  // `distinct: true` LogicalQuery via `execute`, which this adapter honors.
+  // Hosts that need curation/authorization beyond raw distinct values can
+  // wrap or extend SqlQueryAdapter and implement resolveFilterOptions themselves.
+
+  private columnMetadata(planned: PlannedField, datasetId: string): QueryResultColumn {
+    const { field, outputKey } = planned;
+    const datasetMeta = this.catalog?.find((d) => d.id === datasetId);
+    const fieldMeta = datasetMeta?.fields.find((f) => f.id === field.fieldId);
+    const rawDataType: FieldDataType = fieldMeta?.dataType ?? 'unknown';
+    const dataType = isRealAggregation(field.aggregation)
+      ? aggregationDataType(
+          field.aggregation as Exclude<typeof field.aggregation, undefined>,
+          rawDataType,
+        )
+      : rawDataType;
+    const label = fieldMeta?.label ?? humanLabel(outputKey);
+    return { fieldId: outputKey, label, dataType };
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────
+
+function remapRowToOutputKeys(
+  row: Record<string, unknown>,
+  planned: PlannedField[],
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const { sqlAlias, outputKey } of planned) {
+    out[outputKey] = row[sqlAlias] ?? null;
+  }
+  return out;
+}
+
+function aggregationDataType(
+  agg: NonNullable<PlannedField['field']['aggregation']>,
+  base: FieldDataType,
+): FieldDataType {
+  switch (agg) {
+    case 'count':
+    case 'count_distinct':
+      return 'integer';
+    case 'avg':
+      return 'number';
+    case 'sum':
+    case 'min':
+    case 'max':
+      return base === 'integer' ? 'integer' : 'number';
+    default:
+      return base;
+  }
+}
+
+function humanLabel(name: string): string {
+  return name
+    .split('_')
+    .filter(Boolean)
+    .map((p) => p[0].toUpperCase() + p.slice(1))
+    .join(' ');
+}

--- a/packages/query-sql/src/index.ts
+++ b/packages/query-sql/src/index.ts
@@ -5,7 +5,7 @@
  * `SqlQueryAdapter` to get full `LogicalQuery → SQL` behavior, including
  * `LogicalQuery.distinct` support.
  *
- * See ADR-011.
+ * See ADR-012.
  */
 export {
   SqlQueryAdapter,

--- a/packages/query-sql/src/index.ts
+++ b/packages/query-sql/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * @supersubset/query-sql — SQL QueryAdapter and translator.
+ *
+ * Hosts implement `SqlExecutor` (one `run(sql)` method) and use
+ * `SqlQueryAdapter` to get full `LogicalQuery → SQL` behavior, including
+ * `LogicalQuery.distinct` support.
+ *
+ * See ADR-011.
+ */
+export {
+  SqlQueryAdapter,
+  type SqlExecutor,
+  type SqlQueryAdapterOptions,
+  type ExecuteResult,
+} from './adapter';
+
+export {
+  toSql,
+  planFields,
+  escapeLiteral,
+  isRealAggregation,
+  type PlannedField,
+  type TranslateOptions,
+  type TranslateResult,
+} from './translator';

--- a/packages/query-sql/src/translator.ts
+++ b/packages/query-sql/src/translator.ts
@@ -4,7 +4,7 @@
  * other dialects (MySQL backticks, ClickHouse) can wrap or replace this in
  * a future dialect layer.
  *
- * See ADR-011.
+ * See ADR-012.
  */
 import type {
   AggregationType,
@@ -64,24 +64,36 @@ export function planFields(query: LogicalQuery): PlannedField[] {
     return { field, sqlAlias, outputKey };
   });
 
-  // Reject ambiguous column projections. Duplicate `AS "x"` aliases in SQL
-  // give driver-dependent behavior (most keep the last column under that
-  // name) and would silently overwrite row keys during remapping. The user
-  // must disambiguate by setting `alias` on at least one of the colliding
-  // fields.
-  const seen = new Map<string, number>();
+  // Reject ambiguous column projections at two levels:
+  //
+  //   - sqlAlias collisions produce duplicate `AS "x"` clauses; driver
+  //     behavior is then dialect-dependent (most keep the last column under
+  //     that name).
+  //   - outputKey collisions are silent at the SQL level (sqlAlias may
+  //     disambiguate, e.g. `sum_total` vs `avg_total`) but cause the result
+  //     remap to overwrite the same row key — `[{fieldId:'total',aggregation:'sum'}, {fieldId:'total',aggregation:'avg'}]`
+  //     would put both into `row.total`, losing one value. The caller must
+  //     disambiguate by setting a unique `alias` on at least one of the
+  //     colliding fields.
+  assertUniqueAcrossPlanned(planned, 'sqlAlias');
+  assertUniqueAcrossPlanned(planned, 'outputKey');
+
+  return planned;
+}
+
+function assertUniqueAcrossPlanned(planned: PlannedField[], key: 'sqlAlias' | 'outputKey'): void {
+  const counts = new Map<string, number>();
   for (const p of planned) {
-    seen.set(p.sqlAlias, (seen.get(p.sqlAlias) ?? 0) + 1);
+    counts.set(p[key], (counts.get(p[key]) ?? 0) + 1);
   }
-  for (const [alias, count] of seen) {
+  for (const [value, count] of counts) {
     if (count > 1) {
+      const label = key === 'sqlAlias' ? 'column alias' : 'output key';
       throw new Error(
-        `planFields: duplicate column alias "${alias}" — set a unique \`alias\` on the colliding fields.`,
+        `planFields: duplicate ${label} "${value}" — set a unique \`alias\` on the colliding fields.`,
       );
     }
   }
-
-  return planned;
 }
 
 export function toSql(query: LogicalQuery, options: TranslateOptions = {}): TranslateResult {
@@ -131,16 +143,24 @@ export function toSql(query: LogicalQuery, options: TranslateOptions = {}): Tran
 
   // LIMIT (+1 sentinel if truncation probe requested)
   if (query.limit !== undefined) {
+    assertNonNegativeInteger(query.limit, 'limit');
     const limit = options.truncationProbe ? query.limit + 1 : query.limit;
     sql += ` LIMIT ${limit}`;
   }
 
-  // OFFSET
-  if (query.offset !== undefined && query.offset > 0) {
-    sql += ` OFFSET ${query.offset}`;
+  // OFFSET — validate when provided, but only emit when non-zero.
+  if (query.offset !== undefined) {
+    assertNonNegativeInteger(query.offset, 'offset');
+    if (query.offset > 0) sql += ` OFFSET ${query.offset}`;
   }
 
   return { sql, planned };
+}
+
+function assertNonNegativeInteger(value: number, label: 'limit' | 'offset'): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`toSql: ${label} must be a non-negative integer (got ${value}).`);
+  }
 }
 
 // ─── Filters ─────────────────────────────────────────────────

--- a/packages/query-sql/src/translator.ts
+++ b/packages/query-sql/src/translator.ts
@@ -1,0 +1,207 @@
+/**
+ * LogicalQuery → SQL translator. Standard ANSI SQL with double-quoted
+ * identifiers. Compatible with DuckDB, Postgres, and SQLite out of the box;
+ * other dialects (MySQL backticks, ClickHouse) can wrap or replace this in
+ * a future dialect layer.
+ *
+ * See ADR-011.
+ */
+import type {
+  AggregationType,
+  LogicalQuery,
+  QueryField,
+  QueryFilter,
+  QuerySort,
+} from '@supersubset/data-model';
+
+/**
+ * Per-field planning info used by both the translator (for SELECT/GROUP BY/
+ * ORDER BY) and the adapter (for remapping result rows to outputKey).
+ */
+export interface PlannedField {
+  field: QueryField;
+  /** SQL `AS` alias — stable, unique even when the same fieldId appears twice. */
+  sqlAlias: string;
+  /** Key used in the returned `QueryResult.rows` (matches Supersubset convention). */
+  outputKey: string;
+}
+
+export interface TranslateOptions {
+  /**
+   * If set, the emitted SQL adds 1 to the LogicalQuery's `limit` so the caller
+   * can detect truncation by checking `rows.length > limit`. The adapter sets
+   * this to true; standalone `toSql` callers can opt in.
+   */
+  truncationProbe?: boolean;
+}
+
+export interface TranslateResult {
+  sql: string;
+  planned: PlannedField[];
+}
+
+const REAL_AGGREGATIONS: ReadonlySet<AggregationType> = new Set([
+  'sum',
+  'avg',
+  'count',
+  'count_distinct',
+  'min',
+  'max',
+]);
+
+export function isRealAggregation(agg: AggregationType | undefined): boolean {
+  return agg !== undefined && REAL_AGGREGATIONS.has(agg);
+}
+
+export function planFields(query: LogicalQuery): PlannedField[] {
+  return query.fields.map((field) => {
+    const sqlAlias = field.alias
+      ? field.alias
+      : isRealAggregation(field.aggregation)
+        ? `${field.aggregation}_${field.fieldId}`
+        : field.fieldId;
+    const outputKey = field.alias ?? field.fieldId;
+    return { field, sqlAlias, outputKey };
+  });
+}
+
+export function toSql(query: LogicalQuery, options: TranslateOptions = {}): TranslateResult {
+  if (!query.datasetId) {
+    throw new Error('toSql: query.datasetId is required');
+  }
+  if (!Array.isArray(query.fields) || query.fields.length === 0) {
+    throw new Error('toSql: query.fields must contain at least one entry');
+  }
+
+  const planned = planFields(query);
+  const hasAggregation = planned.some((p) => isRealAggregation(p.field.aggregation));
+
+  // SELECT [DISTINCT] ...
+  const selectParts = planned.map(({ field, sqlAlias }) => {
+    const col = quoteIdent(field.fieldId);
+    if (isRealAggregation(field.aggregation)) {
+      if (field.aggregation === 'count_distinct') {
+        return `COUNT(DISTINCT ${col}) AS ${quoteIdent(sqlAlias)}`;
+      }
+      const aggFn = (field.aggregation as string).toUpperCase();
+      return `${aggFn}(${col}) AS ${quoteIdent(sqlAlias)}`;
+    }
+    return `${col} AS ${quoteIdent(sqlAlias)}`;
+  });
+
+  const distinctKeyword = query.distinct && !hasAggregation ? 'DISTINCT ' : '';
+
+  let sql = `SELECT ${distinctKeyword}${selectParts.join(', ')} FROM ${quoteIdent(query.datasetId)}`;
+
+  // WHERE
+  const whereParts = (query.filters ?? []).map((filter) => filterToSql(filter));
+  if (whereParts.length > 0) sql += ` WHERE ${whereParts.join(' AND ')}`;
+
+  // GROUP BY — non-aggregated projection fields are grouped when at least one
+  // aggregation is present. SELECT DISTINCT handles the aggregation-free case.
+  if (hasAggregation) {
+    const groupByFields = planned
+      .filter((p) => !isRealAggregation(p.field.aggregation))
+      .map((p) => quoteIdent(p.field.fieldId));
+    if (groupByFields.length > 0) sql += ` GROUP BY ${groupByFields.join(', ')}`;
+  }
+
+  // ORDER BY — accepts either a raw fieldId or an outputKey/alias.
+  const orderParts = (query.sort ?? []).map((s) => sortToSql(s, planned));
+  if (orderParts.length > 0) sql += ` ORDER BY ${orderParts.join(', ')}`;
+
+  // LIMIT (+1 sentinel if truncation probe requested)
+  if (query.limit !== undefined) {
+    const limit = options.truncationProbe ? query.limit + 1 : query.limit;
+    sql += ` LIMIT ${limit}`;
+  }
+
+  // OFFSET
+  if (query.offset !== undefined && query.offset > 0) {
+    sql += ` OFFSET ${query.offset}`;
+  }
+
+  return { sql, planned };
+}
+
+// ─── Filters ─────────────────────────────────────────────────
+
+function filterToSql(filter: QueryFilter): string {
+  const col = quoteIdent(filter.fieldId);
+  switch (filter.operator) {
+    case 'eq':
+      return `${col} = ${escapeLiteral(filter.value)}`;
+    case 'neq':
+      return `${col} != ${escapeLiteral(filter.value)}`;
+    case 'gt':
+      return `${col} > ${escapeLiteral(filter.value)}`;
+    case 'gte':
+      return `${col} >= ${escapeLiteral(filter.value)}`;
+    case 'lt':
+      return `${col} < ${escapeLiteral(filter.value)}`;
+    case 'lte':
+      return `${col} <= ${escapeLiteral(filter.value)}`;
+    case 'in': {
+      const list = requireArray(filter, 'in').map(escapeLiteral).join(', ');
+      return `${col} IN (${list || 'NULL'})`;
+    }
+    case 'not_in': {
+      const list = requireArray(filter, 'not_in').map(escapeLiteral).join(', ');
+      return `${col} NOT IN (${list || 'NULL'})`;
+    }
+    case 'like':
+      return `${col} LIKE ${escapeLiteral(filter.value)}`;
+    case 'not_like':
+      return `${col} NOT LIKE ${escapeLiteral(filter.value)}`;
+    case 'is_null':
+      return `${col} IS NULL`;
+    case 'is_not_null':
+      return `${col} IS NOT NULL`;
+    case 'between': {
+      const arr = requireArray(filter, 'between');
+      if (arr.length !== 2) {
+        throw new Error(`filterToSql: "between" on "${filter.fieldId}" requires [min, max]`);
+      }
+      return `${col} BETWEEN ${escapeLiteral(arr[0])} AND ${escapeLiteral(arr[1])}`;
+    }
+    default:
+      throw new Error(`filterToSql: unsupported operator "${String(filter.operator)}"`);
+  }
+}
+
+function sortToSql(sort: QuerySort, planned: PlannedField[]): string {
+  if (sort.direction !== 'asc' && sort.direction !== 'desc') {
+    throw new Error(`sortToSql: direction must be "asc" or "desc" (got "${sort.direction}")`);
+  }
+  const direction = sort.direction === 'desc' ? 'DESC' : 'ASC';
+  const byOutput = planned.find((p) => p.outputKey === sort.fieldId);
+  if (byOutput) return `${quoteIdent(byOutput.sqlAlias)} ${direction}`;
+  return `${quoteIdent(sort.fieldId)} ${direction}`;
+}
+
+function requireArray(filter: QueryFilter, op: string): unknown[] {
+  if (!Array.isArray(filter.value)) {
+    throw new Error(`filterToSql: "${op}" on "${filter.fieldId}" requires an array value`);
+  }
+  return filter.value;
+}
+
+// ─── Quoting / escaping ──────────────────────────────────────
+
+function quoteIdent(ident: string): string {
+  // Double-quote identifiers per ANSI SQL. Embedded double quotes are doubled.
+  return `"${ident.replace(/"/g, '""')}"`;
+}
+
+export function escapeLiteral(value: unknown): string {
+  if (value === null || value === undefined) return 'NULL';
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error(`escapeLiteral: invalid numeric value: ${value}`);
+    }
+    return String(value);
+  }
+  if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE';
+  if (value instanceof Date) return `'${value.toISOString()}'`;
+  return `'${String(value).replace(/'/g, "''")}'`;
+}

--- a/packages/query-sql/src/translator.ts
+++ b/packages/query-sql/src/translator.ts
@@ -54,7 +54,7 @@ export function isRealAggregation(agg: AggregationType | undefined): boolean {
 }
 
 export function planFields(query: LogicalQuery): PlannedField[] {
-  return query.fields.map((field) => {
+  const planned = query.fields.map((field) => {
     const sqlAlias = field.alias
       ? field.alias
       : isRealAggregation(field.aggregation)
@@ -63,6 +63,25 @@ export function planFields(query: LogicalQuery): PlannedField[] {
     const outputKey = field.alias ?? field.fieldId;
     return { field, sqlAlias, outputKey };
   });
+
+  // Reject ambiguous column projections. Duplicate `AS "x"` aliases in SQL
+  // give driver-dependent behavior (most keep the last column under that
+  // name) and would silently overwrite row keys during remapping. The user
+  // must disambiguate by setting `alias` on at least one of the colliding
+  // fields.
+  const seen = new Map<string, number>();
+  for (const p of planned) {
+    seen.set(p.sqlAlias, (seen.get(p.sqlAlias) ?? 0) + 1);
+  }
+  for (const [alias, count] of seen) {
+    if (count > 1) {
+      throw new Error(
+        `planFields: duplicate column alias "${alias}" — set a unique \`alias\` on the colliding fields.`,
+      );
+    }
+  }
+
+  return planned;
 }
 
 export function toSql(query: LogicalQuery, options: TranslateOptions = {}): TranslateResult {

--- a/packages/query-sql/test/adapter.test.ts
+++ b/packages/query-sql/test/adapter.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveFilterOptionsWithAdapter, type NormalizedDataset } from '@supersubset/data-model';
+import { SqlQueryAdapter, type SqlExecutor } from '../src/adapter';
+
+function mockExecutor(
+  rows: Array<Record<string, unknown>>,
+): SqlExecutor & { run: ReturnType<typeof vi.fn> } {
+  return { run: vi.fn().mockResolvedValue(rows) };
+}
+
+const catalog: NormalizedDataset[] = [
+  {
+    id: 'plan_events',
+    label: 'Plan Events',
+    fields: [
+      { id: 'plan_type', label: 'Plan Type', dataType: 'string', role: 'dimension' },
+      { id: 'total', label: 'Total', dataType: 'integer', role: 'measure' },
+    ],
+  },
+];
+
+describe('SqlQueryAdapter — execute', () => {
+  it('translates and executes a simple projection', async () => {
+    const executor = mockExecutor([{ plan_type: 'MEETUP' }, { plan_type: 'TRIP' }]);
+    const adapter = new SqlQueryAdapter({ executor, catalog });
+
+    const result = await adapter.execute({
+      datasetId: 'plan_events',
+      fields: [{ fieldId: 'plan_type' }],
+      limit: 10,
+    });
+
+    expect(executor.run).toHaveBeenCalledWith(
+      'SELECT "plan_type" AS "plan_type" FROM "plan_events" LIMIT 11',
+    );
+    expect(result.rows).toEqual([{ plan_type: 'MEETUP' }, { plan_type: 'TRIP' }]);
+    expect(result.columns).toEqual([
+      { fieldId: 'plan_type', label: 'Plan Type', dataType: 'string' },
+    ]);
+    expect(result.truncated).toBe(false);
+    expect(result.totalRows).toBe(2);
+  });
+
+  it('honors distinct: true (DISTINCT in SQL)', async () => {
+    const executor = mockExecutor([{ plan_type: 'MEETUP' }]);
+    const adapter = new SqlQueryAdapter({ executor });
+
+    await adapter.execute({
+      datasetId: 'plan_events',
+      fields: [{ fieldId: 'plan_type' }],
+      distinct: true,
+      limit: 50,
+    });
+
+    expect(executor.run).toHaveBeenCalledWith(
+      'SELECT DISTINCT "plan_type" AS "plan_type" FROM "plan_events" LIMIT 51',
+    );
+  });
+
+  it('detects truncation via the +1 sentinel and slices rows', async () => {
+    const executor = mockExecutor([{ x: 1 }, { x: 2 }, { x: 3 }]); // 3 rows for limit 2 → truncated
+    const adapter = new SqlQueryAdapter({ executor });
+
+    const result = await adapter.execute({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'x' }],
+      limit: 2,
+    });
+
+    expect(result.rows).toHaveLength(2);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('caps limit at maxLimit', async () => {
+    const executor = mockExecutor([]);
+    const adapter = new SqlQueryAdapter({ executor, maxLimit: 100 });
+
+    await adapter.execute({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'x' }],
+      limit: 5000,
+    });
+
+    expect(executor.run).toHaveBeenCalledWith('SELECT "x" AS "x" FROM "orders" LIMIT 101');
+  });
+
+  it('uses defaultLimit when query has no limit', async () => {
+    const executor = mockExecutor([]);
+    const adapter = new SqlQueryAdapter({ executor, defaultLimit: 25 });
+
+    await adapter.execute({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'x' }],
+    });
+
+    expect(executor.run).toHaveBeenCalledWith('SELECT "x" AS "x" FROM "orders" LIMIT 26');
+  });
+
+  it('remaps sqlAlias back to outputKey for aggregations', async () => {
+    const executor = mockExecutor([{ sum_total: 1000 }]);
+    const adapter = new SqlQueryAdapter({ executor, catalog });
+
+    const result = await adapter.execute({
+      datasetId: 'plan_events',
+      fields: [{ fieldId: 'total', aggregation: 'sum' }],
+    });
+
+    expect(result.rows).toEqual([{ total: 1000 }]);
+    expect(result.columns).toEqual([{ fieldId: 'total', label: 'Total', dataType: 'integer' }]);
+  });
+
+  it('exposes the executed SQL on the result for diagnostics', async () => {
+    const executor = mockExecutor([]);
+    const adapter = new SqlQueryAdapter({ executor });
+
+    const result = await adapter.execute({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'x' }],
+    });
+
+    expect(result.sql).toMatch(/^SELECT "x" AS "x" FROM "orders"/);
+  });
+
+  it('falls back to unknown dataType when no catalog is provided', async () => {
+    const executor = mockExecutor([{ status: 'open' }]);
+    const adapter = new SqlQueryAdapter({ executor });
+
+    const result = await adapter.execute({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'status' }],
+    });
+
+    expect(result.columns[0]).toEqual({
+      fieldId: 'status',
+      label: 'Status',
+      dataType: 'unknown',
+    });
+  });
+});
+
+describe('SqlQueryAdapter — resolveFilterOptions via data-model helper', () => {
+  it('synthesizes a distinct-values query and returns options', async () => {
+    const executor = mockExecutor([
+      { plan_type: 'MEETUP' },
+      { plan_type: 'TRIP' },
+      { plan_type: 'AD' },
+    ]);
+    const adapter = new SqlQueryAdapter({ executor });
+
+    const response = await resolveFilterOptionsWithAdapter(adapter, {
+      filterId: 'f-plan-type',
+      datasetId: 'plan_events',
+      fieldId: 'plan_type',
+      limit: 50,
+    });
+
+    expect(executor.run).toHaveBeenCalledWith(
+      'SELECT DISTINCT "plan_type" AS "plan_type" FROM "plan_events" LIMIT 51',
+    );
+    expect(response.options).toEqual([{ value: 'MEETUP' }, { value: 'TRIP' }, { value: 'AD' }]);
+    expect(response.complete).toBe(true);
+  });
+
+  it('translates search into a LIKE filter', async () => {
+    const executor = mockExecutor([{ plan_type: 'MEETUP' }]);
+    const adapter = new SqlQueryAdapter({ executor });
+
+    await resolveFilterOptionsWithAdapter(adapter, {
+      filterId: 'f',
+      datasetId: 'plan_events',
+      fieldId: 'plan_type',
+      search: 'MEET',
+      limit: 10,
+    });
+
+    expect(executor.run).toHaveBeenCalledWith(
+      `SELECT DISTINCT "plan_type" AS "plan_type" FROM "plan_events" WHERE "plan_type" LIKE 'MEET' LIMIT 11`,
+    );
+  });
+
+  it('deduplicates and skips null values defensively', async () => {
+    // Even if the executor returns duplicates (e.g., an older adapter that
+    // ignored the distinct flag) or nulls, the helper de-dupes client-side.
+    const executor = mockExecutor([
+      { plan_type: 'MEETUP' },
+      { plan_type: 'MEETUP' },
+      { plan_type: null },
+      { plan_type: 'TRIP' },
+    ]);
+    const adapter = new SqlQueryAdapter({ executor });
+
+    const response = await resolveFilterOptionsWithAdapter(adapter, {
+      filterId: 'f',
+      datasetId: 'plan_events',
+      fieldId: 'plan_type',
+    });
+
+    expect(response.options).toEqual([{ value: 'MEETUP' }, { value: 'TRIP' }]);
+  });
+});

--- a/packages/query-sql/test/adapter.test.ts
+++ b/packages/query-sql/test/adapter.test.ts
@@ -174,7 +174,7 @@ describe('SqlQueryAdapter — resolveFilterOptions via data-model helper', () =>
     });
 
     expect(executor.run).toHaveBeenCalledWith(
-      `SELECT DISTINCT "plan_type" AS "plan_type" FROM "plan_events" WHERE "plan_type" LIKE 'MEET' LIMIT 11`,
+      `SELECT DISTINCT "plan_type" AS "plan_type" FROM "plan_events" WHERE "plan_type" LIKE '%MEET%' LIMIT 11`,
     );
   });
 

--- a/packages/query-sql/test/translator.test.ts
+++ b/packages/query-sql/test/translator.test.ts
@@ -231,6 +231,23 @@ describe('toSql — validation', () => {
       }),
     ).toThrow(/min, max/);
   });
+
+  it('throws on duplicate sqlAlias collisions (forces caller to disambiguate)', () => {
+    expect(() =>
+      toSql({
+        datasetId: 'orders',
+        fields: [{ fieldId: 'status' }, { fieldId: 'status' }],
+      }),
+    ).toThrow(/duplicate column alias "status"/);
+  });
+
+  it('allows the same fieldId twice when at least one carries a unique alias', () => {
+    const { sql } = toSql({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'status' }, { fieldId: 'status', alias: 'status_raw' }],
+    });
+    expect(sql).toBe('SELECT "status" AS "status", "status" AS "status_raw" FROM "orders"');
+  });
 });
 
 describe('escapeLiteral', () => {

--- a/packages/query-sql/test/translator.test.ts
+++ b/packages/query-sql/test/translator.test.ts
@@ -248,6 +248,66 @@ describe('toSql — validation', () => {
     });
     expect(sql).toBe('SELECT "status" AS "status", "status" AS "status_raw" FROM "orders"');
   });
+
+  it('throws on outputKey collision even when sqlAlias is unique (different aggregations on same fieldId)', () => {
+    // sqlAlias would be sum_total / avg_total (unique), but outputKey defaults
+    // to fieldId for both, which would silently overwrite during row remap.
+    expect(() =>
+      toSql({
+        datasetId: 'orders',
+        fields: [
+          { fieldId: 'total', aggregation: 'sum' },
+          { fieldId: 'total', aggregation: 'avg' },
+        ],
+      }),
+    ).toThrow(/duplicate output key "total"/);
+  });
+
+  it('throws on outputKey collision between raw + aggregated same fieldId', () => {
+    expect(() =>
+      toSql({
+        datasetId: 'orders',
+        fields: [{ fieldId: 'total' }, { fieldId: 'total', aggregation: 'sum' }],
+      }),
+    ).toThrow(/duplicate output key "total"/);
+  });
+
+  it('allows multiple aggregations on the same fieldId when each has a unique alias', () => {
+    const { sql, planned } = toSql({
+      datasetId: 'orders',
+      fields: [
+        { fieldId: 'total', aggregation: 'sum', alias: 'sum_total' },
+        { fieldId: 'total', aggregation: 'avg', alias: 'avg_total' },
+      ],
+    });
+    expect(sql).toBe(
+      'SELECT SUM("total") AS "sum_total", AVG("total") AS "avg_total" FROM "orders"',
+    );
+    expect(planned.map((p) => p.outputKey)).toEqual(['sum_total', 'avg_total']);
+  });
+
+  it('rejects negative or fractional limit/offset', () => {
+    expect(() => toSql({ datasetId: 'orders', fields: [{ fieldId: 'x' }], limit: -1 })).toThrow(
+      /limit must be a non-negative integer/,
+    );
+    expect(() => toSql({ datasetId: 'orders', fields: [{ fieldId: 'x' }], limit: 2.5 })).toThrow(
+      /limit must be a non-negative integer/,
+    );
+    expect(() => toSql({ datasetId: 'orders', fields: [{ fieldId: 'x' }], offset: -5 })).toThrow(
+      /offset must be a non-negative integer/,
+    );
+    expect(() => toSql({ datasetId: 'orders', fields: [{ fieldId: 'x' }], offset: 1.5 })).toThrow(
+      /offset must be a non-negative integer/,
+    );
+  });
+
+  it('accepts limit/offset of 0 (valid edge cases)', () => {
+    const a = toSql({ datasetId: 'orders', fields: [{ fieldId: 'x' }], limit: 0 });
+    expect(a.sql).toContain('LIMIT 0');
+    // offset 0 is valid but omitted from the SQL (no OFFSET clause emitted).
+    const b = toSql({ datasetId: 'orders', fields: [{ fieldId: 'x' }], offset: 0 });
+    expect(b.sql).not.toContain('OFFSET');
+  });
 });
 
 describe('escapeLiteral', () => {

--- a/packages/query-sql/test/translator.test.ts
+++ b/packages/query-sql/test/translator.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from 'vitest';
+import type { LogicalQuery } from '@supersubset/data-model';
+import { escapeLiteral, planFields, toSql } from '../src/translator';
+
+describe('toSql — projection and aliases', () => {
+  it('emits SELECT with quoted identifiers for a simple projection', () => {
+    const { sql } = toSql({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'status' }, { fieldId: 'total' }],
+    });
+    expect(sql).toBe('SELECT "status" AS "status", "total" AS "total" FROM "orders"');
+  });
+
+  it('honors user-supplied aliases', () => {
+    const { sql } = toSql({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'total', alias: 'order_total' }],
+    });
+    expect(sql).toBe('SELECT "total" AS "order_total" FROM "orders"');
+  });
+
+  it('disambiguates an aggregation alias from the raw column name', () => {
+    const { sql, planned } = toSql({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'total', aggregation: 'sum' }],
+    });
+    expect(sql).toBe('SELECT SUM("total") AS "sum_total" FROM "orders"');
+    expect(planned[0].outputKey).toBe('total');
+    expect(planned[0].sqlAlias).toBe('sum_total');
+  });
+});
+
+describe('toSql — DISTINCT', () => {
+  it('emits SELECT DISTINCT when query.distinct is true and no aggregations are present', () => {
+    const { sql } = toSql({
+      datasetId: 'plan_events',
+      fields: [{ fieldId: 'plan_type' }],
+      distinct: true,
+      limit: 50,
+    });
+    expect(sql).toBe('SELECT DISTINCT "plan_type" AS "plan_type" FROM "plan_events" LIMIT 50');
+  });
+
+  it('does not emit DISTINCT when aggregations are present (GROUP BY already deduplicates)', () => {
+    const { sql } = toSql({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'status' }, { fieldId: 'total', aggregation: 'sum' }],
+      distinct: true,
+    });
+    expect(sql).toContain('GROUP BY "status"');
+    expect(sql).not.toContain('SELECT DISTINCT');
+  });
+
+  it('omits DISTINCT when the flag is false or absent', () => {
+    const a = toSql({ datasetId: 'orders', fields: [{ fieldId: 'status' }] }).sql;
+    const b = toSql({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'status' }],
+      distinct: false,
+    }).sql;
+    expect(a).not.toContain('DISTINCT');
+    expect(b).not.toContain('DISTINCT');
+  });
+});
+
+describe('toSql — aggregations and GROUP BY', () => {
+  it('emits GROUP BY for non-aggregated projection fields when at least one aggregation is present', () => {
+    const { sql } = toSql({
+      datasetId: 'orders',
+      fields: [
+        { fieldId: 'status' },
+        { fieldId: 'region' },
+        { fieldId: 'total', aggregation: 'sum' },
+      ],
+    });
+    expect(sql).toBe(
+      'SELECT "status" AS "status", "region" AS "region", SUM("total") AS "sum_total" FROM "orders" GROUP BY "status", "region"',
+    );
+  });
+
+  it('translates COUNT(DISTINCT col)', () => {
+    const { sql } = toSql({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'customer_id', aggregation: 'count_distinct' }],
+    });
+    expect(sql).toBe(
+      'SELECT COUNT(DISTINCT "customer_id") AS "count_distinct_customer_id" FROM "orders"',
+    );
+  });
+
+  it('omits GROUP BY when there are no non-aggregated projection fields', () => {
+    const { sql } = toSql({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'total', aggregation: 'sum' }],
+    });
+    expect(sql).toBe('SELECT SUM("total") AS "sum_total" FROM "orders"');
+  });
+});
+
+describe('toSql — WHERE', () => {
+  it('translates each filter operator', () => {
+    const cases: Array<[LogicalQuery['filters'], string]> = [
+      [[{ fieldId: 'status', operator: 'eq', value: 'open' }], `"status" = 'open'`],
+      [[{ fieldId: 'status', operator: 'neq', value: 'open' }], `"status" != 'open'`],
+      [[{ fieldId: 'total', operator: 'gt', value: 100 }], `"total" > 100`],
+      [[{ fieldId: 'total', operator: 'gte', value: 100 }], `"total" >= 100`],
+      [[{ fieldId: 'total', operator: 'lt', value: 100 }], `"total" < 100`],
+      [[{ fieldId: 'total', operator: 'lte', value: 100 }], `"total" <= 100`],
+      [
+        [{ fieldId: 'status', operator: 'in', value: ['open', 'closed'] }],
+        `"status" IN ('open', 'closed')`,
+      ],
+      [
+        [{ fieldId: 'status', operator: 'not_in', value: ['archived'] }],
+        `"status" NOT IN ('archived')`,
+      ],
+      [[{ fieldId: 'name', operator: 'like', value: '%a%' }], `"name" LIKE '%a%'`],
+      [[{ fieldId: 'name', operator: 'not_like', value: '%a%' }], `"name" NOT LIKE '%a%'`],
+      [[{ fieldId: 'note', operator: 'is_null', value: undefined }], `"note" IS NULL`],
+      [[{ fieldId: 'note', operator: 'is_not_null', value: undefined }], `"note" IS NOT NULL`],
+      [[{ fieldId: 'total', operator: 'between', value: [10, 20] }], `"total" BETWEEN 10 AND 20`],
+    ];
+    for (const [filters, expected] of cases) {
+      const { sql } = toSql({
+        datasetId: 'orders',
+        fields: [{ fieldId: 'status' }],
+        filters,
+      });
+      expect(sql).toContain(`WHERE ${expected}`);
+    }
+  });
+
+  it('joins multiple filters with AND', () => {
+    const { sql } = toSql({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'status' }],
+      filters: [
+        { fieldId: 'status', operator: 'eq', value: 'open' },
+        { fieldId: 'total', operator: 'gt', value: 100 },
+      ],
+    });
+    expect(sql).toContain(`WHERE "status" = 'open' AND "total" > 100`);
+  });
+
+  it('renders empty IN as NULL to keep SQL valid', () => {
+    const { sql } = toSql({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'status' }],
+      filters: [{ fieldId: 'status', operator: 'in', value: [] }],
+    });
+    expect(sql).toContain('IN (NULL)');
+  });
+});
+
+describe('toSql — ORDER BY, LIMIT, OFFSET', () => {
+  it('translates sort by raw column', () => {
+    const { sql } = toSql({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'status' }],
+      sort: [{ fieldId: 'status', direction: 'asc' }],
+    });
+    expect(sql).toContain('ORDER BY "status" ASC');
+  });
+
+  it('translates sort by output key (alias) using the SQL alias', () => {
+    const { sql } = toSql({
+      datasetId: 'orders',
+      fields: [{ fieldId: 'total', aggregation: 'sum' }],
+      sort: [{ fieldId: 'total', direction: 'desc' }],
+    });
+    // outputKey 'total' matches → uses sqlAlias 'sum_total'
+    expect(sql).toContain('ORDER BY "sum_total" DESC');
+  });
+
+  it('emits LIMIT when set, and adds 1 with truncationProbe', () => {
+    const a = toSql({ datasetId: 'orders', fields: [{ fieldId: 'status' }], limit: 100 });
+    expect(a.sql).toContain('LIMIT 100');
+
+    const b = toSql(
+      { datasetId: 'orders', fields: [{ fieldId: 'status' }], limit: 100 },
+      { truncationProbe: true },
+    );
+    expect(b.sql).toContain('LIMIT 101');
+  });
+
+  it('emits OFFSET only when > 0', () => {
+    const a = toSql({ datasetId: 'orders', fields: [{ fieldId: 'status' }], offset: 0 });
+    expect(a.sql).not.toContain('OFFSET');
+    const b = toSql({ datasetId: 'orders', fields: [{ fieldId: 'status' }], offset: 50 });
+    expect(b.sql).toContain('OFFSET 50');
+  });
+});
+
+describe('toSql — validation', () => {
+  it('throws when datasetId is missing', () => {
+    expect(() => toSql({ datasetId: '', fields: [{ fieldId: 'x' }] })).toThrow(/datasetId/);
+  });
+
+  it('throws when fields is empty', () => {
+    expect(() => toSql({ datasetId: 'orders', fields: [] })).toThrow(/fields/);
+  });
+
+  it('throws on unsupported filter operator', () => {
+    expect(() =>
+      toSql({
+        datasetId: 'orders',
+        fields: [{ fieldId: 'status' }],
+        // @ts-expect-error testing runtime guard for bad operator
+        filters: [{ fieldId: 'status', operator: 'starts_with', value: 'x' }],
+      }),
+    ).toThrow(/unsupported operator/);
+  });
+
+  it('throws on bad sort direction', () => {
+    expect(() =>
+      toSql({
+        datasetId: 'orders',
+        fields: [{ fieldId: 'status' }],
+        // @ts-expect-error testing runtime guard for bad direction
+        sort: [{ fieldId: 'status', direction: 'sideways' }],
+      }),
+    ).toThrow(/asc.*desc/);
+  });
+
+  it('throws on between without [min, max]', () => {
+    expect(() =>
+      toSql({
+        datasetId: 'orders',
+        fields: [{ fieldId: 'status' }],
+        filters: [{ fieldId: 'total', operator: 'between', value: [10] }],
+      }),
+    ).toThrow(/min, max/);
+  });
+});
+
+describe('escapeLiteral', () => {
+  it('handles null/undefined → NULL', () => {
+    expect(escapeLiteral(null)).toBe('NULL');
+    expect(escapeLiteral(undefined)).toBe('NULL');
+  });
+  it('handles numbers, booleans, dates, strings', () => {
+    expect(escapeLiteral(42)).toBe('42');
+    expect(escapeLiteral(true)).toBe('TRUE');
+    expect(escapeLiteral(false)).toBe('FALSE');
+    expect(escapeLiteral(new Date('2026-05-27T00:00:00Z'))).toBe(`'2026-05-27T00:00:00.000Z'`);
+    expect(escapeLiteral("it's")).toBe(`'it''s'`);
+  });
+  it('rejects non-finite numbers', () => {
+    expect(() => escapeLiteral(NaN)).toThrow(/invalid numeric/);
+    expect(() => escapeLiteral(Infinity)).toThrow(/invalid numeric/);
+  });
+});
+
+describe('planFields', () => {
+  it('outputKey is alias when provided, else fieldId; sqlAlias makes aggregations unique', () => {
+    const planned = planFields({
+      datasetId: 'orders',
+      fields: [
+        { fieldId: 'status' },
+        { fieldId: 'total', aggregation: 'sum' },
+        { fieldId: 'total', alias: 'raw_total' },
+      ],
+    });
+    expect(planned.map((p) => p.outputKey)).toEqual(['status', 'total', 'raw_total']);
+    expect(planned.map((p) => p.sqlAlias)).toEqual(['status', 'sum_total', 'raw_total']);
+  });
+});

--- a/packages/query-sql/tsconfig.json
+++ b/packages/query-sql/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "test", "node_modules"]
+}

--- a/packages/runtime/src/components/FilterBar.tsx
+++ b/packages/runtime/src/components/FilterBar.tsx
@@ -2,7 +2,8 @@
  * FilterBar — renders dashboard-level filter controls from FilterDefinition[].
  * Uses plain HTML elements with inline styles for a clean, horizontal layout.
  */
-import { createElement, useId, type ReactNode } from 'react';
+import { createElement, useEffect, useId, useState, type ReactNode } from 'react';
+import { resolveFilterOptionsWithAdapter, type QueryAdapter } from '@supersubset/data-model';
 import type {
   FilterDefinition,
   DatasetDefinition,
@@ -79,6 +80,11 @@ export interface FilterBarProps {
   datasets?: DatasetDefinition[];
   /** Legacy static option values per filter ID — compatibility fallback provided by the host */
   filterOptions?: Record<string, string[]>;
+  /**
+   * Host-provided query adapter used to resolve field-backed filter options.
+   * If absent, field-backed filters render an unavailable state.
+   */
+  queryAdapter?: QueryAdapter;
   className?: string;
   layout?: FilterBarLayout;
 }
@@ -89,10 +95,11 @@ interface ResolvedFilterOption {
   disabled?: boolean;
 }
 
-interface ResolvedFilterOptionsState {
-  options: ResolvedFilterOption[];
-  unavailableMessage?: string;
-}
+type ResolvedFilterOptionsState =
+  | { kind: 'ready'; options: ResolvedFilterOption[] }
+  | { kind: 'loading' }
+  | { kind: 'unavailable'; message: string }
+  | { kind: 'error'; message: string };
 
 function getBarStyle(layout: FilterBarLayout): React.CSSProperties {
   if (layout === 'vertical') {
@@ -131,6 +138,7 @@ export function FilterBar({
   filters,
   datasets,
   filterOptions,
+  queryAdapter,
   className,
   layout = 'horizontal',
 }: FilterBarProps) {
@@ -153,7 +161,7 @@ export function FilterBar({
         key: f.id,
         filter: f,
         value: state.values[f.id],
-        datasets,
+        queryAdapter,
         inputIdPrefix,
         legacyOptions: filterOptions?.[f.id],
         onChangeValue: (value: unknown) => setFilter(f.id, value),
@@ -179,7 +187,7 @@ export function FilterBar({
 interface FilterControlProps {
   filter: FilterDefinition;
   value: unknown;
-  datasets?: DatasetDefinition[];
+  queryAdapter?: QueryAdapter;
   inputIdPrefix: string;
   legacyOptions?: string[];
   onChangeValue: (value: unknown) => void;
@@ -188,13 +196,13 @@ interface FilterControlProps {
 function FilterControl({
   filter,
   value,
-  datasets,
+  queryAdapter,
   inputIdPrefix,
   legacyOptions,
   onChangeValue,
 }: FilterControlProps) {
   const label = filter.title ?? filter.fieldRef;
-  const resolvedOptionsState = resolveFilterOptions(filter, legacyOptions, datasets);
+  const resolvedOptionsState = useResolveFilterOptions(filter, queryAdapter, legacyOptions);
   const inputIdBase = `${inputIdPrefix}-ss-filter-${filter.id}`;
 
   return createElement(
@@ -247,16 +255,12 @@ function renderSelect(
   optionsState: ResolvedFilterOptionsState,
   metadata: { inputIdBase: string; inputName: string },
 ): ReactNode {
-  const isUnavailable = optionsState.unavailableMessage !== undefined;
-  const options = isUnavailable
-    ? [
-        {
-          value: '',
-          label: optionsState.unavailableMessage ?? 'Options unavailable',
-          disabled: true,
-        },
-      ]
-    : optionsState.options;
+  const placeholder = placeholderForState(optionsState);
+  const isInteractive = optionsState.kind === 'ready';
+  const options =
+    placeholder !== undefined
+      ? [{ value: '', label: placeholder, disabled: true }]
+      : (optionsState as { kind: 'ready'; options: ResolvedFilterOption[] }).options;
 
   return createElement(
     'select',
@@ -265,14 +269,15 @@ function renderSelect(
       id: `${metadata.inputIdBase}-primary`,
       name: metadata.inputName,
       style: INPUT_STYLE,
-      value: isUnavailable ? '' : ((value as string) ?? ''),
-      disabled: isUnavailable,
+      value: isInteractive ? ((value as string) ?? '') : '',
+      disabled: !isInteractive,
+      'data-ss-filter-options-state': optionsState.kind,
       onChange: (e: React.ChangeEvent<HTMLSelectElement>) => {
         const v = e.target.value;
         onChange(v === '' ? undefined : v);
       },
     },
-    isUnavailable ? null : createElement('option', { value: '' }, 'All'),
+    isInteractive ? createElement('option', { value: '' }, 'All') : null,
     ...options.map((opt) =>
       createElement(
         'option',
@@ -289,16 +294,12 @@ function renderMultiSelect(
   optionsState: ResolvedFilterOptionsState,
   metadata: { inputIdBase: string; inputName: string },
 ): ReactNode {
-  const isUnavailable = optionsState.unavailableMessage !== undefined;
-  const options = isUnavailable
-    ? [
-        {
-          value: '',
-          label: optionsState.unavailableMessage ?? 'Options unavailable',
-          disabled: true,
-        },
-      ]
-    : optionsState.options;
+  const placeholder = placeholderForState(optionsState);
+  const isInteractive = optionsState.kind === 'ready';
+  const options =
+    placeholder !== undefined
+      ? [{ value: '', label: placeholder, disabled: true }]
+      : (optionsState as { kind: 'ready'; options: ResolvedFilterOption[] }).options;
   const selectedValues = Array.isArray(value)
     ? value.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0)
     : typeof value === 'string' && value.length > 0
@@ -312,10 +313,11 @@ function renderMultiSelect(
       id: `${metadata.inputIdBase}-primary`,
       name: metadata.inputName,
       multiple: true,
-      size: isUnavailable ? 1 : Math.min(Math.max(options.length, 3), 6),
+      size: isInteractive ? Math.min(Math.max(options.length, 3), 6) : 1,
       style: { ...INPUT_STYLE, minWidth: '160px', minHeight: '96px' },
-      value: isUnavailable ? [''] : selectedValues,
-      disabled: isUnavailable,
+      value: isInteractive ? selectedValues : [''],
+      disabled: !isInteractive,
+      'data-ss-filter-options-state': optionsState.kind,
       onChange: (e: React.ChangeEvent<HTMLSelectElement>) => {
         const nextValues = Array.from(e.target.selectedOptions)
           .map((option) => option.value)
@@ -571,40 +573,17 @@ function renderDate(
 
 // ─── Field Options ───────────────────────────────────────────
 
-/**
- * Extract distinct options for a select filter from dataset field metadata.
- * In a real scenario, options come from query results. For now we return
- * an empty array when datasets provide no enum values.
- */
-function resolveFilterOptions(
-  filter: FilterDefinition,
-  legacyOptions?: string[],
-  datasets?: DatasetDefinition[],
-): ResolvedFilterOptionsState {
-  if (filter.optionSource?.kind === 'static') {
-    return filter.optionSource.options.length > 0
-      ? { options: filter.optionSource.options.map(normalizeStaticOption) }
-      : { options: [], unavailableMessage: 'No options configured' };
+function placeholderForState(state: ResolvedFilterOptionsState): string | undefined {
+  switch (state.kind) {
+    case 'loading':
+      return 'Loading options…';
+    case 'unavailable':
+      return state.message;
+    case 'error':
+      return state.message;
+    case 'ready':
+      return undefined;
   }
-
-  if (filter.optionSource?.kind === 'field') {
-    const fieldOptions = getFieldOptions(filter, datasets);
-    if (fieldOptions.length > 0) {
-      return { options: fieldOptions };
-    }
-
-    // TODO(issue #121): Replace this unavailable bridge with host-owned runtime resolution.
-    return {
-      options: [],
-      unavailableMessage: 'Field-backed options require host support',
-    };
-  }
-
-  if (legacyOptions && legacyOptions.length > 0) {
-    return { options: legacyOptions.map((option) => ({ value: option, label: option })) };
-  }
-
-  return { options: [], unavailableMessage: 'Options unavailable' };
 }
 
 function normalizeStaticOption(option: FilterOptionDefinition): ResolvedFilterOption {
@@ -615,15 +594,90 @@ function normalizeStaticOption(option: FilterOptionDefinition): ResolvedFilterOp
   };
 }
 
-function getFieldOptions(
+function staticState(filter: FilterDefinition): ResolvedFilterOptionsState | null {
+  if (filter.optionSource?.kind !== 'static') return null;
+  if (filter.optionSource.options.length === 0) {
+    return { kind: 'unavailable', message: 'No options configured' };
+  }
+  return { kind: 'ready', options: filter.optionSource.options.map(normalizeStaticOption) };
+}
+
+function legacyState(legacyOptions?: string[]): ResolvedFilterOptionsState | null {
+  if (!legacyOptions || legacyOptions.length === 0) return null;
+  return {
+    kind: 'ready',
+    options: legacyOptions.map((option) => ({ value: option, label: option })),
+  };
+}
+
+/**
+ * Resolve filter options for a single filter, handling static, field-backed,
+ * legacy, and unavailable cases. Field-backed resolution is async via the
+ * host-provided QueryAdapter. See ADR-009 §2.
+ */
+function useResolveFilterOptions(
   filter: FilterDefinition,
-  datasets?: DatasetDefinition[],
-): ResolvedFilterOption[] {
-  if (!datasets) return [];
-  const ds = datasets.find((d) => d.id === filter.datasetRef);
-  if (!ds) return [];
-  // Field-backed option resolution is still host-owned and not yet wired through
-  // the runtime. Static authored options and the legacy filterOptions prop are
-  // the currently supported sources.
-  return [];
+  queryAdapter: QueryAdapter | undefined,
+  legacyOptions: string[] | undefined,
+): ResolvedFilterOptionsState {
+  const sync = staticState(filter);
+  const isFieldBacked = filter.optionSource?.kind === 'field';
+  const fieldLimit =
+    filter.optionSource?.kind === 'field' ? filter.optionSource.maxOptions : undefined;
+
+  const [fieldState, setFieldState] = useState<ResolvedFilterOptionsState>(() =>
+    isFieldBacked ? { kind: 'loading' } : { kind: 'ready', options: [] },
+  );
+
+  useEffect(() => {
+    if (!isFieldBacked) return;
+    if (!queryAdapter) {
+      setFieldState({
+        kind: 'unavailable',
+        message: 'No query adapter available for field-backed options',
+      });
+      return;
+    }
+
+    let cancelled = false;
+    setFieldState({ kind: 'loading' });
+    void resolveFilterOptionsWithAdapter(queryAdapter, {
+      filterId: filter.id,
+      datasetId: filter.datasetRef,
+      fieldId: filter.fieldRef,
+      limit: fieldLimit,
+    })
+      .then((response) => {
+        if (cancelled) return;
+        if (response.options.length === 0) {
+          setFieldState({ kind: 'unavailable', message: 'No values available' });
+          return;
+        }
+        setFieldState({
+          kind: 'ready',
+          options: response.options.map((option) => ({
+            value: option.value,
+            label: option.label ?? option.value,
+            disabled: option.disabled,
+          })),
+        });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        const message = error instanceof Error ? error.message : 'Failed to load options';
+        setFieldState({ kind: 'error', message });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isFieldBacked, queryAdapter, filter.id, filter.datasetRef, filter.fieldRef, fieldLimit]);
+
+  if (sync) return sync;
+  if (isFieldBacked) return fieldState;
+
+  const legacy = legacyState(legacyOptions);
+  if (legacy) return legacy;
+
+  return { kind: 'unavailable', message: 'Options unavailable' };
 }

--- a/packages/runtime/src/components/FilterBar.tsx
+++ b/packages/runtime/src/components/FilterBar.tsx
@@ -10,6 +10,11 @@ import type {
   FilterOptionDefinition,
 } from '@supersubset/schema';
 import { useFilters } from '../filters/FilterEngine';
+import {
+  DATE_PRESETS,
+  generateWeeklyDateRangeOptions,
+  resolveRelativeDate,
+} from '../filters/date-filter-utils';
 
 // ─── Styles ──────────────────────────────────────────────────
 
@@ -218,7 +223,7 @@ function FilterControl({
       { className: 'ss-filter-label', style: LABEL_STYLE, htmlFor: `${inputIdBase}-primary` },
       label,
     ),
-    renderInput(filter.type, value, onChangeValue, resolvedOptionsState, {
+    renderInput(filter, value, onChangeValue, resolvedOptionsState, {
       inputIdBase,
       inputName: filter.id,
       label,
@@ -227,13 +232,13 @@ function FilterControl({
 }
 
 function renderInput(
-  type: string,
+  filter: FilterDefinition,
   value: unknown,
   onChange: (value: unknown) => void,
   optionsState: ResolvedFilterOptionsState,
   metadata: { inputIdBase: string; inputName: string; label: string },
 ): ReactNode {
-  switch (type) {
+  switch (filter.type) {
     case 'select':
       return renderSelect(value, onChange, optionsState, metadata);
     case 'multi-select':
@@ -243,7 +248,7 @@ function renderInput(
     case 'range':
       return renderRange(value, onChange, metadata);
     case 'date':
-      return renderDate(value, onChange, metadata);
+      return renderDate(filter, value, onChange, metadata);
     default:
       return renderText(value, onChange, metadata);
   }
@@ -395,164 +400,95 @@ function renderRange(
   );
 }
 
-// ─── Relative Date Presets ────────────────────────────────────
-
-export const DATE_PRESETS: { value: string; label: string }[] = [
-  { value: '', label: 'All time' },
-  { value: 'today', label: 'Today' },
-  { value: 'yesterday', label: 'Yesterday' },
-  { value: 'this_week', label: 'This week' },
-  { value: 'last_week', label: 'Last week' },
-  { value: 'this_month', label: 'This month' },
-  { value: 'last_month', label: 'Last month' },
-  { value: 'this_quarter', label: 'This quarter' },
-  { value: 'last_quarter', label: 'Last quarter' },
-  { value: 'this_year', label: 'This year' },
-  { value: 'last_year', label: 'Last year' },
-  { value: 'last_7_days', label: 'Last 7 days' },
-  { value: 'last_30_days', label: 'Last 30 days' },
-  { value: 'last_90_days', label: 'Last 90 days' },
-  { value: 'last_365_days', label: 'Last 365 days' },
-  { value: 'custom', label: 'Custom range…' },
-];
-
-/**
- * Resolve a relative date preset to a concrete { start, end } range (ISO strings).
- * Returns undefined for empty/unknown presets.
- */
-export function resolveRelativeDate(
-  preset: string,
-  now = new Date(),
-): { start: string; end: string } | undefined {
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const iso = (d: Date) => d.toISOString().slice(0, 10);
-
-  switch (preset) {
-    case 'today':
-      return { start: iso(today), end: iso(today) };
-    case 'yesterday': {
-      const d = new Date(today);
-      d.setDate(d.getDate() - 1);
-      return { start: iso(d), end: iso(d) };
-    }
-    case 'this_week': {
-      const d = new Date(today);
-      d.setDate(d.getDate() - d.getDay());
-      return { start: iso(d), end: iso(today) };
-    }
-    case 'last_week': {
-      const end = new Date(today);
-      end.setDate(end.getDate() - end.getDay() - 1);
-      const start = new Date(end);
-      start.setDate(start.getDate() - 6);
-      return { start: iso(start), end: iso(end) };
-    }
-    case 'this_month':
-      return { start: iso(new Date(today.getFullYear(), today.getMonth(), 1)), end: iso(today) };
-    case 'last_month': {
-      const start = new Date(today.getFullYear(), today.getMonth() - 1, 1);
-      const end = new Date(today.getFullYear(), today.getMonth(), 0);
-      return { start: iso(start), end: iso(end) };
-    }
-    case 'this_quarter': {
-      const q = Math.floor(today.getMonth() / 3);
-      return { start: iso(new Date(today.getFullYear(), q * 3, 1)), end: iso(today) };
-    }
-    case 'last_quarter': {
-      const q = Math.floor(today.getMonth() / 3);
-      const start = new Date(today.getFullYear(), (q - 1) * 3, 1);
-      const end = new Date(today.getFullYear(), q * 3, 0);
-      return { start: iso(start), end: iso(end) };
-    }
-    case 'this_year':
-      return { start: iso(new Date(today.getFullYear(), 0, 1)), end: iso(today) };
-    case 'last_year':
-      return {
-        start: iso(new Date(today.getFullYear() - 1, 0, 1)),
-        end: iso(new Date(today.getFullYear() - 1, 11, 31)),
-      };
-    case 'last_7_days': {
-      const d = new Date(today);
-      d.setDate(d.getDate() - 6);
-      return { start: iso(d), end: iso(today) };
-    }
-    case 'last_30_days': {
-      const d = new Date(today);
-      d.setDate(d.getDate() - 29);
-      return { start: iso(d), end: iso(today) };
-    }
-    case 'last_90_days': {
-      const d = new Date(today);
-      d.setDate(d.getDate() - 89);
-      return { start: iso(d), end: iso(today) };
-    }
-    case 'last_365_days': {
-      const d = new Date(today);
-      d.setDate(d.getDate() - 364);
-      return { start: iso(d), end: iso(today) };
-    }
-    default:
-      return undefined;
-  }
-}
-
 function renderDate(
+  filter: FilterDefinition,
   value: unknown,
   onChange: (value: unknown) => void,
   metadata: { inputIdBase: string; inputName: string; label: string },
 ): ReactNode {
   const dateVal = value as { preset?: string; start?: string; end?: string } | string | undefined;
   const isObj = typeof dateVal === 'object' && dateVal !== null;
+  const dateConfig = filter.dateConfig;
+  const isWeekly = dateConfig?.mode === 'weekly';
+  const isRangeMode = dateConfig?.mode === 'range';
+  const allowCustomRange = dateConfig?.allowCustomRange !== false;
   const preset = isObj ? ((dateVal as { preset?: string }).preset ?? '') : '';
-  const isCustom = preset === 'custom';
+  const isCustom =
+    isRangeMode ||
+    (allowCustomRange &&
+      (preset === 'custom' || (!isWeekly && !preset && typeof dateVal === 'string')));
   const customStart = isObj
     ? ((dateVal as { start?: string }).start ?? '')
     : typeof dateVal === 'string'
       ? dateVal
       : '';
   const customEnd = isObj ? ((dateVal as { end?: string }).end ?? '') : '';
+  const weeklyOptions = isWeekly ? generateWeeklyDateRangeOptions(dateConfig) : [];
+  const selectedWeeklyValue =
+    isWeekly && isObj && customStart && customEnd ? `week:${customStart}:${customEnd}` : '';
+  const presetOptions =
+    dateConfig?.presets && dateConfig.presets.length > 0
+      ? DATE_PRESETS.filter(
+          (presetOption) =>
+            presetOption.value === '' ||
+            presetOption.value === 'custom' ||
+            dateConfig.presets?.includes(presetOption.value),
+        )
+      : DATE_PRESETS;
 
   return createElement(
     'div',
     { className: 'ss-filter-date', style: { display: 'flex', alignItems: 'center', gap: '6px' } },
-    // Preset dropdown
-    createElement(
-      'select',
-      {
-        className: 'ss-filter-date-preset',
-        id: `${metadata.inputIdBase}-primary`,
-        name: `${metadata.inputName}-preset`,
-        style: INPUT_STYLE,
-        value: preset,
-        onChange: (e: React.ChangeEvent<HTMLSelectElement>) => {
-          const v = e.target.value;
-          if (v === '') {
-            onChange(undefined);
-          } else if (v === 'custom') {
-            onChange({ preset: 'custom', start: '', end: '' });
-          } else {
-            const resolved = resolveRelativeDate(v);
-            onChange({ preset: v, ...(resolved ?? {}) });
-          }
-        },
-      },
-      ...DATE_PRESETS.map((p) =>
-        createElement('option', { key: p.value, value: p.value }, p.label),
-      ),
-    ),
-    // Custom date pickers (only when "Custom range…" is selected)
+    isRangeMode
+      ? null
+      : createElement(
+          'select',
+          {
+            className: 'ss-filter-date-preset',
+            id: `${metadata.inputIdBase}-primary`,
+            name: `${metadata.inputName}-preset`,
+            style: INPUT_STYLE,
+            value: isWeekly ? selectedWeeklyValue : preset,
+            onChange: (e: React.ChangeEvent<HTMLSelectElement>) => {
+              const v = e.target.value;
+              if (v === '') {
+                onChange(undefined);
+              } else if (isWeekly) {
+                const option = weeklyOptions.find((candidate) => candidate.value === v);
+                if (option) {
+                  onChange({ preset: option.value, start: option.start, end: option.end });
+                }
+              } else if (v === 'custom') {
+                onChange({ preset: 'custom', start: '', end: '' });
+              } else {
+                const resolved = resolveRelativeDate(v, new Date(), dateConfig);
+                onChange({ preset: v, ...(resolved ?? {}) });
+              }
+            },
+          },
+          isWeekly ? createElement('option', { value: '' }, 'All time') : null,
+          ...(isWeekly ? weeklyOptions : presetOptions).map((p) =>
+            createElement('option', { key: p.value, value: p.value }, p.label),
+          ),
+        ),
+    // Custom date pickers (only when custom ranges are enabled and selected)
     isCustom
       ? createElement(
           'div',
           { style: RANGE_STYLE },
           createElement('input', {
+            id: isRangeMode ? `${metadata.inputIdBase}-primary` : undefined,
             name: `${metadata.inputName}-start`,
             'aria-label': `${metadata.label} start date`,
             type: 'date',
             style: { ...INPUT_STYLE, minWidth: '130px' },
             value: customStart,
             onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-              onChange({ preset: 'custom', start: e.target.value, end: customEnd });
+              onChange({
+                ...(isRangeMode ? {} : { preset: 'custom' }),
+                start: e.target.value,
+                end: customEnd,
+              });
             },
           }),
           createElement('span', { style: { color: '#9ca3af' } }, '–'),
@@ -563,7 +499,11 @@ function renderDate(
             style: { ...INPUT_STYLE, minWidth: '130px' },
             value: customEnd,
             onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-              onChange({ preset: 'custom', start: customStart, end: e.target.value });
+              onChange({
+                ...(isRangeMode ? {} : { preset: 'custom' }),
+                start: customStart,
+                end: e.target.value,
+              });
             },
           }),
         )

--- a/packages/runtime/src/components/FilterBar.tsx
+++ b/packages/runtime/src/components/FilterBar.tsx
@@ -614,6 +614,12 @@ function legacyState(legacyOptions?: string[]): ResolvedFilterOptionsState | nul
  * Resolve filter options for a single filter, handling static, field-backed,
  * legacy, and unavailable cases. Field-backed resolution is async via the
  * host-provided QueryAdapter. See ADR-009 §2.
+ *
+ * ADR-009 §3 mandates that `strategy: 'search'` filters must not auto-issue an
+ * unbounded distinct query on initial render. Until the typeahead UI lands
+ * (no debounced text input is wired through `FilterBar` yet), search-strategy
+ * filters render an explicit unavailable state. `preload` keeps the immediate
+ * fetch behavior, which is the safe path for low-cardinality fields.
  */
 function useResolveFilterOptions(
   filter: FilterDefinition,
@@ -621,16 +627,33 @@ function useResolveFilterOptions(
   legacyOptions: string[] | undefined,
 ): ResolvedFilterOptionsState {
   const sync = staticState(filter);
-  const isFieldBacked = filter.optionSource?.kind === 'field';
-  const fieldLimit =
-    filter.optionSource?.kind === 'field' ? filter.optionSource.maxOptions : undefined;
+  const fieldSource = filter.optionSource?.kind === 'field' ? filter.optionSource : undefined;
+  const isFieldBacked = fieldSource !== undefined;
+  const isSearchStrategy = fieldSource?.strategy === 'search';
+  const fieldLimit = fieldSource?.maxOptions;
 
-  const [fieldState, setFieldState] = useState<ResolvedFilterOptionsState>(() =>
-    isFieldBacked ? { kind: 'loading' } : { kind: 'ready', options: [] },
-  );
+  const [fieldState, setFieldState] = useState<ResolvedFilterOptionsState>(() => {
+    if (!isFieldBacked) return { kind: 'ready', options: [] };
+    if (isSearchStrategy) {
+      return {
+        kind: 'unavailable',
+        message:
+          'Search-strategy field options require a typeahead input (not yet implemented). Use strategy: "preload" or a static option list.',
+      };
+    }
+    return { kind: 'loading' };
+  });
 
   useEffect(() => {
     if (!isFieldBacked) return;
+    if (isSearchStrategy) {
+      setFieldState({
+        kind: 'unavailable',
+        message:
+          'Search-strategy field options require a typeahead input (not yet implemented). Use strategy: "preload" or a static option list.',
+      });
+      return;
+    }
     if (!queryAdapter) {
       setFieldState({
         kind: 'unavailable',
@@ -671,7 +694,15 @@ function useResolveFilterOptions(
     return () => {
       cancelled = true;
     };
-  }, [isFieldBacked, queryAdapter, filter.id, filter.datasetRef, filter.fieldRef, fieldLimit]);
+  }, [
+    isFieldBacked,
+    isSearchStrategy,
+    queryAdapter,
+    filter.id,
+    filter.datasetRef,
+    filter.fieldRef,
+    fieldLimit,
+  ]);
 
   if (sync) return sync;
   if (isFieldBacked) return fieldState;

--- a/packages/runtime/src/components/FilterBar.tsx
+++ b/packages/runtime/src/components/FilterBar.tsx
@@ -424,8 +424,18 @@ function renderDate(
       : '';
   const customEnd = isObj ? ((dateVal as { end?: string }).end ?? '') : '';
   const weeklyOptions = isWeekly ? generateWeeklyDateRangeOptions(dateConfig) : [];
+  const weeklyPresetOption =
+    isWeekly && isObj && !customStart && !customEnd
+      ? weeklyOptions.find((option) =>
+          preset === 'this_week'
+            ? option.offset === 0
+            : preset === 'last_week' && option.offset === -1,
+        )
+      : undefined;
   const selectedWeeklyValue =
-    isWeekly && isObj && customStart && customEnd ? `week:${customStart}:${customEnd}` : '';
+    isWeekly && isObj && customStart && customEnd
+      ? `week:${customStart}:${customEnd}`
+      : (weeklyPresetOption?.value ?? '');
   const presetOptions =
     dateConfig?.presets && dateConfig.presets.length > 0
       ? DATE_PRESETS.filter(

--- a/packages/runtime/src/filters/date-filter-utils.ts
+++ b/packages/runtime/src/filters/date-filter-utils.ts
@@ -1,0 +1,298 @@
+import type { QueryFilter, QueryFilterOperator } from '@supersubset/data-model';
+import type { DateFilterConfig, FilterDefinition } from '@supersubset/schema';
+
+export const DATE_PRESETS: { value: string; label: string }[] = [
+  { value: '', label: 'All time' },
+  { value: 'today', label: 'Today' },
+  { value: 'yesterday', label: 'Yesterday' },
+  { value: 'this_week', label: 'This week' },
+  { value: 'last_week', label: 'Last week' },
+  { value: 'this_month', label: 'This month' },
+  { value: 'last_month', label: 'Last month' },
+  { value: 'this_quarter', label: 'This quarter' },
+  { value: 'last_quarter', label: 'Last quarter' },
+  { value: 'this_year', label: 'This year' },
+  { value: 'last_year', label: 'Last year' },
+  { value: 'last_7_days', label: 'Last 7 days' },
+  { value: 'last_30_days', label: 'Last 30 days' },
+  { value: 'last_90_days', label: 'Last 90 days' },
+  { value: 'last_365_days', label: 'Last 365 days' },
+  { value: 'custom', label: 'Custom range…' },
+];
+
+const DIRECT_QUERY_OPERATORS = new Set<QueryFilterOperator>([
+  'eq',
+  'neq',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'in',
+  'not_in',
+  'like',
+  'not_like',
+  'is_null',
+  'is_not_null',
+  'between',
+]);
+
+export interface DateRangeValue {
+  preset?: string;
+  start?: string;
+  end?: string;
+  min?: number;
+  max?: number;
+}
+
+export interface WeeklyDateRangeOption {
+  value: string;
+  label: string;
+  start: string;
+  end: string;
+  offset: number;
+}
+
+function formatIsoDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function clampWeekday(value: unknown): 0 | 1 | 2 | 3 | 4 | 5 | 6 {
+  return value === 0 ||
+    value === 1 ||
+    value === 2 ||
+    value === 3 ||
+    value === 4 ||
+    value === 5 ||
+    value === 6
+    ? value
+    : 0;
+}
+
+function coerceNonNegativeInteger(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : fallback;
+}
+
+function startOfWeek(date: Date, weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6): Date {
+  const dayOffset = (date.getDay() - weekStartsOn + 7) % 7;
+  return addDays(date, -dayOffset);
+}
+
+function formatDateLabel(isoDate: string): string {
+  const [year, month, day] = isoDate.split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function generateWeeklyDateRangeOptions(
+  config: DateFilterConfig | undefined,
+  now = new Date(),
+): WeeklyDateRangeOption[] {
+  const weekStartsOn = clampWeekday(config?.weekStartsOn);
+  const weeksBack = coerceNonNegativeInteger(config?.weeksBack, 4);
+  const weeksForward = coerceNonNegativeInteger(config?.weeksForward, 0);
+  const includeCurrentWeek = config?.includeCurrentWeek !== false;
+  const currentWeekStart = startOfWeek(startOfLocalDay(now), weekStartsOn);
+  const options: WeeklyDateRangeOption[] = [];
+
+  for (let offset = -weeksBack; offset <= weeksForward; offset += 1) {
+    if (!includeCurrentWeek && offset === 0) {
+      continue;
+    }
+
+    const start = addDays(currentWeekStart, offset * 7);
+    const end = addDays(start, 6);
+    const startIso = formatIsoDate(start);
+    const endIso = formatIsoDate(end);
+
+    options.push({
+      value: `week:${startIso}:${endIso}`,
+      label: `${formatDateLabel(startIso)} - ${formatDateLabel(endIso)}`,
+      start: startIso,
+      end: endIso,
+      offset,
+    });
+  }
+
+  return options;
+}
+
+/**
+ * Resolve a relative date preset to a concrete { start, end } range.
+ * Returns undefined for empty/unknown presets.
+ */
+export function resolveRelativeDate(
+  preset: string,
+  now = new Date(),
+  config?: DateFilterConfig,
+): { start: string; end: string } | undefined {
+  const today = startOfLocalDay(now);
+  const weekStartsOn = clampWeekday(config?.weekStartsOn);
+
+  switch (preset) {
+    case 'today':
+      return { start: formatIsoDate(today), end: formatIsoDate(today) };
+    case 'yesterday': {
+      const d = addDays(today, -1);
+      return { start: formatIsoDate(d), end: formatIsoDate(d) };
+    }
+    case 'this_week': {
+      const start = startOfWeek(today, weekStartsOn);
+      return { start: formatIsoDate(start), end: formatIsoDate(today) };
+    }
+    case 'last_week': {
+      const currentStart = startOfWeek(today, weekStartsOn);
+      const start = addDays(currentStart, -7);
+      const end = addDays(currentStart, -1);
+      return { start: formatIsoDate(start), end: formatIsoDate(end) };
+    }
+    case 'this_month':
+      return {
+        start: formatIsoDate(new Date(today.getFullYear(), today.getMonth(), 1)),
+        end: formatIsoDate(today),
+      };
+    case 'last_month': {
+      const start = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+      const end = new Date(today.getFullYear(), today.getMonth(), 0);
+      return { start: formatIsoDate(start), end: formatIsoDate(end) };
+    }
+    case 'this_quarter': {
+      const q = Math.floor(today.getMonth() / 3);
+      return {
+        start: formatIsoDate(new Date(today.getFullYear(), q * 3, 1)),
+        end: formatIsoDate(today),
+      };
+    }
+    case 'last_quarter': {
+      const q = Math.floor(today.getMonth() / 3);
+      const start = new Date(today.getFullYear(), (q - 1) * 3, 1);
+      const end = new Date(today.getFullYear(), q * 3, 0);
+      return { start: formatIsoDate(start), end: formatIsoDate(end) };
+    }
+    case 'this_year':
+      return {
+        start: formatIsoDate(new Date(today.getFullYear(), 0, 1)),
+        end: formatIsoDate(today),
+      };
+    case 'last_year':
+      return {
+        start: formatIsoDate(new Date(today.getFullYear() - 1, 0, 1)),
+        end: formatIsoDate(new Date(today.getFullYear() - 1, 11, 31)),
+      };
+    case 'last_7_days':
+      return { start: formatIsoDate(addDays(today, -6)), end: formatIsoDate(today) };
+    case 'last_30_days':
+      return { start: formatIsoDate(addDays(today, -29)), end: formatIsoDate(today) };
+    case 'last_90_days':
+      return { start: formatIsoDate(addDays(today, -89)), end: formatIsoDate(today) };
+    case 'last_365_days':
+      return { start: formatIsoDate(addDays(today, -364)), end: formatIsoDate(today) };
+    default:
+      return undefined;
+  }
+}
+
+export function compileFilterDefinitionValue(
+  definition: FilterDefinition,
+  value: unknown,
+): QueryFilter | null {
+  if (value == null) {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    const values = value.filter((entry) => entry != null && entry !== '');
+    if (values.length === 0) {
+      return null;
+    }
+
+    return {
+      fieldId: definition.fieldRef,
+      operator: definition.operator === 'not_in' ? 'not_in' : 'in',
+      value: values,
+    };
+  }
+
+  if (isDateRangeLike(value)) {
+    return compileRangeLikeValue(definition.fieldRef, value);
+  }
+
+  if (typeof value === 'string' && value.length === 0) {
+    return null;
+  }
+
+  const operator = normalizeFilterOperator(definition.operator);
+  if (!operator) {
+    return null;
+  }
+
+  return {
+    fieldId: definition.fieldRef,
+    operator,
+    ...(operator === 'is_null' || operator === 'is_not_null' ? {} : { value }),
+  };
+}
+
+export function isDateRangeLike(value: unknown): value is DateRangeValue {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    ('start' in value || 'end' in value || 'min' in value || 'max' in value)
+  );
+}
+
+function compileRangeLikeValue(fieldId: string, value: DateRangeValue): QueryFilter | null {
+  const lower = value.start ?? value.min;
+  const upper = value.end ?? value.max;
+
+  if (lower == null && upper == null) {
+    return null;
+  }
+
+  if (lower != null && upper != null) {
+    return {
+      fieldId,
+      operator: 'between',
+      value: [lower, upper],
+    };
+  }
+
+  return {
+    fieldId,
+    operator: lower != null ? 'gte' : 'lte',
+    value: lower ?? upper,
+  };
+}
+
+function normalizeFilterOperator(operator: string): QueryFilterOperator | null {
+  if (DIRECT_QUERY_OPERATORS.has(operator as QueryFilterOperator)) {
+    return operator as QueryFilterOperator;
+  }
+
+  switch (operator) {
+    case 'equals':
+      return 'eq';
+    case 'not_equals':
+      return 'neq';
+    case 'contains':
+      return 'like';
+    case 'not_contains':
+      return 'not_like';
+    default:
+      return null;
+  }
+}

--- a/packages/runtime/src/filters/date-filter-utils.ts
+++ b/packages/runtime/src/filters/date-filter-utils.ts
@@ -1,24 +1,23 @@
 import type { QueryFilter, QueryFilterOperator } from '@supersubset/data-model';
-import type { DateFilterConfig, FilterDefinition } from '@supersubset/schema';
+import {
+  DATE_PRESETS,
+  generateWeeklyDateRangeOptions,
+  isDateRangeLike,
+  normalizeRangeBound,
+  resolveRelativeDate,
+  type DateRangeValue,
+  type WeeklyDateRangeOption,
+  type FilterDefinition,
+} from '@supersubset/schema';
 
-export const DATE_PRESETS: { value: string; label: string }[] = [
-  { value: '', label: 'All time' },
-  { value: 'today', label: 'Today' },
-  { value: 'yesterday', label: 'Yesterday' },
-  { value: 'this_week', label: 'This week' },
-  { value: 'last_week', label: 'Last week' },
-  { value: 'this_month', label: 'This month' },
-  { value: 'last_month', label: 'Last month' },
-  { value: 'this_quarter', label: 'This quarter' },
-  { value: 'last_quarter', label: 'Last quarter' },
-  { value: 'this_year', label: 'This year' },
-  { value: 'last_year', label: 'Last year' },
-  { value: 'last_7_days', label: 'Last 7 days' },
-  { value: 'last_30_days', label: 'Last 30 days' },
-  { value: 'last_90_days', label: 'Last 90 days' },
-  { value: 'last_365_days', label: 'Last 365 days' },
-  { value: 'custom', label: 'Custom range…' },
-];
+export {
+  DATE_PRESETS,
+  generateWeeklyDateRangeOptions,
+  isDateRangeLike,
+  resolveRelativeDate,
+  type DateRangeValue,
+  type WeeklyDateRangeOption,
+};
 
 const DIRECT_QUERY_OPERATORS = new Set<QueryFilterOperator>([
   'eq',
@@ -35,177 +34,6 @@ const DIRECT_QUERY_OPERATORS = new Set<QueryFilterOperator>([
   'is_not_null',
   'between',
 ]);
-
-export interface DateRangeValue {
-  preset?: string;
-  start?: string;
-  end?: string;
-  min?: number;
-  max?: number;
-}
-
-export interface WeeklyDateRangeOption {
-  value: string;
-  label: string;
-  start: string;
-  end: string;
-  offset: number;
-}
-
-function formatIsoDate(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
-
-function addDays(date: Date, days: number): Date {
-  const next = new Date(date);
-  next.setDate(next.getDate() + days);
-  return next;
-}
-
-function startOfLocalDay(date: Date): Date {
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
-}
-
-function clampWeekday(value: unknown): 0 | 1 | 2 | 3 | 4 | 5 | 6 {
-  return value === 0 ||
-    value === 1 ||
-    value === 2 ||
-    value === 3 ||
-    value === 4 ||
-    value === 5 ||
-    value === 6
-    ? value
-    : 0;
-}
-
-function coerceNonNegativeInteger(value: unknown, fallback: number): number {
-  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : fallback;
-}
-
-function startOfWeek(date: Date, weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6): Date {
-  const dayOffset = (date.getDay() - weekStartsOn + 7) % 7;
-  return addDays(date, -dayOffset);
-}
-
-function formatDateLabel(isoDate: string): string {
-  const [year, month, day] = isoDate.split('-').map(Number);
-  return new Date(year, month - 1, day).toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-  });
-}
-
-export function generateWeeklyDateRangeOptions(
-  config: DateFilterConfig | undefined,
-  now = new Date(),
-): WeeklyDateRangeOption[] {
-  const weekStartsOn = clampWeekday(config?.weekStartsOn);
-  const weeksBack = coerceNonNegativeInteger(config?.weeksBack, 4);
-  const weeksForward = coerceNonNegativeInteger(config?.weeksForward, 0);
-  const includeCurrentWeek = config?.includeCurrentWeek !== false;
-  const currentWeekStart = startOfWeek(startOfLocalDay(now), weekStartsOn);
-  const options: WeeklyDateRangeOption[] = [];
-
-  for (let offset = -weeksBack; offset <= weeksForward; offset += 1) {
-    if (!includeCurrentWeek && offset === 0) {
-      continue;
-    }
-
-    const start = addDays(currentWeekStart, offset * 7);
-    const end = addDays(start, 6);
-    const startIso = formatIsoDate(start);
-    const endIso = formatIsoDate(end);
-
-    options.push({
-      value: `week:${startIso}:${endIso}`,
-      label: `${formatDateLabel(startIso)} - ${formatDateLabel(endIso)}`,
-      start: startIso,
-      end: endIso,
-      offset,
-    });
-  }
-
-  return options;
-}
-
-/**
- * Resolve a relative date preset to a concrete { start, end } range.
- * Returns undefined for empty/unknown presets.
- */
-export function resolveRelativeDate(
-  preset: string,
-  now = new Date(),
-  config?: DateFilterConfig,
-): { start: string; end: string } | undefined {
-  const today = startOfLocalDay(now);
-  const weekStartsOn = clampWeekday(config?.weekStartsOn);
-
-  switch (preset) {
-    case 'today':
-      return { start: formatIsoDate(today), end: formatIsoDate(today) };
-    case 'yesterday': {
-      const d = addDays(today, -1);
-      return { start: formatIsoDate(d), end: formatIsoDate(d) };
-    }
-    case 'this_week': {
-      const start = startOfWeek(today, weekStartsOn);
-      const end = config?.mode === 'weekly' ? addDays(start, 6) : today;
-      return { start: formatIsoDate(start), end: formatIsoDate(end) };
-    }
-    case 'last_week': {
-      const currentStart = startOfWeek(today, weekStartsOn);
-      const start = addDays(currentStart, -7);
-      const end = addDays(currentStart, -1);
-      return { start: formatIsoDate(start), end: formatIsoDate(end) };
-    }
-    case 'this_month':
-      return {
-        start: formatIsoDate(new Date(today.getFullYear(), today.getMonth(), 1)),
-        end: formatIsoDate(today),
-      };
-    case 'last_month': {
-      const start = new Date(today.getFullYear(), today.getMonth() - 1, 1);
-      const end = new Date(today.getFullYear(), today.getMonth(), 0);
-      return { start: formatIsoDate(start), end: formatIsoDate(end) };
-    }
-    case 'this_quarter': {
-      const q = Math.floor(today.getMonth() / 3);
-      return {
-        start: formatIsoDate(new Date(today.getFullYear(), q * 3, 1)),
-        end: formatIsoDate(today),
-      };
-    }
-    case 'last_quarter': {
-      const q = Math.floor(today.getMonth() / 3);
-      const start = new Date(today.getFullYear(), (q - 1) * 3, 1);
-      const end = new Date(today.getFullYear(), q * 3, 0);
-      return { start: formatIsoDate(start), end: formatIsoDate(end) };
-    }
-    case 'this_year':
-      return {
-        start: formatIsoDate(new Date(today.getFullYear(), 0, 1)),
-        end: formatIsoDate(today),
-      };
-    case 'last_year':
-      return {
-        start: formatIsoDate(new Date(today.getFullYear() - 1, 0, 1)),
-        end: formatIsoDate(new Date(today.getFullYear() - 1, 11, 31)),
-      };
-    case 'last_7_days':
-      return { start: formatIsoDate(addDays(today, -6)), end: formatIsoDate(today) };
-    case 'last_30_days':
-      return { start: formatIsoDate(addDays(today, -29)), end: formatIsoDate(today) };
-    case 'last_90_days':
-      return { start: formatIsoDate(addDays(today, -89)), end: formatIsoDate(today) };
-    case 'last_365_days':
-      return { start: formatIsoDate(addDays(today, -364)), end: formatIsoDate(today) };
-    default:
-      return undefined;
-  }
-}
 
 export function compileFilterDefinitionValue(
   definition: FilterDefinition,
@@ -254,14 +82,6 @@ export function compileFilterDefinitionValue(
   };
 }
 
-export function isDateRangeLike(value: unknown): value is DateRangeValue {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    ('start' in value || 'end' in value || 'min' in value || 'max' in value)
-  );
-}
-
 function isDatePresetValue(value: unknown): value is { preset: string } {
   if (typeof value !== 'object' || value === null || !('preset' in value)) {
     return false;
@@ -291,16 +111,6 @@ function compileRangeLikeValue(fieldId: string, value: DateRangeValue): QueryFil
     operator: lower != null ? 'gte' : 'lte',
     value: lower ?? upper,
   };
-}
-
-function normalizeRangeBound(
-  value: DateRangeValue['start'] | DateRangeValue['min'],
-): string | number | undefined {
-  if (value === '') {
-    return undefined;
-  }
-
-  return value;
 }
 
 function normalizeFilterOperator(operator: string): QueryFilterOperator | null {

--- a/packages/runtime/src/filters/date-filter-utils.ts
+++ b/packages/runtime/src/filters/date-filter-utils.ts
@@ -152,7 +152,8 @@ export function resolveRelativeDate(
     }
     case 'this_week': {
       const start = startOfWeek(today, weekStartsOn);
-      return { start: formatIsoDate(start), end: formatIsoDate(today) };
+      const end = config?.mode === 'weekly' ? addDays(start, 6) : today;
+      return { start: formatIsoDate(start), end: formatIsoDate(end) };
     }
     case 'last_week': {
       const currentStart = startOfWeek(today, weekStartsOn);
@@ -231,6 +232,12 @@ export function compileFilterDefinitionValue(
     return compileRangeLikeValue(definition.fieldRef, value);
   }
 
+  if (isDatePresetValue(value)) {
+    const resolved = resolveRelativeDate(value.preset, new Date(), definition.dateConfig);
+
+    return resolved ? compileRangeLikeValue(definition.fieldRef, resolved) : null;
+  }
+
   if (typeof value === 'string' && value.length === 0) {
     return null;
   }
@@ -255,9 +262,17 @@ export function isDateRangeLike(value: unknown): value is DateRangeValue {
   );
 }
 
+function isDatePresetValue(value: unknown): value is { preset: string } {
+  if (typeof value !== 'object' || value === null || !('preset' in value)) {
+    return false;
+  }
+
+  return typeof (value as { preset?: unknown }).preset === 'string';
+}
+
 function compileRangeLikeValue(fieldId: string, value: DateRangeValue): QueryFilter | null {
-  const lower = value.start ?? value.min;
-  const upper = value.end ?? value.max;
+  const lower = normalizeRangeBound(value.start ?? value.min);
+  const upper = normalizeRangeBound(value.end ?? value.max);
 
   if (lower == null && upper == null) {
     return null;
@@ -276,6 +291,16 @@ function compileRangeLikeValue(fieldId: string, value: DateRangeValue): QueryFil
     operator: lower != null ? 'gte' : 'lte',
     value: lower ?? upper,
   };
+}
+
+function normalizeRangeBound(
+  value: DateRangeValue['start'] | DateRangeValue['min'],
+): string | number | undefined {
+  if (value === '') {
+    return undefined;
+  }
+
+  return value;
 }
 
 function normalizeFilterOperator(operator: string): QueryFilterOperator | null {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -7,12 +7,17 @@ export {
 } from './components/SupersubsetRenderer';
 
 // FilterBar component
+export { FilterBar, type FilterBarProps } from './components/FilterBar';
+
 export {
-  FilterBar,
-  type FilterBarProps,
   DATE_PRESETS,
+  compileFilterDefinitionValue,
+  generateWeeklyDateRangeOptions,
+  isDateRangeLike,
   resolveRelativeDate,
-} from './components/FilterBar';
+  type DateRangeValue,
+  type WeeklyDateRangeOption,
+} from './filters/date-filter-utils';
 
 // DrillBreadcrumbBar component
 export { DrillBreadcrumbBar } from './components/DrillBreadcrumbBar';

--- a/packages/runtime/src/layout/LayoutRenderer.tsx
+++ b/packages/runtime/src/layout/LayoutRenderer.tsx
@@ -285,6 +285,7 @@ function renderWidget(node: LayoutComponent, context: RenderContext): ReactNode 
     dashboardFilters: context.filters,
     datasets: context.datasets,
     filterOptions: context.filterOptions,
+    queryAdapter: context.queryAdapter,
     onEvent: context.onWidgetEvent,
   };
 

--- a/packages/runtime/src/layout/render-query-helpers.ts
+++ b/packages/runtime/src/layout/render-query-helpers.ts
@@ -1,13 +1,13 @@
 import type { AggregationType, LogicalQuery, QueryResult } from '@supersubset/data-model';
 import {
   structuredAlertRuleSchema,
+  type FilterDefinition,
   type StructuredAlertRuleDefinition,
   type WidgetDefinition,
-  type FilterDefinition,
 } from '@supersubset/schema';
 import type { WidgetProps } from '../widgets/registry';
 import { filterAppliesToWidget, type FilterValue } from '../filters/FilterEngine';
-import { compileFilterDefinitionValue, isDateRangeLike } from '../filters/date-filter-utils';
+import { compileFilterDefinitionValue } from '../filters/date-filter-utils';
 import { resolveDataBindingConfig } from './widget-config';
 
 export interface QueryDataState {
@@ -324,65 +324,16 @@ function compileCrossFilterValue(
   fieldRef: string,
   value: unknown,
 ): NonNullable<LogicalQuery['filters']>[number] | null {
-  if (value == null) {
-    return null;
-  }
-
-  if (Array.isArray(value)) {
-    const values = value.filter((entry) => entry != null && entry !== '');
-    if (values.length === 0) {
-      return null;
-    }
-
-    return {
-      fieldId: fieldRef,
-      operator: 'in',
-      value: values,
-    };
-  }
-
-  if (isDateRangeLike(value)) {
-    const lower = normalizeCrossFilterRangeBound(value.start ?? value.min);
-    const upper = normalizeCrossFilterRangeBound(value.end ?? value.max);
-
-    if (lower == null && upper == null) {
-      return null;
-    }
-
-    if (lower != null && upper != null) {
-      return {
-        fieldId: fieldRef,
-        operator: 'between',
-        value: [lower, upper],
-      };
-    }
-
-    return {
-      fieldId: fieldRef,
-      operator: lower != null ? 'gte' : 'lte',
-      value: lower ?? upper,
-    };
-  }
-
-  if (typeof value === 'string' && value.length === 0) {
-    return null;
-  }
-
-  return {
-    fieldId: fieldRef,
-    operator: 'eq',
-    value,
+  const syntheticDefinition: FilterDefinition = {
+    id: `cross-filter:${fieldRef}`,
+    type: 'cross-filter',
+    datasetRef: '__cross_filter__',
+    fieldRef,
+    operator: 'equals',
+    scope: { type: 'global' },
   };
-}
 
-function normalizeCrossFilterRangeBound(
-  value: string | number | undefined,
-): string | number | undefined {
-  if (value === '') {
-    return undefined;
-  }
-
-  return value;
+  return compileFilterDefinitionValue(syntheticDefinition, value);
 }
 
 function normalizeAggregation(value: string | undefined): AggregationType | undefined {

--- a/packages/runtime/src/layout/render-query-helpers.ts
+++ b/packages/runtime/src/layout/render-query-helpers.ts
@@ -1,9 +1,4 @@
-import type {
-  AggregationType,
-  LogicalQuery,
-  QueryFilterOperator,
-  QueryResult,
-} from '@supersubset/data-model';
+import type { AggregationType, LogicalQuery, QueryResult } from '@supersubset/data-model';
 import {
   structuredAlertRuleSchema,
   type StructuredAlertRuleDefinition,
@@ -12,28 +7,13 @@ import {
 } from '@supersubset/schema';
 import type { WidgetProps } from '../widgets/registry';
 import { filterAppliesToWidget, type FilterValue } from '../filters/FilterEngine';
+import { compileFilterDefinitionValue, isDateRangeLike } from '../filters/date-filter-utils';
 import { resolveDataBindingConfig } from './widget-config';
 
 export interface QueryDataState {
   data?: Record<string, unknown>[];
   columns?: WidgetProps['columns'];
 }
-
-const DIRECT_QUERY_OPERATORS = new Set<QueryFilterOperator>([
-  'eq',
-  'neq',
-  'gt',
-  'gte',
-  'lt',
-  'lte',
-  'in',
-  'not_in',
-  'like',
-  'not_like',
-  'is_null',
-  'is_not_null',
-  'between',
-]);
 
 const VALID_AGGREGATIONS = new Set<AggregationType>([
   'sum',
@@ -326,7 +306,7 @@ function compileActiveFiltersForQuery(
         return [];
       }
 
-      const compiledFilter = compileFilterValue(definition, activeFilter.value);
+      const compiledFilter = compileFilterDefinitionValue(definition, activeFilter.value);
       return compiledFilter ? [compiledFilter] : [];
     }
 
@@ -338,58 +318,6 @@ function compileActiveFiltersForQuery(
     const compiledFilter = compileCrossFilterValue(crossFilter.fieldRef, activeFilter.value);
     return compiledFilter ? [compiledFilter] : [];
   });
-}
-
-function compileFilterValue(
-  definition: FilterDefinition,
-  value: unknown,
-): NonNullable<LogicalQuery['filters']>[number] | null {
-  if (value == null) {
-    return null;
-  }
-
-  if (Array.isArray(value)) {
-    const values = value.filter((entry) => entry != null && entry !== '');
-    if (values.length === 0) {
-      return null;
-    }
-
-    return {
-      fieldId: definition.fieldRef,
-      operator: definition.operator === 'not_in' ? 'not_in' : 'in',
-      value: values,
-    };
-  }
-
-  if (isBetweenValue(value)) {
-    const lower = value.start ?? value.min;
-    const upper = value.end ?? value.max;
-
-    if (lower == null && upper == null) {
-      return null;
-    }
-
-    return {
-      fieldId: definition.fieldRef,
-      operator: 'between',
-      value: [lower, upper],
-    };
-  }
-
-  if (typeof value === 'string' && value.length === 0) {
-    return null;
-  }
-
-  const operator = normalizeFilterOperator(definition.operator);
-  if (!operator) {
-    return null;
-  }
-
-  return {
-    fieldId: definition.fieldRef,
-    operator,
-    value,
-  };
 }
 
 function compileCrossFilterValue(
@@ -413,7 +341,7 @@ function compileCrossFilterValue(
     };
   }
 
-  if (isBetweenValue(value)) {
+  if (isDateRangeLike(value)) {
     const lower = value.start ?? value.min;
     const upper = value.end ?? value.max;
 
@@ -439,37 +367,12 @@ function compileCrossFilterValue(
   };
 }
 
-function normalizeFilterOperator(operator: string): QueryFilterOperator | null {
-  if (DIRECT_QUERY_OPERATORS.has(operator as QueryFilterOperator)) {
-    return operator as QueryFilterOperator;
-  }
-
-  switch (operator) {
-    case 'equals':
-      return 'eq';
-    case 'contains':
-      return 'like';
-    default:
-      return null;
-  }
-}
-
 function normalizeAggregation(value: string | undefined): AggregationType | undefined {
   if (!value || !VALID_AGGREGATIONS.has(value as AggregationType) || value === 'none') {
     return undefined;
   }
 
   return value as AggregationType;
-}
-
-function isBetweenValue(
-  value: unknown,
-): value is { start?: string; end?: string; min?: number; max?: number } {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    ('start' in value || 'end' in value || 'min' in value || 'max' in value)
-  );
 }
 
 function parseCrossFilterId(filterId: string): { sourceWidgetId: string; fieldRef: string } | null {

--- a/packages/runtime/src/layout/render-query-helpers.ts
+++ b/packages/runtime/src/layout/render-query-helpers.ts
@@ -342,17 +342,25 @@ function compileCrossFilterValue(
   }
 
   if (isDateRangeLike(value)) {
-    const lower = value.start ?? value.min;
-    const upper = value.end ?? value.max;
+    const lower = normalizeCrossFilterRangeBound(value.start ?? value.min);
+    const upper = normalizeCrossFilterRangeBound(value.end ?? value.max);
 
     if (lower == null && upper == null) {
       return null;
     }
 
+    if (lower != null && upper != null) {
+      return {
+        fieldId: fieldRef,
+        operator: 'between',
+        value: [lower, upper],
+      };
+    }
+
     return {
       fieldId: fieldRef,
-      operator: 'between',
-      value: [lower, upper],
+      operator: lower != null ? 'gte' : 'lte',
+      value: lower ?? upper,
     };
   }
 
@@ -365,6 +373,16 @@ function compileCrossFilterValue(
     operator: 'eq',
     value,
   };
+}
+
+function normalizeCrossFilterRangeBound(
+  value: string | number | undefined,
+): string | number | undefined {
+  if (value === '') {
+    return undefined;
+  }
+
+  return value;
 }
 
 function normalizeAggregation(value: string | undefined): AggregationType | undefined {

--- a/packages/runtime/src/widgets/FilterBarWidget.tsx
+++ b/packages/runtime/src/widgets/FilterBarWidget.tsx
@@ -34,6 +34,7 @@ export function FilterBarWidget({
   dashboardFilters,
   datasets,
   filterOptions,
+  queryAdapter,
 }: WidgetProps) {
   const filters = resolveWidgetFilters(dashboardFilters, config);
   if (filters.length === 0) {
@@ -63,6 +64,7 @@ export function FilterBarWidget({
       filters,
       datasets,
       filterOptions,
+      queryAdapter,
       className: 'ss-widget-filter-bar',
       layout,
     }),

--- a/packages/runtime/src/widgets/registry.ts
+++ b/packages/runtime/src/widgets/registry.ts
@@ -3,6 +3,7 @@
  * Chart packages register their components here; the runtime looks them up by type string.
  */
 import type { ComponentType } from 'react';
+import type { QueryAdapter } from '@supersubset/data-model';
 import type { DatasetDefinition, FilterDefinition } from '@supersubset/schema';
 import type { FilterValue } from '../filters/FilterEngine';
 import { FilterBarWidget } from './FilterBarWidget';
@@ -38,6 +39,11 @@ export interface WidgetProps {
   datasets?: DatasetDefinition[];
   /** Legacy static option values for authored filters */
   filterOptions?: Record<string, string[]>;
+  /**
+   * Host-provided query adapter, used by control widgets (e.g. FilterBar) to
+   * resolve field-backed options via `resolveFilterOptionsWithAdapter`.
+   */
+  queryAdapter?: QueryAdapter;
   /** Callback for widget interactions (click, hover, etc.) */
   onEvent?: (event: WidgetEvent) => void;
 }

--- a/packages/runtime/test/filter-bar.test.tsx
+++ b/packages/runtime/test/filter-bar.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import type { QueryAdapter } from '@supersubset/data-model';
 import { FilterBar } from '../src/components/FilterBar';
 import { FilterProvider } from '../src/filters/FilterEngine';
 import type { FilterDefinition } from '@supersubset/schema';
@@ -11,6 +12,7 @@ function renderFilterBar(
     initialValues?: Record<string, unknown>;
     onFilterChange?: (state: { values: Record<string, unknown> }) => void;
     filterOptions?: Record<string, string[]>;
+    queryAdapter?: QueryAdapter;
   },
 ) {
   return render(
@@ -19,7 +21,11 @@ function renderFilterBar(
       initialValues={opts?.initialValues}
       onFilterChange={opts?.onFilterChange}
     >
-      <FilterBar filters={filters} filterOptions={opts?.filterOptions} />
+      <FilterBar
+        filters={filters}
+        filterOptions={opts?.filterOptions}
+        queryAdapter={opts?.queryAdapter}
+      />
     </FilterProvider>,
   );
 }
@@ -174,6 +180,7 @@ describe('FilterBar', () => {
       ],
       {
         filterOptions: { 'f-status': ['open', 'closed'] },
+        // No queryAdapter — field-backed should render unavailable, not use legacy options
       },
     );
 
@@ -183,7 +190,113 @@ describe('FilterBar', () => {
     );
 
     expect(select.disabled).toBe(true);
-    expect(optionLabels).toEqual(['Field-backed options require host support']);
+    expect(select.getAttribute('data-ss-filter-options-state')).toBe('unavailable');
+    expect(optionLabels).toEqual(['No query adapter available for field-backed options']);
+  });
+
+  it('resolves field-backed select options via queryAdapter.resolveFilterOptions when implemented', async () => {
+    const queryAdapter: QueryAdapter = {
+      name: 'mock',
+      execute: vi.fn(),
+      resolveFilterOptions: vi.fn().mockResolvedValue({
+        options: [
+          { value: 'open', label: 'Open' },
+          { value: 'closed', label: 'Closed' },
+        ],
+        complete: true,
+      }),
+    };
+
+    const { container } = renderFilterBar(
+      [
+        {
+          ...selectFilter,
+          optionSource: { kind: 'field', strategy: 'preload', maxOptions: 50 },
+        },
+      ],
+      { queryAdapter },
+    );
+
+    const select = container.querySelector('.ss-filter-select') as HTMLSelectElement;
+
+    await waitFor(() => {
+      expect(select.getAttribute('data-ss-filter-options-state')).toBe('ready');
+    });
+
+    expect(queryAdapter.resolveFilterOptions).toHaveBeenCalledWith({
+      filterId: 'f-status',
+      datasetId: 'ds-1',
+      fieldId: 'status',
+      limit: 50,
+    });
+    const optionLabels = Array.from(select.querySelectorAll('option')).map(
+      (option) => option.textContent,
+    );
+    expect(optionLabels).toEqual(['All', 'Open', 'Closed']);
+  });
+
+  it('resolves field-backed select options via the execute() fallback when the adapter has no resolveFilterOptions', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      columns: [{ fieldId: 'status', label: 'Status', dataType: 'string' }],
+      rows: [{ status: 'open' }, { status: 'closed' }],
+      totalRows: 2,
+    });
+    const queryAdapter: QueryAdapter = { name: 'mock', execute };
+
+    const { container } = renderFilterBar(
+      [
+        {
+          ...selectFilter,
+          optionSource: { kind: 'field', strategy: 'preload' },
+        },
+      ],
+      { queryAdapter },
+    );
+
+    const select = container.querySelector('.ss-filter-select') as HTMLSelectElement;
+
+    await waitFor(() => {
+      expect(select.getAttribute('data-ss-filter-options-state')).toBe('ready');
+    });
+
+    expect(execute).toHaveBeenCalledWith({
+      datasetId: 'ds-1',
+      fields: [{ fieldId: 'status' }],
+      limit: 200,
+      distinct: true,
+    });
+    const optionLabels = Array.from(select.querySelectorAll('option')).map(
+      (option) => option.textContent,
+    );
+    expect(optionLabels).toEqual(['All', 'open', 'closed']);
+  });
+
+  it('shows an error state when the resolver rejects', async () => {
+    const queryAdapter: QueryAdapter = {
+      name: 'mock',
+      execute: vi.fn().mockRejectedValue(new Error('database unreachable')),
+    };
+
+    const { container } = renderFilterBar(
+      [
+        {
+          ...selectFilter,
+          optionSource: { kind: 'field', strategy: 'preload' },
+        },
+      ],
+      { queryAdapter },
+    );
+
+    const select = container.querySelector('.ss-filter-select') as HTMLSelectElement;
+    await waitFor(() => {
+      expect(select.getAttribute('data-ss-filter-options-state')).toBe('error');
+    });
+
+    expect(select.disabled).toBe(true);
+    const optionLabels = Array.from(select.querySelectorAll('option')).map(
+      (option) => option.textContent,
+    );
+    expect(optionLabels).toEqual(['database unreachable']);
   });
 
   it('renders a multi-select control for multi-select filters', () => {
@@ -199,7 +312,7 @@ describe('FilterBar', () => {
     expect(optionLabels).toEqual(['Footwear', 'Apparel', 'Hydration']);
   });
 
-  it('renders an unavailable multi-select state for field-backed options without runtime support', () => {
+  it('renders an unavailable multi-select state for field-backed options when no queryAdapter is provided', () => {
     const { container } = renderFilterBar([
       {
         ...multiSelectFilter,
@@ -218,7 +331,8 @@ describe('FilterBar', () => {
 
     expect(select.disabled).toBe(true);
     expect(select.size).toBe(1);
-    expect(optionLabels).toEqual(['Field-backed options require host support']);
+    expect(select.getAttribute('data-ss-filter-options-state')).toBe('unavailable');
+    expect(optionLabels).toEqual(['No query adapter available for field-backed options']);
   });
 
   it('renders a text input for text-type filter', () => {

--- a/packages/runtime/test/filter-bar.test.tsx
+++ b/packages/runtime/test/filter-bar.test.tsx
@@ -173,8 +173,7 @@ describe('FilterBar', () => {
           ...selectFilter,
           optionSource: {
             kind: 'field',
-            strategy: 'search',
-            minSearchChars: 2,
+            strategy: 'preload',
           },
         },
       ],
@@ -192,6 +191,40 @@ describe('FilterBar', () => {
     expect(select.disabled).toBe(true);
     expect(select.getAttribute('data-ss-filter-options-state')).toBe('unavailable');
     expect(optionLabels).toEqual(['No query adapter available for field-backed options']);
+  });
+
+  it("renders an explicit unavailable state for strategy: 'search' until a typeahead input exists (ADR-009 §3)", async () => {
+    const queryAdapter: QueryAdapter = {
+      name: 'mock',
+      // Adapter present, but search strategy must NOT auto-issue a query.
+      execute: vi.fn(),
+      resolveFilterOptions: vi.fn(),
+    };
+
+    const { container } = renderFilterBar(
+      [
+        {
+          ...selectFilter,
+          optionSource: {
+            kind: 'field',
+            strategy: 'search',
+            minSearchChars: 2,
+          },
+        },
+      ],
+      { queryAdapter },
+    );
+
+    const select = container.querySelector('.ss-filter-select') as HTMLSelectElement;
+
+    expect(select.disabled).toBe(true);
+    expect(select.getAttribute('data-ss-filter-options-state')).toBe('unavailable');
+    const optionLabels = Array.from(select.querySelectorAll('option')).map(
+      (option) => option.textContent,
+    );
+    expect(optionLabels[0]).toMatch(/Search-strategy field options require a typeahead input/);
+    expect(queryAdapter.execute).not.toHaveBeenCalled();
+    expect(queryAdapter.resolveFilterOptions).not.toHaveBeenCalled();
   });
 
   it('resolves field-backed select options via queryAdapter.resolveFilterOptions when implemented', async () => {
@@ -318,8 +351,7 @@ describe('FilterBar', () => {
         ...multiSelectFilter,
         optionSource: {
           kind: 'field',
-          strategy: 'search',
-          minSearchChars: 2,
+          strategy: 'preload',
         },
       },
     ]);

--- a/packages/runtime/test/filter-bar.test.tsx
+++ b/packages/runtime/test/filter-bar.test.tsx
@@ -7,6 +7,7 @@ import type { FilterDefinition } from '@supersubset/schema';
 import {
   compileFilterDefinitionValue,
   generateWeeklyDateRangeOptions,
+  isDateRangeLike,
 } from '../src/filters/date-filter-utils';
 
 // Helper: render FilterBar within FilterProvider
@@ -540,6 +541,13 @@ describe('FilterBar', () => {
     );
 
     expect(compileFilterDefinitionValue(rangeDateFilter, { start: '', end: '' })).toBeNull();
+  });
+
+  it('[filters-and-interactions.FILTER_BAR.4] only treats valid range-shaped objects as date ranges', () => {
+    expect(isDateRangeLike({ start: '2026-05-05', end: '' })).toBe(true);
+    expect(isDateRangeLike({ min: 10, max: 20 })).toBe(true);
+    expect(isDateRangeLike({ start: 'open' })).toBe(false);
+    expect(isDateRangeLike({ min: '10' })).toBe(false);
   });
 
   it('calls setFilter via onFilterChange when text is typed', () => {

--- a/packages/runtime/test/filter-bar.test.tsx
+++ b/packages/runtime/test/filter-bar.test.tsx
@@ -475,6 +475,29 @@ describe('FilterBar', () => {
     });
   });
 
+  it('[filters-and-interactions.FILTER_BAR.5] respects relative weekly defaults', () => {
+    const currentWeek = generateWeeklyDateRangeOptions(weeklyDateFilter.dateConfig).find(
+      (option) => option.offset === 0,
+    );
+
+    expect(currentWeek).toBeDefined();
+    if (!currentWeek) {
+      throw new Error('Expected the weekly filter to include the current week');
+    }
+
+    const { container } = renderFilterBar([weeklyDateFilter], {
+      initialValues: { 'f-week': { preset: 'this_week' } },
+    });
+    const select = container.querySelector('.ss-filter-date-preset') as HTMLSelectElement;
+
+    expect(select.value).toBe(currentWeek.value);
+    expect(compileFilterDefinitionValue(weeklyDateFilter, { preset: 'this_week' })).toEqual({
+      fieldId: 'created_at',
+      operator: 'between',
+      value: [currentWeek.start, currentWeek.end],
+    });
+  });
+
   it('[filters-and-interactions.FILTER_BAR.4] renders range-mode date filters as date inputs without a preset dropdown', () => {
     const onFilterChange = vi.fn();
     const { container } = renderFilterBar([rangeDateFilter], { onFilterChange });
@@ -497,6 +520,26 @@ describe('FilterBar', () => {
       operator: 'between',
       value: ['2026-05-01', '2026-05-31'],
     });
+  });
+
+  it('[filters-and-interactions.FILTER_BAR.4] compiles partial date ranges as one-sided filters', () => {
+    expect(compileFilterDefinitionValue(rangeDateFilter, { start: '2026-05-05', end: '' })).toEqual(
+      {
+        fieldId: 'created_at',
+        operator: 'gte',
+        value: '2026-05-05',
+      },
+    );
+
+    expect(compileFilterDefinitionValue(rangeDateFilter, { start: '', end: '2026-05-31' })).toEqual(
+      {
+        fieldId: 'created_at',
+        operator: 'lte',
+        value: '2026-05-31',
+      },
+    );
+
+    expect(compileFilterDefinitionValue(rangeDateFilter, { start: '', end: '' })).toBeNull();
   });
 
   it('calls setFilter via onFilterChange when text is typed', () => {

--- a/packages/runtime/test/filter-bar.test.tsx
+++ b/packages/runtime/test/filter-bar.test.tsx
@@ -92,7 +92,7 @@ const multiSelectFilter: FilterDefinition = {
 };
 
 describe('FilterBar', () => {
-  it('renders a control for each filter definition', () => {
+  it('[filters-and-interactions.FILTER_BAR.1] renders a control for each filter definition', () => {
     const { container } = renderFilterBar([selectFilter, textFilter, rangeFilter, dateFilter]);
 
     const controls = container.querySelectorAll('.ss-filter-control');
@@ -111,7 +111,7 @@ describe('FilterBar', () => {
     expect(select?.tagName).toBe('SELECT');
   });
 
-  it('renders authored static options without the legacy filterOptions prop', () => {
+  it('[filters-and-interactions.FILTER_OPTION_SOURCES.1] renders authored static options without the legacy filterOptions prop', () => {
     const { container } = renderFilterBar([selectFilter]);
 
     const select = container.querySelector('.ss-filter-select') as HTMLSelectElement;
@@ -148,7 +148,7 @@ describe('FilterBar', () => {
     expect(optionLabels).toEqual(['All', 'Pending', 'Resolved']);
   });
 
-  it('renders an unavailable select state when no option source is available', () => {
+  it('[filters-and-interactions.FILTER_OPTION_SOURCES.3] renders an unavailable select state when no option source is available', () => {
     const { container } = renderFilterBar([{ ...selectFilter, optionSource: undefined }]);
 
     const select = container.querySelector('.ss-filter-select') as HTMLSelectElement;
@@ -278,7 +278,7 @@ describe('FilterBar', () => {
     expect(lastCall.values['f-category']).toEqual(['footwear', 'hydration']);
   });
 
-  it('renders Clear filters button when filters are active', () => {
+  it('[filters-and-interactions.FILTER_BAR.3] renders Clear filters button when filters are active', () => {
     const onFilterChange = vi.fn();
     const { container } = renderFilterBar([textFilter], {
       initialValues: { 'f-search': 'existing' },

--- a/packages/runtime/test/filter-bar.test.tsx
+++ b/packages/runtime/test/filter-bar.test.tsx
@@ -4,6 +4,10 @@ import type { QueryAdapter } from '@supersubset/data-model';
 import { FilterBar } from '../src/components/FilterBar';
 import { FilterProvider } from '../src/filters/FilterEngine';
 import type { FilterDefinition } from '@supersubset/schema';
+import {
+  compileFilterDefinitionValue,
+  generateWeeklyDateRangeOptions,
+} from '../src/filters/date-filter-utils';
 
 // Helper: render FilterBar within FilterProvider
 function renderFilterBar(
@@ -76,6 +80,31 @@ const dateFilter: FilterDefinition = {
   datasetRef: 'ds-1',
   operator: 'gte',
   scope: { type: 'page', pageId: 'page-1' },
+};
+
+const weeklyDateFilter: FilterDefinition = {
+  ...dateFilter,
+  id: 'f-week',
+  title: 'Week',
+  operator: 'between',
+  dateConfig: {
+    mode: 'weekly',
+    weekStartsOn: 1,
+    weeksBack: 1,
+    weeksForward: 1,
+    includeCurrentWeek: true,
+  },
+};
+
+const rangeDateFilter: FilterDefinition = {
+  ...dateFilter,
+  id: 'f-date-range',
+  title: 'Created range',
+  operator: 'between',
+  dateConfig: {
+    mode: 'range',
+    allowCustomRange: true,
+  },
 };
 
 const multiSelectFilter: FilterDefinition = {
@@ -394,6 +423,80 @@ describe('FilterBar', () => {
     expect(options!.length).toBeGreaterThan(5);
     // First option is "All time"
     expect(options![0].textContent).toBe('All time');
+  });
+
+  it('[filters-and-interactions.FILTER_BAR.5] renders authored weekly date range options', () => {
+    const options = generateWeeklyDateRangeOptions(
+      weeklyDateFilter.dateConfig,
+      new Date(2026, 4, 28),
+    );
+
+    expect(options).toEqual([
+      expect.objectContaining({ start: '2026-05-18', end: '2026-05-24', offset: -1 }),
+      expect.objectContaining({ start: '2026-05-25', end: '2026-05-31', offset: 0 }),
+      expect.objectContaining({ start: '2026-06-01', end: '2026-06-07', offset: 1 }),
+    ]);
+
+    const { container } = renderFilterBar([weeklyDateFilter]);
+    const select = container.querySelector('.ss-filter-date-preset') as HTMLSelectElement;
+    const labels = Array.from(select.querySelectorAll('option')).map(
+      (option) => option.textContent,
+    );
+
+    expect(labels[0]).toBe('All time');
+    expect(labels).toContain('May 25 - May 31');
+  });
+
+  it('[filters-and-interactions.FILTER_BAR.5] emits weekly range values that compile to logical query ranges', () => {
+    const onFilterChange = vi.fn();
+    const { container } = renderFilterBar([weeklyDateFilter], { onFilterChange });
+    const select = container.querySelector('.ss-filter-date-preset') as HTMLSelectElement;
+    const firstWeeklyValue = Array.from(select.options).find((option) =>
+      option.value.startsWith('week:'),
+    )?.value;
+
+    expect(firstWeeklyValue).toBeTruthy();
+    fireEvent.change(select, { target: { value: firstWeeklyValue } });
+
+    const lastCall = onFilterChange.mock.calls[onFilterChange.mock.calls.length - 1][0];
+    const filterValue = lastCall.values['f-week'];
+
+    expect(filterValue).toEqual(
+      expect.objectContaining({
+        preset: firstWeeklyValue,
+        start: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        end: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      }),
+    );
+    expect(compileFilterDefinitionValue(weeklyDateFilter, filterValue)).toEqual({
+      fieldId: 'created_at',
+      operator: 'between',
+      value: [filterValue.start, filterValue.end],
+    });
+  });
+
+  it('[filters-and-interactions.FILTER_BAR.4] renders range-mode date filters as date inputs without a preset dropdown', () => {
+    const onFilterChange = vi.fn();
+    const { container } = renderFilterBar([rangeDateFilter], { onFilterChange });
+
+    expect(container.querySelector('.ss-filter-date-preset')).toBeNull();
+
+    const startInput = container.querySelector(
+      'input[name="f-date-range-start"]',
+    ) as HTMLInputElement;
+    const endInput = container.querySelector('input[name="f-date-range-end"]') as HTMLInputElement;
+    expect(startInput?.type).toBe('date');
+    expect(endInput?.type).toBe('date');
+
+    fireEvent.change(startInput, { target: { value: '2026-05-01' } });
+    fireEvent.change(endInput, { target: { value: '2026-05-31' } });
+
+    const lastCall = onFilterChange.mock.calls[onFilterChange.mock.calls.length - 1][0];
+    expect(compileFilterDefinitionValue(rangeDateFilter, lastCall.values['f-date-range'])).toEqual({
+      fieldId: 'created_at',
+      operator: 'between',
+      value: ['2026-05-01', '2026-05-31'],
+    });
   });
 
   it('calls setFilter via onFilterChange when text is typed', () => {

--- a/packages/runtime/test/filter-bar.test.tsx
+++ b/packages/runtime/test/filter-bar.test.tsx
@@ -545,6 +545,7 @@ describe('FilterBar', () => {
 
   it('[filters-and-interactions.FILTER_BAR.4] only treats valid range-shaped objects as date ranges', () => {
     expect(isDateRangeLike({ start: '2026-05-05', end: '' })).toBe(true);
+    expect(isDateRangeLike({ start: 10, end: 20 })).toBe(true);
     expect(isDateRangeLike({ min: 10, max: 20 })).toBe(true);
     expect(isDateRangeLike({ start: 'open' })).toBe(false);
     expect(isDateRangeLike({ min: '10' })).toBe(false);

--- a/packages/runtime/test/layout.test.tsx
+++ b/packages/runtime/test/layout.test.tsx
@@ -548,6 +548,10 @@ describe('LayoutRenderer', () => {
             filterId: 'created-at',
             value: { start: '2024-01-01', end: '2024-01-31' },
           },
+          {
+            filterId: 'cross-filter:chart-1:amount',
+            value: { start: 1, end: 10 },
+          },
           { filterId: 'other-page-region', value: 'APAC' },
           { filterId: 'customer-region', value: 'France' },
         ]}
@@ -579,6 +583,11 @@ describe('LayoutRenderer', () => {
             fieldId: 'created_at',
             operator: 'between',
             value: ['2024-01-01', '2024-01-31'],
+          },
+          {
+            fieldId: 'amount',
+            operator: 'between',
+            value: [1, 10],
           },
         ],
       });

--- a/packages/runtime/test/renderer-interactions.test.tsx
+++ b/packages/runtime/test/renderer-interactions.test.tsx
@@ -128,7 +128,7 @@ const dashboard: DashboardDefinition = {
 };
 
 describe('SupersubsetRenderer interactions', () => {
-  it('routes widget click events through the interaction engine', () => {
+  it('[filters-and-interactions.CLICK_TO_FILTER.1] routes widget click events through the interaction engine', () => {
     const onNavigate = vi.fn();
     const onWidgetEvent = vi.fn();
     const registry = createWidgetRegistry([['clickable-widget', ClickableWidget]]);
@@ -157,7 +157,7 @@ describe('SupersubsetRenderer interactions', () => {
     );
   });
 
-  it('re-executes query-bound widgets when a chart click sets a cross-filter', async () => {
+  it('[filters-and-interactions.CROSS_WIDGET_FILTERS.1] re-executes query-bound widgets when a chart click sets a cross-filter', async () => {
     const execute = vi.fn<QueryAdapter['execute']>().mockImplementation(async (query) => {
       const activeRegion = query.filters?.find((filter) => filter.fieldId === 'region')?.value;
       return createQueryResult(activeRegion === 'North' ? 6400 : 23000);

--- a/packages/schema/src/date-utils.ts
+++ b/packages/schema/src/date-utils.ts
@@ -21,8 +21,8 @@ export const DATE_PRESETS: { value: string; label: string }[] = [
 
 export interface DateRangeValue {
   preset?: string;
-  start?: string;
-  end?: string;
+  start?: string | number;
+  end?: string | number;
   min?: number;
   max?: number;
 }
@@ -222,7 +222,10 @@ function isValidRangeBound(key: string, value: unknown): boolean {
     return typeof value === 'number' && Number.isFinite(value);
   }
 
-  return typeof value === 'string' && DATE_BOUND_PATTERN.test(value);
+  return (
+    (typeof value === 'number' && Number.isFinite(value)) ||
+    (typeof value === 'string' && DATE_BOUND_PATTERN.test(value))
+  );
 }
 
 export function normalizeRangeBound(

--- a/packages/schema/src/date-utils.ts
+++ b/packages/schema/src/date-utils.ts
@@ -1,0 +1,236 @@
+import type { DateFilterConfig } from './types';
+
+export const DATE_PRESETS: { value: string; label: string }[] = [
+  { value: '', label: 'All time' },
+  { value: 'today', label: 'Today' },
+  { value: 'yesterday', label: 'Yesterday' },
+  { value: 'this_week', label: 'This week' },
+  { value: 'last_week', label: 'Last week' },
+  { value: 'this_month', label: 'This month' },
+  { value: 'last_month', label: 'Last month' },
+  { value: 'this_quarter', label: 'This quarter' },
+  { value: 'last_quarter', label: 'Last quarter' },
+  { value: 'this_year', label: 'This year' },
+  { value: 'last_year', label: 'Last year' },
+  { value: 'last_7_days', label: 'Last 7 days' },
+  { value: 'last_30_days', label: 'Last 30 days' },
+  { value: 'last_90_days', label: 'Last 90 days' },
+  { value: 'last_365_days', label: 'Last 365 days' },
+  { value: 'custom', label: 'Custom range…' },
+];
+
+export interface DateRangeValue {
+  preset?: string;
+  start?: string;
+  end?: string;
+  min?: number;
+  max?: number;
+}
+
+export interface WeeklyDateRangeOption {
+  value: string;
+  label: string;
+  start: string;
+  end: string;
+  offset: number;
+}
+
+const DATE_BOUND_PATTERN = /^\d{4}-\d{2}-\d{2}(?:$|[T\s])/;
+
+export function formatIsoDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+export function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+export function clampWeekday(value: unknown): 0 | 1 | 2 | 3 | 4 | 5 | 6 {
+  return value === 0 ||
+    value === 1 ||
+    value === 2 ||
+    value === 3 ||
+    value === 4 ||
+    value === 5 ||
+    value === 6
+    ? value
+    : 0;
+}
+
+export function coerceNonNegativeInteger(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : fallback;
+}
+
+export function startOfWeek(date: Date, weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6): Date {
+  const dayOffset = (date.getDay() - weekStartsOn + 7) % 7;
+  return addDays(date, -dayOffset);
+}
+
+function formatDateLabel(isoDate: string): string {
+  const [year, month, day] = isoDate.split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function generateWeeklyDateRangeOptions(
+  config: DateFilterConfig | undefined,
+  now = new Date(),
+): WeeklyDateRangeOption[] {
+  const weekStartsOn = clampWeekday(config?.weekStartsOn);
+  const weeksBack = coerceNonNegativeInteger(config?.weeksBack, 4);
+  const weeksForward = coerceNonNegativeInteger(config?.weeksForward, 0);
+  const includeCurrentWeek = config?.includeCurrentWeek !== false;
+  const currentWeekStart = startOfWeek(startOfLocalDay(now), weekStartsOn);
+  const options: WeeklyDateRangeOption[] = [];
+
+  for (let offset = -weeksBack; offset <= weeksForward; offset += 1) {
+    if (!includeCurrentWeek && offset === 0) {
+      continue;
+    }
+
+    const start = addDays(currentWeekStart, offset * 7);
+    const end = addDays(start, 6);
+    const startIso = formatIsoDate(start);
+    const endIso = formatIsoDate(end);
+
+    options.push({
+      value: `week:${startIso}:${endIso}`,
+      label: `${formatDateLabel(startIso)} - ${formatDateLabel(endIso)}`,
+      start: startIso,
+      end: endIso,
+      offset,
+    });
+  }
+
+  return options;
+}
+
+/**
+ * Resolve a relative date preset to a concrete { start, end } range.
+ * Returns undefined for empty/unknown presets.
+ */
+export function resolveRelativeDate(
+  preset: string,
+  now = new Date(),
+  config?: DateFilterConfig,
+): { start: string; end: string } | undefined {
+  const today = startOfLocalDay(now);
+  const weekStartsOn = clampWeekday(config?.weekStartsOn);
+
+  switch (preset) {
+    case 'today':
+      return { start: formatIsoDate(today), end: formatIsoDate(today) };
+    case 'yesterday': {
+      const d = addDays(today, -1);
+      return { start: formatIsoDate(d), end: formatIsoDate(d) };
+    }
+    case 'this_week': {
+      const start = startOfWeek(today, weekStartsOn);
+      const end = config?.mode === 'weekly' ? addDays(start, 6) : today;
+      return { start: formatIsoDate(start), end: formatIsoDate(end) };
+    }
+    case 'last_week': {
+      const currentStart = startOfWeek(today, weekStartsOn);
+      const start = addDays(currentStart, -7);
+      const end = addDays(currentStart, -1);
+      return { start: formatIsoDate(start), end: formatIsoDate(end) };
+    }
+    case 'this_month':
+      return {
+        start: formatIsoDate(new Date(today.getFullYear(), today.getMonth(), 1)),
+        end: formatIsoDate(today),
+      };
+    case 'last_month': {
+      const start = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+      const end = new Date(today.getFullYear(), today.getMonth(), 0);
+      return { start: formatIsoDate(start), end: formatIsoDate(end) };
+    }
+    case 'this_quarter': {
+      const q = Math.floor(today.getMonth() / 3);
+      return {
+        start: formatIsoDate(new Date(today.getFullYear(), q * 3, 1)),
+        end: formatIsoDate(today),
+      };
+    }
+    case 'last_quarter': {
+      const q = Math.floor(today.getMonth() / 3);
+      const start = new Date(today.getFullYear(), (q - 1) * 3, 1);
+      const end = new Date(today.getFullYear(), q * 3, 0);
+      return { start: formatIsoDate(start), end: formatIsoDate(end) };
+    }
+    case 'this_year':
+      return {
+        start: formatIsoDate(new Date(today.getFullYear(), 0, 1)),
+        end: formatIsoDate(today),
+      };
+    case 'last_year':
+      return {
+        start: formatIsoDate(new Date(today.getFullYear() - 1, 0, 1)),
+        end: formatIsoDate(new Date(today.getFullYear() - 1, 11, 31)),
+      };
+    case 'last_7_days':
+      return { start: formatIsoDate(addDays(today, -6)), end: formatIsoDate(today) };
+    case 'last_30_days':
+      return { start: formatIsoDate(addDays(today, -29)), end: formatIsoDate(today) };
+    case 'last_90_days':
+      return { start: formatIsoDate(addDays(today, -89)), end: formatIsoDate(today) };
+    case 'last_365_days':
+      return { start: formatIsoDate(addDays(today, -364)), end: formatIsoDate(today) };
+    default:
+      return undefined;
+  }
+}
+
+export function isRangeLikeValue(value: unknown): value is DateRangeValue {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const presentKeys = ['start', 'end', 'min', 'max'].filter((key) => key in candidate);
+
+  return (
+    presentKeys.length > 0 && presentKeys.every((key) => isValidRangeBound(key, candidate[key]))
+  );
+}
+
+/**
+ * Backwards-compatible alias for the original public runtime helper.
+ * Prefer isRangeLikeValue for new code.
+ */
+export function isDateRangeLike(value: unknown): value is DateRangeValue {
+  return isRangeLikeValue(value);
+}
+
+function isValidRangeBound(key: string, value: unknown): boolean {
+  if (value == null || value === '') {
+    return true;
+  }
+
+  if (key === 'min' || key === 'max') {
+    return typeof value === 'number' && Number.isFinite(value);
+  }
+
+  return typeof value === 'string' && DATE_BOUND_PATTERN.test(value);
+}
+
+export function normalizeRangeBound(
+  value: DateRangeValue['start'] | DateRangeValue['min'],
+): string | number | undefined {
+  if (value === '') {
+    return undefined;
+  }
+
+  return value;
+}

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -2,4 +2,9 @@ export * from './types';
 export * from './validation';
 export * from './serializers';
 export * from './json-schema';
-export { CURRENT_SCHEMA_VERSION, migrateDashboardDefinition, isSupportedSchemaVersion } from './migrations';
+export * from './date-utils';
+export {
+  CURRENT_SCHEMA_VERSION,
+  migrateDashboardDefinition,
+  isSupportedSchemaVersion,
+} from './migrations';

--- a/packages/schema/src/types/dashboard.ts
+++ b/packages/schema/src/types/dashboard.ts
@@ -212,8 +212,20 @@ export interface FilterDefinition {
   datasetRef: string;
   operator: string;
   defaultValue?: unknown;
+  dateConfig?: DateFilterConfig;
   optionSource?: FilterOptionSource;
   scope: FilterScope;
+}
+
+export interface DateFilterConfig {
+  mode?: 'range' | 'preset' | 'weekly';
+  presets?: string[];
+  defaultPreset?: string;
+  allowCustomRange?: boolean;
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  weeksBack?: number;
+  weeksForward?: number;
+  includeCurrentWeek?: boolean;
 }
 
 export interface FilterOptionDefinition {

--- a/packages/schema/src/types/dashboard.ts
+++ b/packages/schema/src/types/dashboard.ts
@@ -220,7 +220,6 @@ export interface FilterDefinition {
 export interface DateFilterConfig {
   mode?: 'range' | 'preset' | 'weekly';
   presets?: string[];
-  defaultPreset?: string;
   allowCustomRange?: boolean;
   weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   weeksBack?: number;

--- a/packages/schema/src/validation/dashboard.ts
+++ b/packages/schema/src/validation/dashboard.ts
@@ -140,6 +140,27 @@ const filterOptionSourceSchema = z.discriminatedUnion('kind', [
   }),
 ]);
 
+const dateFilterConfigSchema = z.object({
+  mode: z.enum(['range', 'preset', 'weekly']).optional(),
+  presets: z.array(z.string().min(1)).optional(),
+  defaultPreset: z.string().min(1).optional(),
+  allowCustomRange: z.boolean().optional(),
+  weekStartsOn: z
+    .union([
+      z.literal(0),
+      z.literal(1),
+      z.literal(2),
+      z.literal(3),
+      z.literal(4),
+      z.literal(5),
+      z.literal(6),
+    ])
+    .optional(),
+  weeksBack: z.number().int().min(0).optional(),
+  weeksForward: z.number().int().min(0).optional(),
+  includeCurrentWeek: z.boolean().optional(),
+});
+
 const filterDefinitionSchema = z.object({
   id: z.string().min(1),
   title: z.string().optional(),
@@ -148,6 +169,7 @@ const filterDefinitionSchema = z.object({
   datasetRef: z.string().min(1),
   operator: z.string().min(1),
   defaultValue: z.unknown().optional(),
+  dateConfig: dateFilterConfigSchema.optional(),
   optionSource: filterOptionSourceSchema.optional(),
   scope: filterScopeSchema,
 });
@@ -405,6 +427,7 @@ export {
   dataBindingSchema,
   fieldBindingSchema,
   filterDefinitionSchema,
+  dateFilterConfigSchema,
   filterOptionDefinitionSchema,
   filterOptionSourceSchema,
   filterScopeSchema,

--- a/packages/schema/src/validation/dashboard.ts
+++ b/packages/schema/src/validation/dashboard.ts
@@ -148,7 +148,6 @@ const dateFilterConfigSchema = z
   .object({
     mode: z.enum(['range', 'preset', 'weekly']).optional(),
     presets: z.array(z.string().min(1)).optional(),
-    defaultPreset: z.string().min(1).optional(),
     allowCustomRange: z.boolean().optional(),
     weekStartsOn: z
       .union([
@@ -175,22 +174,6 @@ const dateFilterConfigSchema = z
         });
       }
     });
-
-    if (config.defaultPreset && !KNOWN_DATE_PRESET_VALUES.has(config.defaultPreset)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['defaultPreset'],
-        message: `Unknown default date preset: ${config.defaultPreset}`,
-      });
-    }
-
-    if (config.defaultPreset && config.presets && !config.presets.includes(config.defaultPreset)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['defaultPreset'],
-        message: 'defaultPreset must be included in presets when presets is set',
-      });
-    }
 
     if (config.mode === 'weekly' && generateWeeklyDateRangeOptions(config).length === 0) {
       ctx.addIssue({

--- a/packages/schema/src/validation/dashboard.ts
+++ b/packages/schema/src/validation/dashboard.ts
@@ -1,8 +1,12 @@
 import { z } from 'zod';
+import { DATE_PRESETS, generateWeeklyDateRangeOptions } from '../date-utils';
 import { VALID_CHILDREN } from '../types/dashboard';
 import type { LayoutComponentType } from '../types/dashboard';
 
 const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const KNOWN_DATE_PRESET_VALUES = new Set(
+  DATE_PRESETS.map((preset) => preset.value).filter((value) => value.length > 0),
+);
 
 function safeRecord<V extends z.ZodTypeAny>(valueSchema: V) {
   return z.record(z.string(), valueSchema).transform((obj) => {
@@ -140,26 +144,62 @@ const filterOptionSourceSchema = z.discriminatedUnion('kind', [
   }),
 ]);
 
-const dateFilterConfigSchema = z.object({
-  mode: z.enum(['range', 'preset', 'weekly']).optional(),
-  presets: z.array(z.string().min(1)).optional(),
-  defaultPreset: z.string().min(1).optional(),
-  allowCustomRange: z.boolean().optional(),
-  weekStartsOn: z
-    .union([
-      z.literal(0),
-      z.literal(1),
-      z.literal(2),
-      z.literal(3),
-      z.literal(4),
-      z.literal(5),
-      z.literal(6),
-    ])
-    .optional(),
-  weeksBack: z.number().int().min(0).optional(),
-  weeksForward: z.number().int().min(0).optional(),
-  includeCurrentWeek: z.boolean().optional(),
-});
+const dateFilterConfigSchema = z
+  .object({
+    mode: z.enum(['range', 'preset', 'weekly']).optional(),
+    presets: z.array(z.string().min(1)).optional(),
+    defaultPreset: z.string().min(1).optional(),
+    allowCustomRange: z.boolean().optional(),
+    weekStartsOn: z
+      .union([
+        z.literal(0),
+        z.literal(1),
+        z.literal(2),
+        z.literal(3),
+        z.literal(4),
+        z.literal(5),
+        z.literal(6),
+      ])
+      .optional(),
+    weeksBack: z.number().int().min(0).optional(),
+    weeksForward: z.number().int().min(0).optional(),
+    includeCurrentWeek: z.boolean().optional(),
+  })
+  .superRefine((config, ctx) => {
+    config.presets?.forEach((preset, index) => {
+      if (!KNOWN_DATE_PRESET_VALUES.has(preset)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['presets', index],
+          message: `Unknown date preset: ${preset}`,
+        });
+      }
+    });
+
+    if (config.defaultPreset && !KNOWN_DATE_PRESET_VALUES.has(config.defaultPreset)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['defaultPreset'],
+        message: `Unknown default date preset: ${config.defaultPreset}`,
+      });
+    }
+
+    if (config.defaultPreset && config.presets && !config.presets.includes(config.defaultPreset)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['defaultPreset'],
+        message: 'defaultPreset must be included in presets when presets is set',
+      });
+    }
+
+    if (config.mode === 'weekly' && generateWeeklyDateRangeOptions(config).length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['includeCurrentWeek'],
+        message: 'weekly date filters must generate at least one option',
+      });
+    }
+  });
 
 const filterDefinitionSchema = z.object({
   id: z.string().min(1),

--- a/packages/schema/test/dashboard.test.ts
+++ b/packages/schema/test/dashboard.test.ts
@@ -13,41 +13,41 @@ const fixturePath = resolve(__dirname, 'fixtures/sales-dashboard.json');
 const fixtureJSON = readFileSync(fixturePath, 'utf-8');
 
 describe('DashboardDefinition schema', () => {
-  it('validates the sales dashboard fixture', () => {
+  it('[schema-and-serialization.CANONICAL_SCHEMA.1] validates the sales dashboard fixture', () => {
     const raw = JSON.parse(fixtureJSON);
     const result = dashboardDefinitionSchema.safeParse(raw);
     expect(result.success).toBe(true);
   });
 
-  it('rejects missing schemaVersion', () => {
+  it('[schema-and-serialization.CANONICAL_SCHEMA.2] rejects missing schemaVersion', () => {
     const raw = JSON.parse(fixtureJSON);
     delete raw.schemaVersion;
     const result = dashboardDefinitionSchema.safeParse(raw);
     expect(result.success).toBe(false);
   });
 
-  it('rejects empty pages array', () => {
+  it('[schema-and-serialization.CANONICAL_SCHEMA.3] rejects empty pages array', () => {
     const raw = JSON.parse(fixtureJSON);
     raw.pages = [];
     const result = dashboardDefinitionSchema.safeParse(raw);
     expect(result.success).toBe(false);
   });
 
-  it('rejects missing widget id', () => {
+  it('[schema-and-serialization.STABLE_IDS.2] rejects missing widget id', () => {
     const raw = JSON.parse(fixtureJSON);
     delete raw.pages[0].widgets[0].id;
     const result = dashboardDefinitionSchema.safeParse(raw);
     expect(result.success).toBe(false);
   });
 
-  it('validates filter scope discriminated union', () => {
+  it('[schema-and-serialization.ZOD_VALIDATION.3] validates filter scope discriminated union', () => {
     const raw = JSON.parse(fixtureJSON);
     expect(raw.filters[0].scope.type).toBe('global');
     const result = dashboardDefinitionSchema.safeParse(raw);
     expect(result.success).toBe(true);
   });
 
-  it('validates interaction action discriminated union', () => {
+  it('[schema-and-serialization.ZOD_VALIDATION.3] validates interaction action discriminated union', () => {
     const raw = JSON.parse(fixtureJSON);
     expect(raw.interactions[0].action.type).toBe('filter');
     const result = dashboardDefinitionSchema.safeParse(raw);
@@ -116,7 +116,7 @@ describe('DashboardDefinition schema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('rejects field-backed option sources with minSearchChars below 1', () => {
+  it('[schema-and-serialization.ZOD_VALIDATION.2] rejects field-backed option sources with minSearchChars below 1', () => {
     const raw = JSON.parse(fixtureJSON);
     raw.filters[0].optionSource = {
       kind: 'field',
@@ -192,7 +192,7 @@ describe('layout nesting validation', () => {
 });
 
 describe('JSON serialization round-trip', () => {
-  it('round-trips without semantic loss', () => {
+  it('[schema-and-serialization.SERIALIZATION.1] round-trips without semantic loss', () => {
     const parsed = parseFromJSON(fixtureJSON);
     const serialized = serializeToJSON(parsed);
     const reparsed = parseFromJSON(serialized);
@@ -206,7 +206,7 @@ describe('JSON serialization round-trip', () => {
     expect(reparsed.interactions).toHaveLength(parsed.interactions!.length);
   });
 
-  it('round-trips layout map structure', () => {
+  it('[schema-and-serialization.STABLE_IDS.1] round-trips layout map structure', () => {
     const parsed = parseFromJSON(fixtureJSON);
     const serialized = serializeToJSON(parsed);
     const reparsed = parseFromJSON(serialized);
@@ -217,7 +217,7 @@ describe('JSON serialization round-trip', () => {
     expect(reparsed.pages[0].rootNodeId).toBe(parsed.pages[0].rootNodeId);
   });
 
-  it('produces deterministic output (sorted keys)', () => {
+  it('[schema-and-serialization.SERIALIZATION.2] produces deterministic output (sorted keys)', () => {
     const parsed = parseFromJSON(fixtureJSON);
     const first = serializeToJSON(parsed);
     const second = serializeToJSON(parsed);
@@ -253,7 +253,7 @@ describe('JSON serialization round-trip', () => {
 });
 
 describe('minimal valid dashboard', () => {
-  it('accepts a dashboard with one page and flat layout map', () => {
+  it('[schema-and-serialization.ZOD_VALIDATION.1] accepts a dashboard with one page and flat layout map', () => {
     const minimal: DashboardDefinition = {
       schemaVersion: '0.2.0',
       id: 'test-min',

--- a/packages/schema/test/dashboard.validation.test.ts
+++ b/packages/schema/test/dashboard.validation.test.ts
@@ -70,7 +70,7 @@ describe('dashboardDefinitionSchema alert rules', () => {
     expect(result.success).toBe(true);
   });
 
-  it('accepts structured alert rules on alerts widgets', () => {
+  it('[navigation-and-alerts.ALERT_RULES.1] accepts structured alert rules on alerts widgets', () => {
     const result = dashboardDefinitionSchema.safeParse(
       createAlertsDashboard({
         mode: 'structured',
@@ -108,7 +108,7 @@ describe('dashboardDefinitionSchema alert rules', () => {
     expect(result.success).toBe(true);
   });
 
-  it('rejects malformed structured alert rules on alerts widgets', () => {
+  it('[navigation-and-alerts.ALERT_RULES.2] rejects malformed structured alert rules on alerts widgets', () => {
     const result = dashboardDefinitionSchema.safeParse(
       createAlertsDashboard({
         mode: 'structured',
@@ -133,7 +133,7 @@ describe('dashboardDefinitionSchema alert rules', () => {
     ).toBe(true);
   });
 
-  it('rejects unknown keys in structured alert rules on alerts widgets', () => {
+  it('[navigation-and-alerts.ALERT_RULES.3] rejects unknown keys in structured alert rules on alerts widgets', () => {
     const result = dashboardDefinitionSchema.safeParse(
       createAlertsDashboard({
         mode: 'structured',

--- a/packages/schema/test/dashboard.validation.test.ts
+++ b/packages/schema/test/dashboard.validation.test.ts
@@ -210,25 +210,6 @@ describe('dashboardDefinitionSchema date filters', () => {
     ).toBe(true);
   });
 
-  it('[filters-and-interactions.FILTER_BAR.4] rejects default presets outside the curated list', () => {
-    const result = dashboardDefinitionSchema.safeParse(
-      createDashboardWithDateConfig({
-        mode: 'preset',
-        presets: ['today'],
-        defaultPreset: 'last_7_days',
-      }),
-    );
-
-    expect(result.success).toBe(false);
-    expect(
-      result.success
-        ? false
-        : result.error.issues.some((issue) =>
-            issue.path.join('.').endsWith('dateConfig.defaultPreset'),
-          ),
-    ).toBe(true);
-  });
-
   it('[filters-and-interactions.FILTER_BAR.4] rejects weekly configs with no generated options', () => {
     const result = dashboardDefinitionSchema.safeParse(
       createDashboardWithDateConfig({

--- a/packages/schema/test/dashboard.validation.test.ts
+++ b/packages/schema/test/dashboard.validation.test.ts
@@ -54,6 +54,36 @@ function createAlertsDashboard(alertRule: Record<string, unknown>) {
   };
 }
 
+function createDashboardWithDateConfig(dateConfig: Record<string, unknown>) {
+  return {
+    schemaVersion: '0.2.0',
+    id: 'dashboard-date-filters',
+    title: 'Date Filters',
+    pages: [
+      {
+        id: 'page-1',
+        title: 'Overview',
+        rootNodeId: 'root',
+        layout: {
+          root: { id: 'root', type: 'root', children: [], meta: {} },
+        },
+        widgets: [],
+      },
+    ],
+    filters: [
+      {
+        id: 'event-week',
+        type: 'date',
+        fieldRef: 'event_date',
+        datasetRef: 'events',
+        operator: 'between',
+        dateConfig,
+        scope: { type: 'global' },
+      },
+    ],
+  };
+}
+
 describe('dashboardDefinitionSchema alert rules', () => {
   it('keeps widgetDefinitionSchema chainable for sub-schema consumers', () => {
     const extendedWidgetSchema = widgetDefinitionSchema.extend({
@@ -156,6 +186,65 @@ describe('dashboardDefinitionSchema alert rules', () => {
         ? false
         : result.error.issues.some(
             (issue) => issue.path.join('.') === 'pages.0.widgets.0.config.alertRule',
+          ),
+    ).toBe(true);
+  });
+});
+
+describe('dashboardDefinitionSchema date filters', () => {
+  it('[filters-and-interactions.FILTER_BAR.4] rejects unknown date presets', () => {
+    const result = dashboardDefinitionSchema.safeParse(
+      createDashboardWithDateConfig({
+        mode: 'preset',
+        presets: ['next_fortnight'],
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(
+      result.success
+        ? false
+        : result.error.issues.some((issue) =>
+            issue.path.join('.').endsWith('dateConfig.presets.0'),
+          ),
+    ).toBe(true);
+  });
+
+  it('[filters-and-interactions.FILTER_BAR.4] rejects default presets outside the curated list', () => {
+    const result = dashboardDefinitionSchema.safeParse(
+      createDashboardWithDateConfig({
+        mode: 'preset',
+        presets: ['today'],
+        defaultPreset: 'last_7_days',
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(
+      result.success
+        ? false
+        : result.error.issues.some((issue) =>
+            issue.path.join('.').endsWith('dateConfig.defaultPreset'),
+          ),
+    ).toBe(true);
+  });
+
+  it('[filters-and-interactions.FILTER_BAR.4] rejects weekly configs with no generated options', () => {
+    const result = dashboardDefinitionSchema.safeParse(
+      createDashboardWithDateConfig({
+        mode: 'weekly',
+        weeksBack: 0,
+        weeksForward: 0,
+        includeCurrentWeek: false,
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(
+      result.success
+        ? false
+        : result.error.issues.some((issue) =>
+            issue.path.join('.').endsWith('dateConfig.includeCurrentWeek'),
           ),
     ).toBe(true);
   });

--- a/packages/schema/test/migrations.test.ts
+++ b/packages/schema/test/migrations.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { CURRENT_SCHEMA_VERSION, isSupportedSchemaVersion, migrateDashboardDefinition } from '../src/migrations';
+import {
+  CURRENT_SCHEMA_VERSION,
+  isSupportedSchemaVersion,
+  migrateDashboardDefinition,
+} from '../src/migrations';
 import { parseFromJSON } from '../src/serializers';
 import { parseFromYAML } from '../src/serializers/yaml';
 
@@ -118,14 +122,16 @@ describe('schema migrations', () => {
     expect(isSupportedSchemaVersion('9.9.9')).toBe(false);
   });
 
-  it('migrates a 0.1.0 recursive-layout dashboard into the current schema', () => {
+  it('[schema-and-serialization.MIGRATIONS.1] migrates a 0.1.0 recursive-layout dashboard into the current schema', () => {
     const migrated = migrateDashboardDefinition(legacyRecursiveDashboard);
 
     expect(migrated.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(migrated.dataModel).toEqual({ type: 'external', externalRef: 'catalog://sales' });
     expect(migrated.pages[0].rootNodeId).toBeTruthy();
     expect(migrated.pages[0].layout[migrated.pages[0].rootNodeId].type).toBe('root');
-    expect(migrated.pages[0].layout[migrated.pages[0].rootNodeId].children).toContain('legacy-grid');
+    expect(migrated.pages[0].layout[migrated.pages[0].rootNodeId].children).toContain(
+      'legacy-grid',
+    );
     expect(migrated.pages[0].layout['legacy-widget-node'].parentId).toBe('legacy-row');
     expect(migrated.pages[0].layout['legacy-widget-node'].meta.widgetRef).toBe('widget-revenue');
     expect(migrated.pages[0].layout['legacy-header-node'].meta.text).toBe('Legacy Header');
@@ -136,7 +142,7 @@ describe('schema migrations', () => {
     });
   });
 
-  it('normalizes legacy navigate actions on current-version documents', () => {
+  it('[schema-and-serialization.MIGRATIONS.2] normalizes legacy navigate actions on current-version documents', () => {
     const migrated = migrateDashboardDefinition(legacyCurrentNavigateDashboard);
 
     expect(migrated.interactions?.[0].action).toEqual({
@@ -204,7 +210,7 @@ interactions:
     });
   });
 
-  it('rejects unsupported schema versions before validation', () => {
+  it('[schema-and-serialization.MIGRATIONS.3] rejects unsupported schema versions before validation', () => {
     expect(() =>
       migrateDashboardDefinition({
         schemaVersion: '9.9.9',

--- a/packages/schema/test/serializers.test.ts
+++ b/packages/schema/test/serializers.test.ts
@@ -43,7 +43,7 @@ describe('JSON Schema generation', () => {
 });
 
 describe('YAML serialization', () => {
-  it('round-trips fixture through YAML', () => {
+  it('[schema-and-serialization.SERIALIZATION.1] round-trips fixture through YAML', () => {
     const parsed = parseFromJSON(fixtureJSON);
     const yaml = serializeToYAML(parsed);
     const reparsed = parseFromYAML(yaml);
@@ -54,7 +54,7 @@ describe('YAML serialization', () => {
     expect(reparsed.pages).toHaveLength(parsed.pages.length);
   });
 
-  it('preserves layout map structure', () => {
+  it('[schema-and-serialization.SERIALIZATION.2] preserves layout map structure', () => {
     const parsed = parseFromJSON(fixtureJSON);
     const yaml = serializeToYAML(parsed);
     const reparsed = parseFromYAML(yaml);
@@ -83,7 +83,7 @@ pages: []
     expect(() => parseFromYAML(badYaml)).toThrow();
   });
 
-  it('JSON and YAML are semantically equivalent', () => {
+  it('[schema-and-serialization.LIBRARY_SCOPE.1] JSON and YAML are semantically equivalent', () => {
     const parsed = parseFromJSON(fixtureJSON);
     const yamlStr = serializeToYAML(parsed);
     const fromYaml = parseFromYAML(yamlStr);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,6 +456,22 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@22.19.17)(happy-dom@20.8.9)(jsdom@29.0.2)
 
+  packages/query-sql:
+    dependencies:
+      '@supersubset/data-model':
+        specifier: workspace:*
+        version: link:../data-model
+    devDependencies:
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@22.19.17)(happy-dom@20.8.9)(jsdom@29.0.2)
+
   packages/runtime:
     dependencies:
       '@supersubset/data-model':
@@ -13304,7 +13320,7 @@ snapshots:
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(postcss@8.5.13)(yaml@2.8.3)
       resolve-from: 5.0.0
-      rollup: 4.60.1
+      rollup: 4.60.2
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 8.6.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.8.2))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^8.6.0
-        version: 8.6.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.2)(storybook@8.6.18(prettier@3.8.2))(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(yaml@2.8.3))
+        version: 8.6.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.2)(storybook@8.6.18(prettier@3.8.2))(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(yaml@2.9.0))
       eslint:
         specifier: ^10.2.0
         version: 10.2.0
@@ -62,6 +62,9 @@ importers:
       typescript-eslint:
         specifier: ^8.58.2
         version: 8.58.2(eslint@10.2.0)(typescript@5.9.3)
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
   examples/nextjs-ecommerce:
     dependencies:
@@ -163,7 +166,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
@@ -179,7 +182,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
@@ -195,7 +198,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
@@ -211,7 +214,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
@@ -254,7 +257,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
@@ -288,7 +291,7 @@ importers:
         version: 22.19.17
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
@@ -304,7 +307,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
@@ -353,7 +356,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
@@ -426,10 +429,10 @@ importers:
     dependencies:
       '@astrojs/starlight':
         specifier: ^0.38.4
-        version: 0.38.4(astro@6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))
+        version: 0.38.4(astro@6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.9.0))
       astro:
         specifier: ^6.1.6
-        version: 6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)
+        version: 6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.9.0)
       sharp:
         specifier: ^0.33.0
         version: 0.33.5
@@ -445,7 +448,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
@@ -482,7 +485,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
@@ -520,7 +523,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
@@ -6679,6 +6682,11 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -6786,12 +6794,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.4(astro@6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))':
+  '@astrojs/mdx@5.0.4(astro@6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.9.0))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.1
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)
+      astro: 6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.9.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -6815,17 +6823,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.2
 
-  '@astrojs/starlight@0.38.4(astro@6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))':
+  '@astrojs/starlight@0.38.4(astro@6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.9.0))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.1
-      '@astrojs/mdx': 5.0.4(astro@6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))
+      '@astrojs/mdx': 5.0.4(astro@6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.9.0))
       '@astrojs/sitemap': 3.7.2
       '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)
-      astro-expressive-code: 0.41.7(astro@6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))
+      astro: 6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.9.0)
+      astro-expressive-code: 0.41.7(astro@6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.9.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -8364,12 +8372,12 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.34.49
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(yaml@2.9.0))':
     dependencies:
       glob: 10.5.0
       magic-string: 0.27.0
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 7.3.2(@types/node@22.19.17)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(yaml@2.9.0)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -9174,13 +9182,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-vite@8.6.18(storybook@8.6.18(prettier@3.8.2))(vite@7.3.2(@types/node@22.19.17)(yaml@2.8.3))':
+  '@storybook/builder-vite@8.6.18(storybook@8.6.18(prettier@3.8.2))(vite@7.3.2(@types/node@22.19.17)(yaml@2.9.0))':
     dependencies:
       '@storybook/csf-plugin': 8.6.18(storybook@8.6.18(prettier@3.8.2))
       browser-assert: 1.2.1
       storybook: 8.6.18(prettier@3.8.2)
       ts-dedent: 2.2.0
-      vite: 7.3.2(@types/node@22.19.17)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(yaml@2.9.0)
 
   '@storybook/components@8.6.18(storybook@8.6.18(prettier@3.8.2))':
     dependencies:
@@ -9244,11 +9252,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.18(prettier@3.8.2)
 
-  '@storybook/react-vite@8.6.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.2)(storybook@8.6.18(prettier@3.8.2))(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(yaml@2.8.3))':
+  '@storybook/react-vite@8.6.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.2)(storybook@8.6.18(prettier@3.8.2))(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(yaml@2.9.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(yaml@2.9.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
-      '@storybook/builder-vite': 8.6.18(storybook@8.6.18(prettier@3.8.2))(vite@7.3.2(@types/node@22.19.17)(yaml@2.8.3))
+      '@storybook/builder-vite': 8.6.18(storybook@8.6.18(prettier@3.8.2))(vite@7.3.2(@types/node@22.19.17)(yaml@2.9.0))
       '@storybook/react': 8.6.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.18(prettier@3.8.2))(typescript@5.9.3)
       find-up: 5.0.0
       magic-string: 0.30.21
@@ -9258,7 +9266,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 8.6.18(prettier@3.8.2)
       tsconfig-paths: 4.2.0
-      vite: 7.3.2(@types/node@22.19.17)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(yaml@2.9.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -9820,12 +9828,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.7(astro@6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)):
+  astro-expressive-code@0.41.7(astro@6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.9.0)):
     dependencies:
-      astro: 6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)
+      astro: 6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.9.0)
       rehype-expressive-code: 0.41.7
 
-  astro@6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3):
+  astro@6.2.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.9.0
@@ -9876,8 +9884,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.2(@types/node@22.19.17)(yaml@2.8.3)
-      vitefu: 1.1.3(vite@7.3.2(@types/node@22.19.17)(yaml@2.8.3))
+      vite: 7.3.2(@types/node@22.19.17)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.2(@types/node@22.19.17)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.2
@@ -11377,7 +11385,7 @@ snapshots:
       picomatch: 4.0.4
       string-argv: 0.3.2
       tinyexec: 1.1.1
-      yaml: 2.8.3
+      yaml: 2.9.0
 
   listr2@9.0.5:
     dependencies:
@@ -12096,7 +12104,7 @@ snapshots:
       tree-kill: 1.2.2
       tsconfig-paths: 4.2.0
       tslib: 2.3.0
-      yaml: 2.8.3
+      yaml: 2.9.0
       yargs: 17.7.2
       yargs-parser: 21.1.1
     optionalDependencies:
@@ -12337,6 +12345,13 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.13
       yaml: 2.8.3
+
+  postcss-load-config@6.0.1(postcss@8.5.13)(yaml@2.9.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.13
+      yaml: 2.9.0
 
   postcss-nested@6.2.0(postcss@8.5.13):
     dependencies:
@@ -13304,6 +13319,34 @@ snapshots:
       - tsx
       - yaml
 
+  tsup@8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.9.0):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.13)(yaml@2.9.0)
+      resolve-from: 5.0.0
+      rollup: 4.60.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.13
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -13531,7 +13574,7 @@ snapshots:
       '@types/node': 22.19.17
       fsevents: 2.3.3
 
-  vite@7.3.2(@types/node@22.19.17)(yaml@2.8.3):
+  vite@7.3.2(@types/node@22.19.17)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -13542,11 +13585,11 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.17
       fsevents: 2.3.3
-      yaml: 2.8.3
+      yaml: 2.9.0
 
-  vitefu@1.1.3(vite@7.3.2(@types/node@22.19.17)(yaml@2.8.3)):
+  vitefu@1.1.3(vite@7.3.2(@types/node@22.19.17)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(yaml@2.9.0)
 
   vitest@1.6.1(@types/node@22.19.17)(happy-dom@20.8.9)(jsdom@29.0.2):
     dependencies:
@@ -13714,6 +13757,8 @@ snapshots:
   yaml@1.10.3: {}
 
   yaml@2.8.3: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/tools/requirements/fixtures/bad-req-key/features/bad-req-key.feature.yaml
+++ b/tools/requirements/fixtures/bad-req-key/features/bad-req-key.feature.yaml
@@ -1,0 +1,13 @@
+feature:
+  name: bad-req-key
+  product: supersubset
+components:
+  DEMO:
+    requirements:
+      one:
+        requirement: Invalid requirement key shape.
+constraints:
+  PLATFORM:
+    requirements:
+      1:
+        requirement: Default platform scope applies.

--- a/tools/requirements/fixtures/bad-req-key/features/references/acai-feature-yaml.yaml
+++ b/tools/requirements/fixtures/bad-req-key/features/references/acai-feature-yaml.yaml
@@ -1,0 +1,2 @@
+placeholder: true
+source: acai-feature-yaml fixture copy

--- a/tools/requirements/fixtures/bad-req-key/features/references/platforms.yaml
+++ b/tools/requirements/fixtures/bad-req-key/features/references/platforms.yaml
@@ -1,0 +1,7 @@
+platforms:
+  web:
+    name: Web
+    description: Web app behavior.
+  native_app:
+    name: Native app
+    description: Expo React Native app behavior.

--- a/tools/requirements/fixtures/bad-req-key/features/references/term-yaml.schema.yaml
+++ b/tools/requirements/fixtures/bad-req-key/features/references/term-yaml.schema.yaml
@@ -1,0 +1,2 @@
+placeholder: true
+source: term-yaml.schema fixture copy

--- a/tools/requirements/fixtures/bad-ui-key/features/references/acai-feature-yaml.yaml
+++ b/tools/requirements/fixtures/bad-ui-key/features/references/acai-feature-yaml.yaml
@@ -1,0 +1,2 @@
+placeholder: true
+source: acai-feature-yaml fixture copy

--- a/tools/requirements/fixtures/bad-ui-key/features/references/platforms.yaml
+++ b/tools/requirements/fixtures/bad-ui-key/features/references/platforms.yaml
@@ -1,0 +1,7 @@
+platforms:
+  web:
+    name: Web
+    description: Web app behavior.
+  native_app:
+    name: Native app
+    description: Expo React Native app behavior.

--- a/tools/requirements/fixtures/bad-ui-key/features/references/term-yaml.schema.yaml
+++ b/tools/requirements/fixtures/bad-ui-key/features/references/term-yaml.schema.yaml
@@ -1,0 +1,2 @@
+placeholder: true
+source: term-yaml.schema fixture copy

--- a/tools/requirements/fixtures/bad-ui-key/features/terms/widget.term.yaml
+++ b/tools/requirements/fixtures/bad-ui-key/features/terms/widget.term.yaml
@@ -1,0 +1,7 @@
+term:
+  id: widget
+  definition: A UI widget reference fixture.
+  references:
+    ui:
+      native_app:
+        - packages/mobile-app/src/screens/Example.tsx

--- a/tools/requirements/fixtures/empty-feature/features/references/acai-feature-yaml.yaml
+++ b/tools/requirements/fixtures/empty-feature/features/references/acai-feature-yaml.yaml
@@ -1,0 +1,2 @@
+placeholder: true
+source: acai-feature-yaml fixture copy

--- a/tools/requirements/fixtures/empty-feature/features/references/platforms.yaml
+++ b/tools/requirements/fixtures/empty-feature/features/references/platforms.yaml
@@ -1,0 +1,7 @@
+platforms:
+  web:
+    name: Web
+    description: Web app behavior.
+  native_app:
+    name: Native app
+    description: Expo React Native app behavior.

--- a/tools/requirements/fixtures/empty-feature/features/references/term-yaml.schema.yaml
+++ b/tools/requirements/fixtures/empty-feature/features/references/term-yaml.schema.yaml
@@ -1,0 +1,2 @@
+placeholder: true
+source: term-yaml.schema fixture copy

--- a/tools/requirements/fixtures/extra-top-level/features/extra-top-level.feature.yaml
+++ b/tools/requirements/fixtures/extra-top-level/features/extra-top-level.feature.yaml
@@ -1,0 +1,14 @@
+feature:
+  name: extra-top-level
+  product: supersubset
+components:
+  DEMO:
+    requirements:
+      1:
+        requirement: Baseline requirement.
+constraints:
+  PLATFORM:
+    requirements:
+      1:
+        requirement: Default platform scope applies.
+terms: {}

--- a/tools/requirements/fixtures/extra-top-level/features/references/acai-feature-yaml.yaml
+++ b/tools/requirements/fixtures/extra-top-level/features/references/acai-feature-yaml.yaml
@@ -1,0 +1,2 @@
+placeholder: true
+source: acai-feature-yaml fixture copy

--- a/tools/requirements/fixtures/extra-top-level/features/references/platforms.yaml
+++ b/tools/requirements/fixtures/extra-top-level/features/references/platforms.yaml
@@ -1,0 +1,7 @@
+platforms:
+  web:
+    name: Web
+    description: Web app behavior.
+  native_app:
+    name: Native app
+    description: Expo React Native app behavior.

--- a/tools/requirements/fixtures/extra-top-level/features/references/term-yaml.schema.yaml
+++ b/tools/requirements/fixtures/extra-top-level/features/references/term-yaml.schema.yaml
@@ -1,0 +1,2 @@
+placeholder: true
+source: term-yaml.schema fixture copy

--- a/tools/requirements/fixtures/hyphen-key/features/hyphen-key.feature.yaml
+++ b/tools/requirements/fixtures/hyphen-key/features/hyphen-key.feature.yaml
@@ -1,0 +1,13 @@
+feature:
+  name: hyphen-key
+  product: supersubset
+components:
+  DEMO:
+    requirements:
+      '1-1':
+        requirement: Nested numeric requirement keys must stay quoted in YAML.
+constraints:
+  PLATFORM:
+    requirements:
+      1:
+        requirement: Default platform scope applies.

--- a/tools/requirements/fixtures/hyphen-key/features/references/acai-feature-yaml.yaml
+++ b/tools/requirements/fixtures/hyphen-key/features/references/acai-feature-yaml.yaml
@@ -1,0 +1,2 @@
+placeholder: true
+source: acai-feature-yaml fixture copy

--- a/tools/requirements/fixtures/hyphen-key/features/references/platforms.yaml
+++ b/tools/requirements/fixtures/hyphen-key/features/references/platforms.yaml
@@ -1,0 +1,7 @@
+platforms:
+  web:
+    name: Web
+    description: Web app behavior.
+  native_app:
+    name: Native app
+    description: Expo React Native app behavior.

--- a/tools/requirements/fixtures/hyphen-key/features/references/term-yaml.schema.yaml
+++ b/tools/requirements/fixtures/hyphen-key/features/references/term-yaml.schema.yaml
@@ -1,0 +1,2 @@
+placeholder: true
+source: term-yaml.schema fixture copy

--- a/tools/requirements/fixtures/orphan-acid/features/orphan-acid.feature.yaml
+++ b/tools/requirements/fixtures/orphan-acid/features/orphan-acid.feature.yaml
@@ -1,0 +1,13 @@
+feature:
+  name: orphan-acid
+  product: supersubset
+components:
+  DEMO:
+    requirements:
+      1:
+        requirement: A valid requirement with no matching test prefix in this fixture.
+constraints:
+  PLATFORM:
+    requirements:
+      1:
+        requirement: Default platform scope applies.

--- a/tools/requirements/fixtures/orphan-acid/features/references/acai-feature-yaml.yaml
+++ b/tools/requirements/fixtures/orphan-acid/features/references/acai-feature-yaml.yaml
@@ -1,0 +1,2 @@
+placeholder: true
+source: acai-feature-yaml fixture copy

--- a/tools/requirements/fixtures/orphan-acid/features/references/platforms.yaml
+++ b/tools/requirements/fixtures/orphan-acid/features/references/platforms.yaml
@@ -1,0 +1,7 @@
+platforms:
+  web:
+    name: Web
+    description: Web app behavior.
+  native_app:
+    name: Native app
+    description: Expo React Native app behavior.

--- a/tools/requirements/fixtures/orphan-acid/features/references/term-yaml.schema.yaml
+++ b/tools/requirements/fixtures/orphan-acid/features/references/term-yaml.schema.yaml
@@ -1,0 +1,2 @@
+placeholder: true
+source: term-yaml.schema fixture copy

--- a/tools/requirements/fixtures/orphan-acid/orphan.spec.ts
+++ b/tools/requirements/fixtures/orphan-acid/orphan.spec.ts
@@ -1,0 +1,5 @@
+describe('orphan fixture', () => {
+  it('[orphan-acid.DEMO.99] references a missing requirement', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/tools/requirements/fixtures/shared/references/acai-feature-yaml.yaml
+++ b/tools/requirements/fixtures/shared/references/acai-feature-yaml.yaml
@@ -1,0 +1,2 @@
+placeholder: true
+source: acai-feature-yaml fixture copy

--- a/tools/requirements/fixtures/shared/references/platforms.yaml
+++ b/tools/requirements/fixtures/shared/references/platforms.yaml
@@ -1,0 +1,7 @@
+platforms:
+  web:
+    name: Web
+    description: Web app behavior.
+  native_app:
+    name: Native app
+    description: Expo React Native app behavior.

--- a/tools/requirements/fixtures/shared/references/term-yaml.schema.yaml
+++ b/tools/requirements/fixtures/shared/references/term-yaml.schema.yaml
@@ -1,0 +1,2 @@
+placeholder: true
+source: term-yaml.schema fixture copy

--- a/tools/requirements/fixtures/shared/terms/user.term.yaml
+++ b/tools/requirements/fixtures/shared/terms/user.term.yaml
@@ -1,0 +1,3 @@
+term:
+  id: user
+  definition: A Wandir account holder.

--- a/tools/requirements/fixtures/valid-minimal/features/references/acai-feature-yaml.yaml
+++ b/tools/requirements/fixtures/valid-minimal/features/references/acai-feature-yaml.yaml
@@ -1,0 +1,2 @@
+placeholder: true
+source: acai-feature-yaml fixture copy

--- a/tools/requirements/fixtures/valid-minimal/features/references/platforms.yaml
+++ b/tools/requirements/fixtures/valid-minimal/features/references/platforms.yaml
@@ -1,0 +1,7 @@
+platforms:
+  web:
+    name: Web
+    description: Web app behavior.
+  native_app:
+    name: Native app
+    description: Expo React Native app behavior.

--- a/tools/requirements/fixtures/valid-minimal/features/references/term-yaml.schema.yaml
+++ b/tools/requirements/fixtures/valid-minimal/features/references/term-yaml.schema.yaml
@@ -1,0 +1,2 @@
+placeholder: true
+source: term-yaml.schema fixture copy

--- a/tools/requirements/fixtures/valid-minimal/features/terms/user.term.yaml
+++ b/tools/requirements/fixtures/valid-minimal/features/terms/user.term.yaml
@@ -1,0 +1,3 @@
+term:
+  id: user
+  definition: A Wandir account holder.

--- a/tools/requirements/fixtures/valid-minimal/features/valid-minimal.feature.yaml
+++ b/tools/requirements/fixtures/valid-minimal/features/valid-minimal.feature.yaml
@@ -1,0 +1,13 @@
+feature:
+  name: valid-minimal
+  product: supersubset
+components:
+  DEMO:
+    requirements:
+      1:
+        requirement: A *user* can sign in.
+constraints:
+  PLATFORM:
+    requirements:
+      1:
+        requirement: Default platform scope applies to both web and native_app.

--- a/tools/requirements/validate-feature-specs.mjs
+++ b/tools/requirements/validate-feature-specs.mjs
@@ -1,0 +1,916 @@
+#!/usr/bin/env node
+
+/**
+ * Feature spec and Acai ID test-prefix validator.
+ *
+ * Usage:
+ *   node tools/requirements/validate-feature-specs.mjs [--coverage] [--json] [--root <path>]
+ *
+ * npm run validate:requirements
+ * npm run requirements:coverage
+ * npm run --silent requirements:coverage:json
+ * npm run test:requirements-validator
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { basename, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+
+const DEFAULT_ROOT = resolve(import.meta.dirname, '../..');
+const ACID = /\[([a-z0-9-]+\.[A-Z0-9_]+\.\d+(?:-\d+)*)\]/g;
+const EMPHASIZED_TERM = /\*([^*]+)\*/g;
+const GROUP_KEY = /^[A-Z][A-Z0-9_]*$/;
+const REQUIREMENT_KEY = /^\d+(?:-\d+)*$/;
+const TERM_ID = /^[a-z][a-z0-9_]*$/;
+const FEATURE_TOP_LEVEL_KEYS = new Set(['feature', 'components', 'constraints']);
+const EXPECTED_PRODUCT = 'supersubset';
+const TEST_SCAN_SKIP_DIRS = new Set([
+  '.git',
+  '.nx',
+  '.next',
+  '.cache',
+  '.expo',
+  'node_modules',
+  'dist',
+  'coverage',
+  'fixtures',
+]);
+const KNOWN_CLI_FLAGS = new Set(['--coverage', '--json', '--root', '--help']);
+
+/** @type {string} */
+let ROOT = DEFAULT_ROOT;
+const errors = [];
+const warnings = [];
+
+/** @type {string[]} */
+let featureFiles = [];
+/** @type {string[]} */
+let termFiles = [];
+/** @type {string[]} */
+let referenceFiles = [];
+/** @type {string} */
+let platformFile = '';
+/** @type {string[]} */
+let testScanRoots = [DEFAULT_ROOT];
+
+/** @type {Set<string>} */
+let termIds = new Set();
+/** @type {Map<string, string>} */
+const termPhraseIndex = new Map();
+
+/** @type {Record<string, string>} */
+const specIds = {};
+/** @type {Record<string, { path: string, feature: string, text: string }>} */
+const specIdMeta = {};
+
+/**
+ * @param {string[]} argv
+ */
+function parseCliArgs(argv) {
+  /** @type {{ root: string, coverageMode: boolean, jsonOutput: boolean, help: boolean, unknownArgs: string[] }} */
+  const parsed = {
+    root: DEFAULT_ROOT,
+    coverageMode: false,
+    jsonOutput: false,
+    help: false,
+    unknownArgs: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    if (arg === '--coverage') {
+      parsed.coverageMode = true;
+      continue;
+    }
+    if (arg === '--json') {
+      parsed.jsonOutput = true;
+      continue;
+    }
+    if (arg === '--root') {
+      const value = argv[index + 1];
+      if (!value) {
+        parsed.unknownArgs.push('--root (missing value)');
+        break;
+      }
+      parsed.root = resolve(value);
+      index += 1;
+      continue;
+    }
+    if (KNOWN_CLI_FLAGS.has(arg) || arg.startsWith('--root=')) {
+      parsed.unknownArgs.push(arg);
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      parsed.unknownArgs.push(arg);
+      continue;
+    }
+    parsed.unknownArgs.push(arg);
+  }
+
+  if (argv.some((arg) => arg.startsWith('--root='))) {
+    parsed.unknownArgs.push('--root=... (use --root <path>)');
+  }
+
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node tools/requirements/validate-feature-specs.mjs [--coverage] [--json] [--root <path>]
+
+Options:
+  --coverage   Print requirement test coverage by feature
+  --json       Emit coverage as JSON (use with --coverage)
+  --root       Validate a fixture or alternate repo root (for tests)
+  --help       Show this help`);
+}
+
+function resetValidationState(root) {
+  ROOT = root;
+  errors.length = 0;
+  warnings.length = 0;
+  for (const key of Object.keys(specIds)) {
+    delete specIds[key];
+  }
+  for (const key of Object.keys(specIdMeta)) {
+    delete specIdMeta[key];
+  }
+  termPhraseIndex.clear();
+
+  featureFiles = listDirectFiles(join(ROOT, 'features'), (name) =>
+    name.endsWith('.feature.yaml'),
+  ).sort();
+  termFiles = listDirectFiles(join(ROOT, 'features', 'terms'), (name) =>
+    name.endsWith('.term.yaml'),
+  ).sort();
+  referenceFiles = [
+    join(ROOT, 'features', 'references', 'acai-feature-yaml.yaml'),
+    join(ROOT, 'features', 'references', 'term-yaml.schema.yaml'),
+  ];
+  platformFile = join(ROOT, 'features', 'references', 'platforms.yaml');
+  testScanRoots = [ROOT];
+  termIds = new Set(termFiles.map((path) => basename(path, '.term.yaml')));
+}
+
+function listDirectFiles(dir, predicate) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  return entries
+    .filter((entry) => entry.isFile() && predicate(entry.name))
+    .map((entry) => join(dir, entry.name));
+}
+
+function requireObject(path, label, value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    errors.push(`${path}: ${label} must be a map`);
+    return false;
+  }
+  return true;
+}
+
+function nonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function relPath(path) {
+  return relative(ROOT, path);
+}
+
+function normalizeRequirementText(text) {
+  return text.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function requirementText(req) {
+  if (typeof req === 'string') {
+    return req;
+  }
+  if (req && typeof req === 'object' && nonEmptyString(req.requirement)) {
+    return req.requirement;
+  }
+  return '';
+}
+
+function registerTermPhrase(phrase, termId) {
+  if (!nonEmptyString(phrase)) {
+    return;
+  }
+  termPhraseIndex.set(phrase.trim().toLowerCase(), termId);
+  termPhraseIndex.set(phrase.trim().toLowerCase().replace(/-/g, '_'), termId);
+  termPhraseIndex.set(emphasizedTermToFileStem(phrase), termId);
+}
+
+function buildTermPhraseIndex() {
+  for (const path of termFiles) {
+    const loaded = loadYamlFile(path);
+    if (loaded.loadError || !loaded.data?.term || typeof loaded.data.term !== 'object') {
+      continue;
+    }
+    const data = loaded.data;
+
+    const term = data.term;
+    if (!nonEmptyString(term.id)) {
+      continue;
+    }
+
+    registerTermPhrase(term.id, term.id);
+    registerTermPhrase(term.id.replace(/_/g, ' '), term.id);
+
+    if (Array.isArray(term.aliases)) {
+      for (const alias of term.aliases) {
+        registerTermPhrase(alias, term.id);
+        registerTermPhrase(String(alias).replace(/_/g, ' '), term.id);
+      }
+    }
+  }
+}
+
+function resolveEmphasizedTerm(phrase) {
+  const candidates = new Set([
+    phrase.trim().toLowerCase(),
+    phrase.trim().toLowerCase().replace(/-/g, '_'),
+    emphasizedTermToFileStem(phrase),
+  ]);
+
+  for (const candidate of candidates) {
+    if (termPhraseIndex.has(candidate)) {
+      return termPhraseIndex.get(candidate);
+    }
+    if (termIds.has(candidate)) {
+      return candidate;
+    }
+    if (candidate.endsWith('s') && termPhraseIndex.has(candidate.slice(0, -1))) {
+      return termPhraseIndex.get(candidate.slice(0, -1));
+    }
+    if (candidate.endsWith('_links')) {
+      const linkForm = candidate.slice(0, -'_links'.length);
+      if (termPhraseIndex.has(`${linkForm}_link`)) {
+        return termPhraseIndex.get(`${linkForm}_link`);
+      }
+      if (termPhraseIndex.has(linkForm)) {
+        return termPhraseIndex.get(linkForm);
+      }
+    }
+  }
+
+  return null;
+}
+
+function validateStringArray(path, label, value) {
+  if (!Array.isArray(value)) {
+    errors.push(`${path}: ${label} must be an array`);
+    return;
+  }
+
+  value.forEach((item, index) => {
+    if (!nonEmptyString(item)) {
+      errors.push(`${path}: ${label}[${index}] must be a non-empty string`);
+    }
+  });
+}
+
+function validateNamedReferences(path, label, value) {
+  if (!Array.isArray(value)) {
+    errors.push(`${path}: ${label} must be an array`);
+    return;
+  }
+
+  value.forEach((item, index) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      errors.push(`${path}: ${label}[${index}] must be a map`);
+      return;
+    }
+
+    if (!nonEmptyString(item.name)) {
+      errors.push(`${path}: ${label}[${index}].name must be a non-empty string`);
+    }
+
+    if ('schema' in item && !nonEmptyString(item.schema)) {
+      errors.push(`${path}: ${label}[${index}].schema must be a non-empty string`);
+    }
+
+    const extraKeys = Object.keys(item).filter((key) => key !== 'name' && key !== 'schema');
+    if (extraKeys.length > 0) {
+      errors.push(`${path}: ${label}[${index}] has unsupported keys ${extraKeys.join(', ')}`);
+    }
+  });
+}
+
+/**
+ * @returns {{ data: unknown, loadError: string | null }}
+ */
+function loadYamlFile(path) {
+  let text;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch (error) {
+    return { data: null, loadError: `failed to read file: ${error.message}` };
+  }
+
+  if (text.trim().length === 0) {
+    return { data: null, loadError: 'file is empty' };
+  }
+
+  try {
+    const data = parseYaml(text);
+    if (data === null || data === undefined) {
+      return { data: null, loadError: 'parsed to empty/null YAML document' };
+    }
+    return { data, loadError: null };
+  } catch (error) {
+    return { data: null, loadError: `failed to parse YAML: ${error.message}` };
+  }
+}
+
+function reportYamlLoadError(path, { loadError }) {
+  if (loadError) {
+    errors.push(`${path}: ${loadError}`);
+    return true;
+  }
+  return false;
+}
+
+function findTestFiles(dir, results = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    if (TEST_SCAN_SKIP_DIRS.has(entry.name)) {
+      continue;
+    }
+
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      findTestFiles(full, results);
+    } else if (entry.isFile() && /\.(spec|test)\.(ts|tsx|js|jsx)$/.test(entry.name)) {
+      results.push(full);
+    }
+  }
+
+  return results;
+}
+
+function emphasizedTermToFileStem(phrase) {
+  return phrase.trim().toLowerCase().replace(/\s+/g, '_');
+}
+
+function validateEmphasizedTerms(path, acid, text) {
+  for (const match of text.matchAll(EMPHASIZED_TERM)) {
+    const phrase = match[1];
+    const termId = resolveEmphasizedTerm(phrase);
+    if (!termId) {
+      errors.push(
+        `${path}: ${acid} emphasizes *${phrase}* but no matching features/terms/<term>.term.yaml was found`,
+      );
+      continue;
+    }
+    const termPath = join(ROOT, 'features', 'terms', `${termId}.term.yaml`);
+    if (!existsSync(termPath)) {
+      errors.push(
+        `${path}: ${acid} emphasizes *${phrase}* but features/terms/${termId}.term.yaml is missing`,
+      );
+    }
+  }
+}
+
+function validateTerms() {
+  /** @type {Record<string, string>} */
+  const aliasOwners = {};
+
+  for (const path of termFiles) {
+    const loaded = loadYamlFile(path);
+    if (reportYamlLoadError(path, loaded)) {
+      continue;
+    }
+
+    const data = loaded.data;
+    if (
+      typeof data !== 'object' ||
+      Array.isArray(data) ||
+      Object.keys(data).length !== 1 ||
+      !data.term ||
+      typeof data.term !== 'object'
+    ) {
+      errors.push(`${path}: expected top-level term map only`);
+      continue;
+    }
+
+    const term = data.term;
+    const expectedId = basename(path, '.term.yaml');
+
+    if (term.id !== expectedId) {
+      errors.push(`${path}: term.id must match filename stem ${JSON.stringify(expectedId)}`);
+    }
+
+    if (!nonEmptyString(term.definition)) {
+      errors.push(`${path}: term.definition must be a non-empty string`);
+    }
+
+    if ('platform' in term || 'platforms' in term) {
+      errors.push(`${path}: platform scope belongs in feature specs, not term files`);
+    }
+
+    if (typeof term.id !== 'string' || !TERM_ID.test(term.id)) {
+      errors.push(`${path}: term.id must be lower snake case`);
+    }
+
+    const names = [term.id, ...(Array.isArray(term.aliases) ? term.aliases : [])];
+    for (const name of names) {
+      if (!nonEmptyString(name)) {
+        continue;
+      }
+      const normalized = String(name).trim().toLowerCase();
+      if (aliasOwners[normalized] && aliasOwners[normalized] !== term.id) {
+        warnings.push(
+          `${relPath(path)}: alias ${JSON.stringify(name)} also maps to term ${aliasOwners[normalized]}`,
+        );
+      } else {
+        aliasOwners[normalized] = term.id;
+      }
+    }
+
+    if ('aliases' in term) {
+      validateStringArray(path, 'term.aliases', term.aliases);
+    }
+    if ('notes' in term) {
+      validateStringArray(path, 'term.notes', term.notes);
+    }
+
+    const allowedTermKeys = new Set(['id', 'definition', 'aliases', 'references', 'notes']);
+    for (const key of Object.keys(term)) {
+      if (allowedTermKeys.has(key)) {
+        continue;
+      }
+      if (!TERM_ID.test(key)) {
+        errors.push(`${path}: term.${key} must use lower snake case`);
+        continue;
+      }
+      if (!requireObject(path, `term.${key}`, term[key])) {
+        continue;
+      }
+      if (!Object.values(term[key]).every((item) => nonEmptyString(item))) {
+        errors.push(`${path}: term.${key} must be a compact map of string values`);
+      }
+    }
+
+    if (!('references' in term)) {
+      continue;
+    }
+
+    if (!requireObject(path, 'term.references', term.references)) {
+      continue;
+    }
+
+    const refs = term.references;
+    const allowedRefKeys = new Set([
+      'prisma',
+      'graphql',
+      'ui',
+      'server',
+      'worker',
+      'docs',
+      'adr',
+      'skills',
+      'memory',
+    ]);
+    const unknownRefs = Object.keys(refs).filter((key) => !allowedRefKeys.has(key));
+    if (unknownRefs.length > 0) {
+      errors.push(`${path}: term.references has unsupported keys ${unknownRefs.join(', ')}`);
+    }
+
+    if ('prisma' in refs && requireObject(path, 'term.references.prisma', refs.prisma)) {
+      const extraPrismaKeys = Object.keys(refs.prisma).filter(
+        (key) => key !== 'models' && key !== 'enums',
+      );
+      if (extraPrismaKeys.length > 0) {
+        errors.push(
+          `${path}: term.references.prisma has unsupported keys ${extraPrismaKeys.join(', ')}`,
+        );
+      }
+      if ('models' in refs.prisma) {
+        validateNamedReferences(path, 'term.references.prisma.models', refs.prisma.models);
+      }
+      if ('enums' in refs.prisma) {
+        validateNamedReferences(path, 'term.references.prisma.enums', refs.prisma.enums);
+      }
+    }
+
+    if ('graphql' in refs && requireObject(path, 'term.references.graphql', refs.graphql)) {
+      const extraGraphqlKeys = Object.keys(refs.graphql).filter((key) => key !== 'operations');
+      if (extraGraphqlKeys.length > 0) {
+        errors.push(
+          `${path}: term.references.graphql has unsupported keys ${extraGraphqlKeys.join(', ')}`,
+        );
+      }
+      if ('operations' in refs.graphql) {
+        validateNamedReferences(
+          path,
+          'term.references.graphql.operations',
+          refs.graphql.operations,
+        );
+      }
+    }
+
+    if ('ui' in refs && requireObject(path, 'term.references.ui', refs.ui)) {
+      const extraUiKeys = Object.keys(refs.ui).filter(
+        (key) => key !== 'web' && key !== 'native' && key !== 'shared',
+      );
+      if (extraUiKeys.length > 0) {
+        errors.push(`${path}: term.references.ui has unsupported keys ${extraUiKeys.join(', ')}`);
+      }
+      for (const uiKey of ['web', 'native', 'shared']) {
+        if (uiKey in refs.ui) {
+          validateStringArray(path, `term.references.ui.${uiKey}`, refs.ui[uiKey]);
+        }
+      }
+    }
+
+    for (const refKey of ['server', 'worker', 'docs', 'adr', 'skills', 'memory']) {
+      if (refKey in refs) {
+        validateStringArray(path, `term.references.${refKey}`, refs[refKey]);
+      }
+    }
+  }
+}
+
+function validateFeatures(platformIds) {
+  /** @type {Record<string, string>} */
+  const featureNameOwners = {};
+  /** @type {Record<string, string[]>} */
+  const duplicateRequirementTexts = {};
+
+  for (const path of featureFiles) {
+    const loaded = loadYamlFile(path);
+    if (reportYamlLoadError(path, loaded)) {
+      continue;
+    }
+
+    const data = loaded.data;
+    if (
+      typeof data !== 'object' ||
+      Array.isArray(data) ||
+      !data.feature ||
+      typeof data.feature !== 'object' ||
+      !data.components ||
+      typeof data.components !== 'object' ||
+      !data.constraints ||
+      typeof data.constraints !== 'object'
+    ) {
+      errors.push(`${path}: expected Acai-compatible feature/components/constraints shape`);
+      continue;
+    }
+
+    const extraTopLevelKeys = Object.keys(data).filter((key) => !FEATURE_TOP_LEVEL_KEYS.has(key));
+    if (extraTopLevelKeys.length > 0) {
+      errors.push(`${path}: unsupported top-level keys ${extraTopLevelKeys.join(', ')}`);
+    }
+
+    const featureName = data.feature.name;
+    const expectedFeatureName = basename(path, '.feature.yaml');
+    if (featureName !== expectedFeatureName) {
+      errors.push(
+        `${path}: feature.name ${JSON.stringify(featureName)} must match filename stem ${JSON.stringify(expectedFeatureName)}`,
+      );
+    }
+
+    if (featureNameOwners[featureName] && featureNameOwners[featureName] !== path) {
+      errors.push(
+        `${path}: duplicate feature.name ${JSON.stringify(featureName)} also defined in ${featureNameOwners[featureName]}`,
+      );
+    } else {
+      featureNameOwners[featureName] = path;
+    }
+
+    if ('product' in data.feature && data.feature.product !== EXPECTED_PRODUCT) {
+      errors.push(`${path}: feature.product must be ${JSON.stringify(EXPECTED_PRODUCT)}`);
+    }
+
+    const groupKeys = new Set();
+    for (const section of ['components', 'constraints']) {
+      for (const groupKey of Object.keys(data[section])) {
+        if (groupKeys.has(groupKey)) {
+          errors.push(
+            `${path}: duplicate group key ${groupKey} appears in both components and constraints`,
+          );
+        }
+        groupKeys.add(groupKey);
+      }
+    }
+
+    for (const section of ['components', 'constraints']) {
+      for (const [groupKey, group] of Object.entries(data[section])) {
+        if (!GROUP_KEY.test(groupKey)) {
+          errors.push(`${path}: ${section}.${groupKey} must use uppercase snake case group keys`);
+        }
+        const requirements = group?.requirements ?? {};
+        for (const [reqKey, req] of Object.entries(requirements)) {
+          if (!REQUIREMENT_KEY.test(String(reqKey))) {
+            errors.push(
+              `${path}: ${section}.${groupKey}.requirements.${reqKey} must use numeric keys like 1 or 1-1`,
+            );
+            continue;
+          }
+          const id = `${featureName}.${groupKey}.${reqKey}`;
+          if (specIds[id]) {
+            errors.push(`${path}: duplicate ACID ${id} also defined in ${specIds[id]}`);
+          }
+          specIds[id] = path;
+
+          const text = requirementText(req);
+          if (nonEmptyString(text)) {
+            specIdMeta[id] = { path, feature: featureName, text };
+            validateEmphasizedTerms(path, id, text);
+
+            const normalized = normalizeRequirementText(text);
+            if (!duplicateRequirementTexts[normalized]) {
+              duplicateRequirementTexts[normalized] = [];
+            }
+            duplicateRequirementTexts[normalized].push(id);
+          }
+
+          const note = req && typeof req === 'object' && req.note ? String(req.note) : '';
+          for (const match of note.matchAll(/(?:^|\n)\s*platforms:\s*([a-z0-9_, ]+)/g)) {
+            for (const raw of match[1].split(',')) {
+              const platformId = raw.trim();
+              if (!platformId) {
+                continue;
+              }
+              if (!platformIds.includes(platformId)) {
+                errors.push(
+                  `${path}: ${id} references unknown platform ${JSON.stringify(platformId)}`,
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  for (const [text, ids] of Object.entries(duplicateRequirementTexts)) {
+    if (ids.length < 2) {
+      continue;
+    }
+    warnings.push(
+      `duplicate requirement text across ${ids.join(', ')} (${text.slice(0, 80)}${text.length > 80 ? '...' : ''})`,
+    );
+  }
+}
+
+function collectTestRefs() {
+  /** @type {Record<string, number>} */
+  const testRefs = {};
+  const seen = new Set();
+  for (const scanRoot of testScanRoots) {
+    for (const path of findTestFiles(scanRoot).sort()) {
+      if (seen.has(path)) {
+        continue;
+      }
+      seen.add(path);
+
+      const rel = relative(ROOT, path);
+      if (rel.split(/[/\\]/).some((part) => TEST_SCAN_SKIP_DIRS.has(part))) {
+        continue;
+      }
+
+      const text = readFileSync(path, 'utf8');
+      for (const match of text.matchAll(ACID)) {
+        const id = match[1];
+        testRefs[id] = (testRefs[id] ?? 0) + 1;
+      }
+    }
+  }
+  return testRefs;
+}
+
+function printDiagnostics(options = {}) {
+  const { exitOnError = true } = options;
+  if (warnings.length > 0) {
+    console.log('\nWarnings:');
+    for (const warning of warnings) {
+      console.log(`- ${warning}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error('\nErrors:');
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    if (exitOnError) {
+      process.exit(1);
+    }
+  }
+}
+
+/**
+ * @param {{ root?: string, scanTests?: boolean }} [options]
+ */
+export function runValidation(options = {}) {
+  const root = options.root ?? DEFAULT_ROOT;
+  const scanTests = options.scanTests ?? true;
+
+  resetValidationState(root);
+
+  for (const referenceFile of referenceFiles) {
+    if (!existsSync(referenceFile)) {
+      continue;
+    }
+    reportYamlLoadError(referenceFile, loadYamlFile(referenceFile));
+  }
+
+  /** @type {string[]} */
+  let platformIds = [];
+  const platformsLoaded = loadYamlFile(platformFile);
+  if (!existsSync(platformFile)) {
+    errors.push(`${platformFile}: missing platforms file`);
+  } else if (!reportYamlLoadError(platformFile, platformsLoaded)) {
+    const platformsData = platformsLoaded.data;
+    if (platformsData?.platforms && typeof platformsData.platforms === 'object') {
+      platformIds = Object.keys(platformsData.platforms);
+    } else {
+      errors.push(`${platformFile}: expected top-level platforms map`);
+    }
+  }
+
+  buildTermPhraseIndex();
+  validateFeatures(platformIds);
+  validateTerms();
+
+  const testRefs = scanTests ? collectTestRefs() : {};
+  if (scanTests) {
+    applyTestRefChecks(testRefs);
+  }
+
+  return {
+    root,
+    errors: [...errors],
+    warnings: [...warnings],
+    specIds: { ...specIds },
+    testRefs: { ...testRefs },
+    featureFiles: [...featureFiles],
+    termFiles: [...termFiles],
+  };
+}
+
+function applyTestRefChecks(testRefs) {
+  const orphans = Object.keys(testRefs)
+    .filter((id) => !(id in specIds))
+    .sort();
+  for (const id of orphans) {
+    errors.push(`test reference ${id} has no matching feature requirement`);
+  }
+
+  for (const [id, count] of Object.entries(testRefs)
+    .filter(([, count]) => count > 15)
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))) {
+    warnings.push(`${id} is referenced ${count} times; verify this is not bucket tagging`);
+  }
+}
+
+function main() {
+  const cli = parseCliArgs(process.argv.slice(2));
+  if (cli.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (cli.unknownArgs.length > 0) {
+    console.error(`Unknown argument(s): ${cli.unknownArgs.join(', ')}`);
+    printHelp();
+    process.exit(1);
+  }
+
+  const result = runValidation({ root: cli.root, scanTests: true });
+
+  if (cli.coverageMode) {
+    if (result.errors.length > 0) {
+      printDiagnostics({ exitOnError: false });
+    }
+    printCoverageReport(result.testRefs, cli.jsonOutput);
+    if (result.warnings.length > 0 && !cli.jsonOutput) {
+      console.log('\nWarnings:');
+      for (const warning of result.warnings) {
+        console.log(`- ${warning}`);
+      }
+    }
+    process.exit(0);
+  }
+
+  printSummary(result.testRefs);
+  printDiagnostics();
+}
+
+function printSummary(testRefs) {
+  const orphans = Object.keys(testRefs)
+    .filter((id) => !(id in specIds))
+    .sort();
+  const uncoveredCount = Object.keys(specIds).filter((id) => !(id in testRefs)).length;
+  const totalTestRefs = Object.values(testRefs).reduce((sum, count) => sum + count, 0);
+
+  console.log(`Feature specs: ${featureFiles.length}`);
+  console.log(`Glossary terms: ${termFiles.length}`);
+  console.log(`Spec ACIDs: ${Object.keys(specIds).length}`);
+  console.log(`Unique ACIDs in tests: ${Object.keys(testRefs).length}`);
+  console.log(`Total test ACID refs: ${totalTestRefs}`);
+  console.log(`Orphan test refs: ${orphans.length}`);
+  console.log(`Uncovered spec ACIDs: ${uncoveredCount}`);
+}
+
+function buildCoverageReport(testRefs) {
+  /** @type {Record<string, { total: number, covered: string[], uncovered: string[] }>} */
+  const byFeature = {};
+
+  for (const id of Object.keys(specIds).sort()) {
+    const feature = specIdMeta[id]?.feature ?? id.split('.', 1)[0];
+    if (!byFeature[feature]) {
+      byFeature[feature] = { total: 0, covered: [], uncovered: [] };
+    }
+    byFeature[feature].total += 1;
+    if (id in testRefs) {
+      byFeature[feature].covered.push(id);
+    } else {
+      byFeature[feature].uncovered.push(id);
+    }
+  }
+
+  const features = Object.keys(byFeature).sort();
+  const total = Object.keys(specIds).length;
+  const covered = Object.keys(specIds).filter((id) => id in testRefs).length;
+
+  return {
+    summary: {
+      featureSpecs: featureFiles.length,
+      glossaryTerms: termFiles.length,
+      specAcids: total,
+      coveredAcids: covered,
+      uncoveredAcids: total - covered,
+      coveragePercent: total === 0 ? 0 : Number(((covered / total) * 100).toFixed(1)),
+      uniqueAcidsInTests: Object.keys(testRefs).length,
+      totalTestAcidRefs: Object.values(testRefs).reduce((sum, count) => sum + count, 0),
+    },
+    features: features.map((feature) => {
+      const entry = byFeature[feature];
+      const featureCovered = entry.covered.length;
+      return {
+        feature,
+        total: entry.total,
+        covered: featureCovered,
+        uncovered: entry.uncovered.length,
+        coveragePercent:
+          entry.total === 0 ? 0 : Number(((featureCovered / entry.total) * 100).toFixed(1)),
+        coveredAcids: entry.covered.sort(),
+        uncoveredAcids: entry.uncovered.sort(),
+        testRefCounts: Object.fromEntries(
+          entry.covered
+            .map((id) => [id, testRefs[id] ?? 0])
+            .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0])),
+        ),
+      };
+    }),
+  };
+}
+
+function printCoverageReport(testRefs, jsonOutput = false) {
+  const report = buildCoverageReport(testRefs);
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  console.log('Requirement test coverage');
+  console.log('=========================');
+  console.log(
+    `Overall: ${report.summary.coveredAcids}/${report.summary.specAcids} (${report.summary.coveragePercent}%)`,
+  );
+  console.log('');
+
+  for (const feature of report.features) {
+    console.log(
+      `${feature.feature}: ${feature.covered}/${feature.total} (${feature.coveragePercent}%)`,
+    );
+    if (feature.uncoveredAcids.length > 0) {
+      console.log('  uncovered:');
+      for (const id of feature.uncoveredAcids) {
+        console.log(`    - ${id}`);
+      }
+    }
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tools/requirements/validate-feature-specs.spec.mjs
+++ b/tools/requirements/validate-feature-specs.spec.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import { runValidation } from './validate-feature-specs.mjs';
+
+const TOOL_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(TOOL_DIR, '../..');
+const FIXTURES_ROOT = join(TOOL_DIR, 'fixtures');
+
+/** @param {string} name */
+function fixtureRoot(name) {
+  return join(FIXTURES_ROOT, name);
+}
+
+/** @param {{ errors: string[] }} result */
+function errorText(result) {
+  return result.errors.join('\n');
+}
+
+test('repo requirements layer passes validation', () => {
+  const result = runValidation({ root: REPO_ROOT, scanTests: true });
+  assert.equal(result.errors.length, 0, `expected no validation errors:\n${errorText(result)}`);
+});
+
+test('repo term files do not use ui.native_app keys', () => {
+  const result = runValidation({ root: REPO_ROOT, scanTests: false });
+  const uiKeyErrors = result.errors.filter((error) =>
+    error.includes('term.references.ui has unsupported keys native_app'),
+  );
+  assert.deepEqual(uiKeyErrors, []);
+});
+
+test('valid minimal fixture passes', () => {
+  const result = runValidation({ root: fixtureRoot('valid-minimal'), scanTests: false });
+  assert.equal(result.errors.length, 0, errorText(result));
+  assert.ok('valid-minimal.DEMO.1' in result.specIds);
+});
+
+test('empty feature file fails validation', () => {
+  const result = runValidation({ root: fixtureRoot('empty-feature'), scanTests: false });
+  assert.ok(result.errors.some((error) => error.includes('file is empty')));
+});
+
+test('term ui.native_app key fails validation', () => {
+  const result = runValidation({ root: fixtureRoot('bad-ui-key'), scanTests: false });
+  assert.ok(
+    result.errors.some((error) =>
+      error.includes('term.references.ui has unsupported keys native_app'),
+    ),
+  );
+});
+
+test('extra feature top-level keys fail validation', () => {
+  const result = runValidation({ root: fixtureRoot('extra-top-level'), scanTests: false });
+  assert.ok(result.errors.some((error) => error.includes('unsupported top-level keys terms')));
+});
+
+test('non-numeric requirement keys fail validation', () => {
+  const result = runValidation({ root: fixtureRoot('bad-req-key'), scanTests: false });
+  assert.ok(result.errors.some((error) => error.includes('must use numeric keys like 1 or 1-1')));
+});
+
+test('quoted hyphenated requirement keys pass validation', () => {
+  const result = runValidation({ root: fixtureRoot('hyphen-key'), scanTests: false });
+  assert.equal(result.errors.length, 0, errorText(result));
+  assert.ok('hyphen-key.DEMO.1-1' in result.specIds);
+});
+
+test('orphan test ACIDs fail validation', () => {
+  const result = runValidation({ root: fixtureRoot('orphan-acid'), scanTests: true });
+  assert.ok(
+    result.errors.some((error) =>
+      error.includes('test reference orphan-acid.DEMO.99 has no matching feature requirement'),
+    ),
+  );
+});


### PR DESCRIPTION
Cuts the release from `staging` to `main`. Merging this triggers the Release workflow on `main`, which will auto-open a **chore(release): version packages** PR.

## Included

- **#161** — Centralize SQL generation in `SqlQueryAdapter` (ADR-012). New `@supersubset/query-sql` package, `LogicalQuery.distinct` flag, async field-backed filter resolution in `FilterBar`, search-strategy gating per ADR-009 §3, security boundary docs.
- **#163** — Date-aware dashboard filters (closes #162). `FilterDefinition.dateConfig`, weekly dropdown mode, partial custom ranges → one-sided `gte`/`lte`, shared date utilities in `@supersubset/schema/date-utils`.
- **#164** — Changeset entry for #163.

Two changesets pending consumption:
- `.changeset/sql-query-adapter.md` — minor bump (from #161)
- `.changeset/date-aware-filters.md` — minor bump (from #164, credits #163)

Both bumps are minor; the fixed group versions together.

## After merge

1. Release workflow opens `chore(release): version packages` PR
2. Merge that PR; the next `main` push runs `pnpm release` → `changeset publish` to npm
3. Verify via `npm view @supersubset/runtime version dist-tags`
4. Backport `main → develop` to pull in version bumps + CHANGELOG