### PR TITLE
fix: analytics host integration for Tripmatch dogfooding

### DIFF
--- a/.changeset/analytics-host-integration.md
+++ b/.changeset/analytics-host-integration.md
@@ -1,0 +1,5 @@
+---
+'@supersubset/runtime': patch
+---
+
+Analytics host integration for Tripmatch dogfooding: prefer `config.logicalQuery` in `buildWidgetQuery`, resolve output aliases for yField/yFields and combo bar/line fields, combo chart cumulative line series from `cumulativeFromField`, designer chart type switch panel, axis binding repair on select, and inline preview canvas scroll fix.

--- a/.github/skills/bi-visualization-quality/SKILL.md
+++ b/.github/skills/bi-visualization-quality/SKILL.md
@@ -108,6 +108,7 @@ Use this skill to strengthen evidence, not replace it.
 ## See Also
 
 - `.github/skills/testing-strategy/SKILL.md`
+- `.github/skills/chart-feature-testing/SKILL.md`
 - `.github/skills/browser-testing/SKILL.md`
 - `docs/testing/verification-strategy.md`
 - `docs/testing/qa-checklist.md`

--- a/.github/skills/chart-feature-testing/BROWSER-GATES.md
+++ b/.github/skills/chart-feature-testing/BROWSER-GATES.md
@@ -1,0 +1,86 @@
+# Chart Feature Testing — Browser Gates (required)
+
+Unit tests in `@supersubset/designer` are **necessary but not sufficient**. A fix is not done until these browser gates pass on the host stack.
+
+## Setup
+
+```bash
+export SUPERSET_ROOT=~/apps/supersubset
+export TRIPMATCH_ROOT=~/apps/issue-604-editing-chart-type-d  # or your worktree
+
+cd "$SUPERSET_ROOT/packages/designer" && pnpm build && yalc push
+cd "$TRIPMATCH_ROOT"
+bash tools/verify-yalc-supersubset.sh chart-type-switch-panel
+rm -rf node_modules/.vite
+bash tools/devenv.sh restart ui-app
+```
+
+Hard-refresh the browser (`Cmd+Shift+R`).
+
+## Gate A — Bindings visible on load (P0)
+
+1. `/admin/analytics` → **Revert dashboard to seed** (toast, no dialog)
+2. **Dashboard Editor** tab → wait for **Components** sidebar
+3. Click the **6/12** canvas slot for **Plans created per day** (second row, left chart — not KPI cards)
+4. Right panel must show:
+   - **X-Axis Field:** Event Date (`event_date`)
+   - **Y-Axis Field:** Event Id (`event_id`) — **not** “Select y-axis field…”
+   - **Aggregation:** Count
+
+**MCP check** (`evaluate_script`):
+
+```javascript
+() => {
+  const y = document.querySelector('[data-testid="field-ref-yAxisField"]');
+  const x = document.querySelector('[data-testid="field-ref-xAxisField"]');
+  return {
+    xValue: x?.value,
+    yValue: y?.value,
+    pass: x?.value === 'event_date' && y?.value === 'event_id',
+  };
+};
+```
+
+## Gate B — Chart type switch + publish (P0)
+
+1. With chart selected → **Chart type** → **Bar chart**
+2. Confirm X/Y fields still populated (Gate A selectors)
+3. **Publish**
+4. **Metrics** tab → **Plans created per day** must show **date** X-axis ticks (`2026-03-11`, …), not a single numeric bucket (`415`)
+5. **Dashboard JSON** tab → `plan_chart_day`:
+   - `"type": "bar-chart"`
+   - `"xField": "event_date"`
+   - `"yField": "count"`
+   - `logicalQuery.fields` includes `event_date` + `event_id` count alias
+
+## Gate C — JSON evidence after revert (sanity)
+
+Dashboard JSON → find `plan_chart_day` → must have `config.yField: "count"` and `logicalQuery` even before any edit.
+
+## Failure protocol
+
+If a gate fails:
+
+1. Capture Gate A `evaluate_script` output + screenshot
+2. Confirm yalc marker in `node_modules/.vite/ui-app/deps/@supersubset_designer.js`
+3. Fix in `packages/designer` (load path + chart-type switch preserve list + publish supplement)
+4. Re-run unit tests **and** repeat browser gates
+
+## Why unit tests alone miss these bugs
+
+Puck merges block `defaultProps` (`yAxisField: ''`) **after** `canonicalToPuck()` runs. The editor field panel reads **Puck store** props, not the adapter output. Fixes must include:
+
+- `chartAxisResolveData` on chart blocks (via `puck-config.ts`)
+- `repairChartAxisPropsInPuckData` on designer load/change/publish
+- Remove empty-string axis defaults from chart `defaultProps`
+- `normalizePuckOptionProps` for wrapped select values like `'{"value":"count"}'`
+
+## Login automation note
+
+Tripmatch login is two-step (email → password). Use slow typing on the email field so MUI validation accepts the value before clicking Continue.
+
+## Publish control
+
+Puck **Publish** may be hidden until **Toggle menu bar** is clicked. Query `span` text "Publish" and click its parent if no `<button>` is found.
+
+See also `scripts/browser-verify-bindings.mjs`.

--- a/.github/skills/chart-feature-testing/SKILL.md
+++ b/.github/skills/chart-feature-testing/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: chart-feature-testing
+description: 'End-to-end verification of Supersubset chart features in a host app (Tripmatch/Wandir). Formulate user intents, exercise the Dashboard Editor, and confirm Metrics/runtime behavior. Use when validating chart type switching, field binding round-trips, publish flows, or running a BI quality sweep before release.'
+---
+
+# Chart Feature Testing (Host-Embedded)
+
+## When to Use
+
+- A chart feature ships in `@supersubset/designer` and must work in a **real host** (Tripmatch `/admin/analytics`), not just unit tests
+- You need to verify **editor state ↔ published JSON ↔ Metrics view** stay aligned
+- You are doing a pre-release sweep of chart editing, binding, or visualization quality
+- A bug report mentions “properties look wrong”, “chart broke after publish”, or “type switch clobbered fields”
+
+## Prerequisites
+
+- Supersubset clone (`$SUPERSET_ROOT`) and Tripmatch checkout or issue worktree (`$TRIPMATCH_ROOT`)
+- yalc linked per Tripmatch `.ai/skills/supersubset-development/SKILL.md` (all six packages)
+- Tripmatch dev stack running (`bash tools/devenv.sh up` in the host checkout)
+- Analytics mart seeded when testing real data: `prisma-seed`, `BI_TEST_DATA_GEN_BATCH` (see Tripmatch analytics docs)
+
+## Core loop
+
+```text
+Intent → Editor action → Publish (if persistence matters) → Metrics / JSON evidence
+```
+
+1. **State intent** as a user would (“I want to change this area chart to a bar without losing date on X”)
+2. **Open host**: `http://localhost:<UI_APP_PORT>/admin/analytics` → Dashboard Editor tab
+3. **Login**: `admin@wandir.com` / `11111111` (Tripmatch local seed)
+4. **Select widget** on canvas; confirm property panel reflects bindings
+5. **Make the edit** (chart type, axis field, aggregation, etc.)
+6. **Publish** when testing persistence (Puck header Publish control)
+7. **Verify**:
+   - Dashboard JSON tab: widget `type`, `config.xField` / `config.yField`, `dataBinding`, `logicalQuery`
+   - Metrics tab: chart renders with correct axes/legend (not a single mystery bar)
+8. **Automated checks** (run before/after fixes — **not a substitute for browser gates**):
+
+```bash
+cd "$SUPERSET_ROOT/packages/designer"
+pnpm test -- run host-embedded-chart-roundtrip switch-puck-chart-type
+
+cd "$TRIPMATCH_ROOT"
+npx nx run analytics-worker:test --testPathPattern=analytics-dashboard-definition.normalization
+```
+
+9. **Browser gates (required)** — see [BROWSER-GATES.md](./BROWSER-GATES.md). A chart binding or type-switch fix is **not complete** until Gate A + Gate B pass in Chrome on the host stack.
+
+**Why the skill exists:** `@supersubset/designer` unit tests exercise `canonicalToPuck()` / `puckToCanonical()` in isolation. Puck's runtime merges `defaultProps` and serializes select values (`'{"value":"count"}'`) in the live editor — only browser gates catch that.
+
+10. **yalc refresh** after designer changes:
+
+```bash
+cd "$SUPERSET_ROOT/packages/designer" && pnpm build && yalc push
+cd "$TRIPMATCH_ROOT" && bash tools/verify-yalc-supersubset.sh chart-type-switch-panel
+bash tools/devenv.sh restart ui-app
+```
+
+Hard-refresh the browser before re-testing.
+
+## Intent catalog (starter set)
+
+Use these as templates; extend with `.github/skills/bi-visualization-quality/SKILL.md` heuristics.
+
+| Intent                         | Editor steps                                    | Pass criteria                                                                                  |
+| ------------------------------ | ----------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| **Change chart type in place** | Select area chart → Chart type → Bar → Publish  | JSON `"type": "bar-chart"`; Metrics shows dated X-axis, not one bucket labeled with a field id |
+| **Bindings visible on load**   | Revert to seed → select “Plans created per day” | X-axis shows Event Date; Y-axis shows Event Id (count) or aggregation, not empty “Select…”     |
+| **Publish round-trip**         | Edit title only → Publish → reload page         | Unrelated bindings unchanged in JSON and Metrics                                               |
+| **Filter + chart**             | Metrics tab → change Plan Type filter           | Chart data changes; no console errors                                                          |
+| **Pie ↔ bar task fit**         | (quality review) part-to-whole vs trend         | Flag mismatches per bi-visualization-quality                                                   |
+
+### Generating broader intent sets
+
+Read `.github/skills/bi-visualization-quality/SKILL.md` and translate each concern into a **testable intent**:
+
+- Chart type fits task → intent + expected visual encoding
+- Labels/units clear → intent to inspect axis labels and legend after publish
+- Filters discoverable → intent to change filter and assert visible data shift
+- Misleading patterns → intent to flag (e.g., count on wrong axis, truncated axis)
+
+Record intents in the tracking issue (see below) before executing; check off with evidence links (screenshot path, JSON snippet, test name).
+
+## Browser execution
+
+Use Chrome DevTools MCP or Tripmatch `.ai/skills/browser-debugging/SKILL.md`:
+
+- Dashboard Editor is lazy-loaded; wait for “Components” sidebar
+- Puck Publish is a `span` with primary button class, not always `<button>` — use DOM query if automation misses it
+- Select charts by clicking the canvas overlay (6/12 column), not KPI cards
+- **Revert to seed** is a one-click admin action (toast on success, no native `confirm` dialog)
+
+## Known host-bridge invariants
+
+Tripmatch runtime reads **`config.xField` / `config.yField`** and **`logicalQuery`** with **`alias: 'count'`** for count aggregations. The designer uses **`dataBinding`** + Puck props (`xAxisField`, `yAxisField`, `aggregation`).
+
+Fixes must preserve:
+
+- `dataBinding.fields` with correct roles (x-axis without spurious aggregation)
+- `config.xField` / `config.yField` mirrored on publish (`mirrorHostRuntimeConfigFields` in designer)
+- `normalizeAnalyticsDashboardDefinition` in Tripmatch rebuilds `logicalQuery` **and** host config fields
+
+## Tracking defects
+
+Log all host-embedded chart bugs in **one Supersubset GitHub issue** per initiative (no per-bug tickets unless scope explodes). Include:
+
+- Intent that failed
+- Editor vs JSON vs Metrics observations
+- Root cause package (designer / api-access / runtime)
+- Test added (file + test name)
+
+## See Also
+
+- `.github/skills/bi-visualization-quality/SKILL.md` — generate quality-oriented intents
+- `.github/skills/browser-testing/SKILL.md` — MCP browser setup
+- `.github/skills/testing-strategy/SKILL.md` — unit vs integration vs browser layers
+- `.github/skills/puck-integration/SKILL.md` — Puck props and publish mechanics
+- Tripmatch `.ai/skills/supersubset-development/SKILL.md` — yalc loop with host stack

--- a/.github/skills/chart-feature-testing/scripts/browser-verify-bindings.mjs
+++ b/.github/skills/chart-feature-testing/scripts/browser-verify-bindings.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * Browser-side assertions for chart-feature-testing (paste into DevTools console
+ * or run via Chrome DevTools MCP evaluate_script on /admin/analytics Dashboard Editor).
+ *
+ * Usage (MCP):
+ *   evaluate_script with the function body of readChartBindingState below after
+ *   selecting the "Plans created per day" chart (click the 6/12 canvas slot).
+ */
+export function readChartBindingState() {
+  const y = document.querySelector('[data-testid="field-ref-yAxisField"]');
+  const x = document.querySelector('[data-testid="field-ref-xAxisField"]');
+  const agg = document.querySelector('[data-testid="field-ref-aggregation"]');
+  return {
+    xValue: x?.value ?? null,
+    xLabel: x ? x.options?.[x.selectedIndex]?.text : null,
+    yValue: y?.value ?? null,
+    yLabel: y ? y.options?.[y.selectedIndex]?.text : null,
+    aggregation: agg?.value ?? null,
+    pass:
+      x?.value === 'event_date' &&
+      y?.value === 'event_id' &&
+      (agg?.value === 'count' || agg?.value === ''),
+  };
+}
+
+export function readMetricsChartAxisLabels() {
+  const titles = [...document.querySelectorAll('h6')].map((el) => el.textContent?.trim());
+  const ticks = [
+    ...document.querySelectorAll('.recharts-xAxis tick text, .recharts-cartesian-axis-tick-value'),
+  ]
+    .map((el) => el.textContent?.trim())
+    .filter(Boolean);
+  const hasDateTicks = ticks.some((t) => /^\d{4}-\d{2}-\d{2}/.test(t));
+  const hasMysteryNumberOnly = ticks.length === 1 && /^\d+$/.test(ticks[0] ?? '');
+  return {
+    titles,
+    ticks,
+    hasDateTicks,
+    hasMysteryNumberOnly,
+    pass: hasDateTicks && !hasMysteryNumberOnly,
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  console.log('Import readChartBindingState / readMetricsChartAxisLabels in browser context.');
+}

--- a/.github/skills/chart-feature-testing/scripts/run-browser-gates.mjs
+++ b/.github/skills/chart-feature-testing/scripts/run-browser-gates.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * Run chart-feature-testing browser gates A+B against a live Tripmatch stack.
+ *
+ *   UI_APP_PORT=4365 API_PORT=3174 node run-browser-gates.mjs
+ */
+import { chromium } from 'playwright';
+
+const APP =
+  process.env.PLAYWRIGHT_APP_BASE_URL || `http://localhost:${process.env.UI_APP_PORT || '4200'}`;
+const ADMIN_EMAIL = process.env.PLAYWRIGHT_ADMIN_EMAIL || 'admin@wandir.com';
+const ADMIN_PASSWORD = process.env.PLAYWRIGHT_ADMIN_PASSWORD || '11111111';
+
+async function login(page) {
+  await page.goto(`${APP}/login`, { waitUntil: 'domcontentloaded' });
+  await page.getByTestId('login-email').fill(ADMIN_EMAIL);
+  await page.getByTestId('login-email-continue-btn').click();
+  await page.getByTestId('login-password').waitFor({ state: 'visible' });
+  await page.getByTestId('login-password').fill(ADMIN_PASSWORD);
+  await page.getByTestId('login-submit').click();
+  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 });
+}
+
+async function readBindingState(page) {
+  return page.evaluate(() => {
+    const y = document.querySelector('[data-testid="field-ref-yAxisField"]');
+    const x = document.querySelector('[data-testid="field-ref-xAxisField"]');
+    const agg = document.querySelector('[data-testid="field-ref-aggregation"]');
+    return {
+      xValue: x?.value ?? null,
+      yValue: y?.value ?? null,
+      aggregation: agg?.value ?? null,
+      pass:
+        x?.value === 'event_date' &&
+        y?.value === 'event_id' &&
+        (agg?.value === 'count' || agg?.value === ''),
+    };
+  });
+}
+
+async function clickPlansCreatedPerDayChart(page) {
+  const chartTitle = page.getByText('Plans created per day', { exact: true });
+  await chartTitle.waitFor({ state: 'visible', timeout: 30_000 });
+  const box = await chartTitle.boundingBox();
+  if (!box) throw new Error('Could not locate Plans created per day chart');
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height + 40);
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+
+  const consoleErrors = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+
+  try {
+    console.log(`Login → ${APP}`);
+    await login(page);
+
+    console.log('Open analytics + revert to seed');
+    await page.goto(`${APP}/admin/analytics`, { waitUntil: 'domcontentloaded' });
+    await page.getByRole('heading', { name: 'Analytics' }).waitFor({ timeout: 30_000 });
+    await page.getByRole('button', { name: /revert dashboard to seed/i }).click();
+    await page.getByText(/dashboard reset to seed/i).waitFor({ timeout: 30_000 });
+
+    console.log('Gate A — select chart, verify bindings (no hang)');
+    await page.getByRole('tab', { name: /dashboard editor/i }).click();
+    await page.getByRole('textbox', { name: /dashboard title/i }).waitFor({ timeout: 30_000 });
+    await clickPlansCreatedPerDayChart(page);
+
+    await page.waitForTimeout(3000);
+    const gateA = await readBindingState(page);
+    console.log('Gate A result:', gateA);
+    if (!gateA.pass) {
+      throw new Error(`Gate A failed: ${JSON.stringify(gateA)}`);
+    }
+
+    console.log('Gate B — area → bar → publish → metrics');
+    await page.locator('[data-testid="chart-type-bar-chart"]').first().click();
+
+    await page.waitForTimeout(500);
+    const gateBFields = await readBindingState(page);
+    console.log('Gate B fields after switch:', gateBFields);
+    if (!gateBFields.pass) {
+      throw new Error(`Gate B fields failed: ${JSON.stringify(gateBFields)}`);
+    }
+
+    const publish = page.getByRole('button', { name: /^publish$/i });
+    if (!(await publish.count())) {
+      await page
+        .getByRole('button', { name: /toggle menu bar/i })
+        .click()
+        .catch(() => {});
+    }
+    await page.getByRole('button', { name: /^publish$/i }).click({ timeout: 10_000 });
+    await page
+      .getByText(/saved|showing the updated metrics/i)
+      .waitFor({ timeout: 60_000 })
+      .catch(() => {});
+
+    await page.getByRole('tab', { name: /^metrics$/i }).click();
+    await page.getByText('Plans created per day').waitFor({ timeout: 30_000 });
+
+    const metrics = await page.evaluate(() => {
+      const ticks = [...document.querySelectorAll('.recharts-cartesian-axis-tick-value')]
+        .map((el) => el.textContent?.trim())
+        .filter(Boolean);
+      const hasDateTicks = ticks.some((t) => /^\d{4}-\d{2}-\d{2}/.test(t));
+      const hasMysteryNumberOnly = ticks.length === 1 && /^\d+$/.test(ticks[0] ?? '');
+      return {
+        ticks: ticks.slice(0, 8),
+        hasDateTicks,
+        hasMysteryNumberOnly,
+        pass: hasDateTicks && !hasMysteryNumberOnly,
+      };
+    });
+    console.log('Gate B metrics:', metrics);
+    if (!metrics.pass) {
+      throw new Error(`Gate B metrics failed: ${JSON.stringify(metrics)}`);
+    }
+
+    if (consoleErrors.length) {
+      console.warn('Console errors (non-fatal):', consoleErrors.slice(0, 5));
+    }
+
+    console.log('\n✅ All browser gates passed');
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('\n❌ Browser gates failed:', err.message);
+  process.exit(1);
+});

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ The **orchestrator agent** (`orchestrator.agent.md`) is the coordinator. It deco
 
 For designer-shell visual work, pair the `designer` agent with `.github/skills/designer-design/SKILL.md`. Use `.github/skills/puck-integration/SKILL.md` for Puck mechanics and serialization.
 
-For testing work, pair the `testing` agent with `.github/skills/testing-strategy/SKILL.md` for layer selection and evidence expectations. Use `.github/skills/browser-testing/SKILL.md` for Chrome MCP and Playwright browser execution details.
+For testing work, pair the `testing` agent with `.github/skills/testing-strategy/SKILL.md` for layer selection and evidence expectations. Use `.github/skills/browser-testing/SKILL.md` for Chrome MCP and Playwright browser execution details. For chart editing in Tripmatch/Wandir, use `.github/skills/chart-feature-testing/SKILL.md`.
 
 ### Planning, CI, and AI context skills
 
@@ -87,6 +87,7 @@ For testing work, pair the `testing` agent with `.github/skills/testing-strategy
 | `requirements-intake`         | Creating or backfilling Acai-compatible feature specs and glossary terms                                  |
 | `requirements-driven-work`    | Implementing or reviewing against existing `features/*.feature.yaml` ACIDs                                |
 | `requirements-test-tagging`   | Prefixing tests with `[ACID]` evidence links                                                              |
+| `chart-feature-testing`       | Host-embedded chart intents (Tripmatch editor → publish → Metrics)                                        |
 | `branch-ci-promotion`         | PR readiness: `pnpm lint`, `typecheck`, `test`, E2E, merge expectations                                   |
 | `ai-code-cleanup`             | Continuous AI-code cleanup: drift detection, duplicate removal, bounded refactors, and standards updates  |
 | `release-runbook`             | End-to-end release execution: candidate validation, changesets, branch promotion, publish, downstream PRs |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,7 @@ export default tseslint.config(
       'test-results/**',
       'screenshots/**',
       'tools/requirements/**',
+      '.github/skills/**/scripts/**',
     ],
   },
   {

--- a/package.json
+++ b/package.json
@@ -69,5 +69,13 @@
       "prettier --write"
     ]
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@supersubset/adapter-sql": "file:.yalc/@supersubset/adapter-sql",
+    "@supersubset/data-model": "file:.yalc/@supersubset/data-model",
+    "@supersubset/designer": "file:.yalc/@supersubset/designer",
+    "@supersubset/query-client": "file:.yalc/@supersubset/query-client",
+    "@supersubset/runtime": "file:.yalc/@supersubset/runtime",
+    "@supersubset/schema": "file:.yalc/@supersubset/schema"
+  }
 }

--- a/packages/charts-echarts/src/base/resolve-field-keys.ts
+++ b/packages/charts-echarts/src/base/resolve-field-keys.ts
@@ -1,0 +1,84 @@
+import type { WidgetProps } from '@supersubset/runtime';
+
+type ColumnList = NonNullable<WidgetProps['columns']>;
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/** Prefer plural array keys; fall back to singular host config (e.g. yField) then query columns. */
+export function resolveYFields(config: Record<string, unknown>, columns?: ColumnList): string[] {
+  const singular = readString(config.yField);
+  const plural = readStringArray(config.yFields);
+
+  // Host apps often keep the query output alias on yField while dataBinding fills
+  // yFields with mart field ids (e.g. event_id vs count).
+  if (singular && plural.length > 0 && !plural.includes(singular)) {
+    return [singular];
+  }
+  if (plural.length > 0) return plural;
+  if (singular) return [singular];
+
+  return (
+    columns
+      ?.slice(1)
+      .map((column) => column.fieldId)
+      .filter(Boolean) ?? []
+  );
+}
+
+export function resolveBarFields(config: Record<string, unknown>, columns?: ColumnList): string[] {
+  const singular = readString(config.barField);
+  const plural = readStringArray(config.barFields);
+
+  if (singular && plural.length > 0 && !plural.includes(singular)) {
+    return [singular];
+  }
+  if (plural.length > 0) return plural;
+  if (singular) return [singular];
+
+  return (
+    columns
+      ?.slice(1)
+      .map((column) => column.fieldId)
+      .filter(Boolean) ?? []
+  );
+}
+
+export function resolveLineFields(
+  config: Record<string, unknown>,
+  _columns?: ColumnList,
+): string[] {
+  const singular = readString(config.lineField);
+  const plural = readStringArray(config.lineFields);
+
+  if (singular && plural.length > 0 && !plural.includes(singular)) {
+    return [singular];
+  }
+  if (plural.length > 0) return plural;
+  if (singular) return [singular];
+
+  return [];
+}
+
+export function resolveCategoryField(
+  config: Record<string, unknown>,
+  columns?: ColumnList,
+): string {
+  return (
+    readString(config.xField) ??
+    readString(config.categoryField) ??
+    readString(config.nameField) ??
+    columns?.[0]?.fieldId ??
+    ''
+  );
+}
+
+export function resolveValueField(config: Record<string, unknown>, columns?: ColumnList): string {
+  return readString(config.valueField) ?? readString(config.yField) ?? columns?.[1]?.fieldId ?? '';
+}

--- a/packages/charts-echarts/src/charts/AreaChartWidget.tsx
+++ b/packages/charts-echarts/src/charts/AreaChartWidget.tsx
@@ -23,6 +23,7 @@ import {
   buildLabelOption,
   buildTitleOption,
 } from '../base/shared-options';
+import { resolveYFields } from '../base/resolve-field-keys';
 
 echarts.use([EChartsLine]);
 
@@ -33,7 +34,7 @@ export function AreaChartWidget({ config, data, columns, title, height, theme }:
     }
 
     const xField = (config.xField as string) ?? columns?.[0]?.fieldId ?? '';
-    const yFields = (config.yFields as string[]) ?? columns?.slice(1).map((c) => c.fieldId) ?? [];
+    const yFields = resolveYFields(config, columns);
     const smooth = config.smooth === true;
     const stacked = config.stacked !== false; // default true for area chart
     const areaOpacity = (config.areaOpacity as number) ?? 0.7;

--- a/packages/charts-echarts/src/charts/BarChartWidget.tsx
+++ b/packages/charts-echarts/src/charts/BarChartWidget.tsx
@@ -18,6 +18,7 @@ import {
   buildLabelOption,
   buildTitleOption,
 } from '../base/shared-options';
+import { resolveYFields } from '../base/resolve-field-keys';
 
 echarts.use([EChartsBar]);
 
@@ -37,7 +38,7 @@ export function BarChartWidget({
     }
 
     const xField = (config.xField as string) ?? columns?.[0]?.fieldId;
-    const yFields = (config.yFields as string[]) ?? columns?.slice(1).map((c) => c.fieldId) ?? [];
+    const yFields = resolveYFields(config, columns);
     const horizontal = config.horizontal === true;
     const stacked = config.stacked === true;
     const barWidth = config.barWidth as string | number | undefined;

--- a/packages/charts-echarts/src/charts/ComboChartWidget.tsx
+++ b/packages/charts-echarts/src/charts/ComboChartWidget.tsx
@@ -21,8 +21,50 @@ import {
   buildLabelOption,
   buildTitleOption,
 } from '../base/shared-options';
+import {
+  resolveBarFields,
+  resolveCategoryField,
+  resolveLineFields,
+} from '../base/resolve-field-keys';
 
 echarts.use([EChartsBar, EChartsLine]);
+
+function readConfigString(config: Record<string, unknown>, key: string): string | undefined {
+  const value = config[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export function applyCumulativeLineSeries(
+  data: Array<Record<string, unknown>>,
+  config: Record<string, unknown>,
+  barFields: string[],
+  lineFields: string[],
+): { data: Array<Record<string, unknown>>; lineFields: string[] } {
+  const cumulativeFromField = readConfigString(config, 'cumulativeFromField');
+  const lineField = readConfigString(config, 'lineField');
+  if (!cumulativeFromField || !lineField) {
+    return { data, lineFields };
+  }
+
+  let cumulative = 0;
+  const enriched = data.map((row) => {
+    const rawIncrement =
+      row[cumulativeFromField] ?? (barFields[0] != null ? row[barFields[0]] : undefined);
+    const increment =
+      typeof rawIncrement === 'number'
+        ? rawIncrement
+        : rawIncrement == null
+          ? 0
+          : Number(rawIncrement) || 0;
+    cumulative += increment;
+    return { ...row, [lineField]: cumulative };
+  });
+
+  return {
+    data: enriched,
+    lineFields: lineFields.length > 0 ? lineFields : [lineField],
+  };
+}
 
 export function ComboChartWidget({ config, data, columns, title, height, theme }: WidgetProps) {
   const option = useMemo(() => {
@@ -30,24 +72,36 @@ export function ComboChartWidget({ config, data, columns, title, height, theme }
       return buildEmptyOption(title);
     }
 
-    const xField = (config.xField as string) ?? columns?.[0]?.fieldId ?? '';
-    const barFields = (config.barFields as string[]) ?? [];
-    const lineFields = (config.lineFields as string[]) ?? [];
+    const xField = resolveCategoryField(config, columns);
+    const barFields = resolveBarFields(config, columns);
+    let lineFields = resolveLineFields(config, columns);
+    const { data: chartData, lineFields: effectiveLineFields } = applyCumulativeLineSeries(
+      data,
+      config,
+      barFields,
+      lineFields,
+    );
+    lineFields = effectiveLineFields;
     const stacked = config.stacked === true;
     const lineSmooth = config.lineSmooth !== false;
     const barBorderRadius = (config.barBorderRadius as number) ?? 0;
+    const barLabel = readConfigString(config, 'barLabel');
+    const lineLabel = readConfigString(config, 'lineLabel');
     const shared = extractSharedConfig(config);
     const label = buildLabelOption(shared);
 
-    const categoryData = data.map((row) => String(row[xField] ?? ''));
-    const allFields = [...barFields, ...lineFields];
+    const categoryData = chartData.map((row) => String(row[xField] ?? ''));
+    const allFields = [
+      ...barFields.map((field) => barLabel ?? field),
+      ...lineFields.map((field) => lineLabel ?? field),
+    ];
     const hasTitle = Boolean(title);
     const legend = buildLegendOption(shared, allFields, hasTitle);
 
     const barSeries = barFields.map((field) => ({
-      name: field,
+      name: barLabel ?? field,
       type: 'bar' as const,
-      data: data.map((row) => row[field]),
+      data: chartData.map((row) => row[field]),
       yAxisIndex: 0,
       ...(label ? { label } : {}),
       ...(stacked ? { stack: 'bars' } : {}),
@@ -55,9 +109,9 @@ export function ComboChartWidget({ config, data, columns, title, height, theme }
     }));
 
     const lineSeries = lineFields.map((field) => ({
-      name: field,
+      name: lineLabel ?? field,
       type: 'line' as const,
-      data: data.map((row) => row[field]),
+      data: chartData.map((row) => row[field]),
       yAxisIndex: lineFields.length > 0 ? 1 : 0,
       smooth: lineSmooth,
       ...(label ? { label } : {}),

--- a/packages/charts-echarts/src/charts/LineChartWidget.tsx
+++ b/packages/charts-echarts/src/charts/LineChartWidget.tsx
@@ -17,6 +17,7 @@ import {
   buildLabelOption,
   buildTitleOption,
 } from '../base/shared-options';
+import { resolveYFields } from '../base/resolve-field-keys';
 
 echarts.use([EChartsLine]);
 
@@ -36,7 +37,7 @@ export function LineChartWidget({
     }
 
     const xField = (config.xField as string) ?? columns?.[0]?.fieldId;
-    const yFields = (config.yFields as string[]) ?? columns?.slice(1).map((c) => c.fieldId) ?? [];
+    const yFields = resolveYFields(config, columns);
     const showArea = config.area === true;
     const showMarkers = config.showMarkers !== false;
     const markerSize = (config.markerSize as number) ?? 4;

--- a/packages/charts-echarts/test/combo-cumulative.test.ts
+++ b/packages/charts-echarts/test/combo-cumulative.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { applyCumulativeLineSeries } from '../src/charts/ComboChartWidget';
+
+describe('applyCumulativeLineSeries', () => {
+  it('computes a running total line from cumulativeFromField', () => {
+    const data = [
+      { created_date: '2026-01-01', signups: 2 },
+      { created_date: '2026-01-02', signups: 3 },
+      { created_date: '2026-01-03', signups: 1 },
+    ];
+
+    const result = applyCumulativeLineSeries(
+      data,
+      {
+        cumulativeFromField: 'signups',
+        lineField: 'cumulative_users',
+      },
+      ['signups'],
+      [],
+    );
+
+    expect(result.lineFields).toEqual(['cumulative_users']);
+    expect(result.data).toEqual([
+      { created_date: '2026-01-01', signups: 2, cumulative_users: 2 },
+      { created_date: '2026-01-02', signups: 3, cumulative_users: 5 },
+      { created_date: '2026-01-03', signups: 1, cumulative_users: 6 },
+    ]);
+  });
+});

--- a/packages/charts-echarts/test/resolve-field-keys.test.ts
+++ b/packages/charts-echarts/test/resolve-field-keys.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { resolveYFields } from '../src/base/resolve-field-keys';
+
+describe('resolveYFields', () => {
+  it('prefers yField alias when yFields holds mart field ids from dataBinding', () => {
+    expect(
+      resolveYFields({ yField: 'count', yFields: ['event_id'] }, [
+        { fieldId: 'event_date', label: 'Date', dataType: 'date' },
+        { fieldId: 'count', label: 'Count', dataType: 'integer' },
+      ]),
+    ).toEqual(['count']);
+  });
+
+  it('falls back to yField when yFields is missing', () => {
+    expect(resolveYFields({ yField: 'count' }, undefined)).toEqual(['count']);
+  });
+
+  it('falls back to query columns when neither yFields nor yField is set', () => {
+    expect(
+      resolveYFields({}, [
+        { fieldId: 'event_date', label: 'Date', dataType: 'date' },
+        { fieldId: 'count', label: 'Count', dataType: 'integer' },
+      ]),
+    ).toEqual(['count']);
+  });
+});

--- a/packages/designer/src/adapters/puck-canonical.ts
+++ b/packages/designer/src/adapters/puck-canonical.ts
@@ -61,12 +61,13 @@ export function puckToCanonical(
   const layout: LayoutMap = {};
   const widgets: WidgetDefinition[] = [];
 
-  // Recursively walk content items
+  // Recursively walk content items (slot children may live in data.zones at runtime)
   const childIds = processContentItems(
     (puckData.content ?? []) as ComponentData[],
     'grid-main',
     layout,
     widgets,
+    puckData.zones as PuckZones | undefined,
   );
 
   // Root layout node
@@ -184,11 +185,38 @@ const layoutTypeToPuckName: Record<string, string> = {
  * Recursively walk Puck content items and build layout nodes + widgets.
  * Handles RowBlock/ColumnBlock nesting by creating row/column layout nodes.
  */
+type PuckZones = Record<string, ComponentData[]>;
+
+const PUCK_SLOT_FIELD_NAMES = ['content'] as const;
+
+/** Read slot children from inline props or Puck runtime zones (`parentId:slotField`). */
+function readPuckSlotContent(
+  props: Record<string, unknown>,
+  itemId: string | undefined,
+  zones: PuckZones | undefined,
+  slotField = 'content',
+): ComponentData[] {
+  const inline = props[slotField];
+  if (Array.isArray(inline) && inline.length > 0) {
+    return inline as ComponentData[];
+  }
+
+  if (itemId && zones) {
+    const fromZone = zones[`${itemId}:${slotField}`];
+    if (Array.isArray(fromZone)) {
+      return fromZone;
+    }
+  }
+
+  return Array.isArray(inline) ? (inline as ComponentData[]) : [];
+}
+
 function processContentItems(
   items: ComponentData[],
   parentLayoutId: string,
   layout: LayoutMap,
   widgets: WidgetDefinition[],
+  zones?: PuckZones,
 ): string[] {
   const childIds: string[] = [];
 
@@ -201,8 +229,8 @@ function processContentItems(
     const layoutBlockType = LAYOUT_PUCK_NAME_TO_TYPE[puckType];
     if (layoutBlockType) {
       const layoutId = `layout-${itemId}`;
-      const slotContent = (props.content as ComponentData[]) ?? [];
-      const nestedChildIds = processContentItems(slotContent, layoutId, layout, widgets);
+      const slotContent = readPuckSlotContent(props, itemId, zones);
+      const nestedChildIds = processContentItems(slotContent, layoutId, layout, widgets, zones);
 
       layout[layoutId] = {
         id: layoutId,
@@ -481,6 +509,19 @@ function unwrapPuckOptionValue(value: unknown): unknown {
   return value;
 }
 
+/** Flatten Puck select/radio values like `'{"value":"count"}'` → `'count'`. */
+function normalizePuckOptionProps(props: Record<string, unknown>): void {
+  for (const [key, value] of Object.entries(props)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    const unwrapped = unwrapPuckOptionValue(value);
+    if (unwrapped !== value) {
+      props[key] = unwrapped;
+    }
+  }
+}
+
 function normalizeNumericConfigValue(value: unknown): unknown {
   const unwrapped = unwrapPuckOptionValue(value);
   if (typeof unwrapped === 'number' && Number.isFinite(unwrapped)) {
@@ -562,6 +603,15 @@ function buildWidgetDefinition(
       ['timestampField', 'alert-timestamp'],
     ];
 
+    const METRIC_BINDING_ROLES = new Set([
+      'y-axis',
+      'value',
+      'bar-y',
+      'line-y',
+      'size',
+      'comparison',
+    ]);
+
     for (const [propKey, role] of fieldMappings) {
       const fieldRef = props[propKey] as string;
       if (fieldRef) {
@@ -569,12 +619,14 @@ function buildWidgetDefinition(
           role,
           fieldRef,
           aggregation:
-            props.aggregation && props.aggregation !== 'none'
+            METRIC_BINDING_ROLES.has(role) && props.aggregation && props.aggregation !== 'none'
               ? (props.aggregation as string)
               : undefined,
         });
       }
     }
+
+    supplementDataBindingFieldsFromLegacyProps(props, fields);
 
     // Always create dataBinding when datasetRef is present (even without fields,
     // e.g. Table widget needs datasetRef to know which dataset to query)
@@ -635,7 +687,269 @@ function buildWidgetDefinition(
     }
   }
 
+  mirrorHostRuntimeConfigFields(widget);
+
   return widget;
+}
+
+interface LogicalQueryFieldLike {
+  fieldId: string;
+  aggregation?: string;
+  alias?: string;
+}
+
+interface LogicalQueryLike {
+  datasetId: string;
+  fields: LogicalQueryFieldLike[];
+}
+
+interface ResolvedFieldBinding {
+  fieldRef: string;
+  aggregation?: string;
+}
+
+const HOST_CONFIG_FIELD_MIRROR: Array<[string, string]> = [
+  ['x-axis', 'xField'],
+  ['y-axis', 'yField'],
+  ['bar-y', 'barField'],
+  ['line-y', 'lineField'],
+  ['category', 'categoryField'],
+  ['value', 'valueField'],
+];
+
+/** Host apps (e.g. Tripmatch) read xField/yField from widget.config at runtime. */
+function mirrorHostRuntimeConfigFields(widget: WidgetDefinition): void {
+  if (!widget.dataBinding) {
+    return;
+  }
+
+  for (const [role, configKey] of HOST_CONFIG_FIELD_MIRROR) {
+    const binding = widget.dataBinding.fields.find((field) => field.role === role);
+    if (!binding) {
+      continue;
+    }
+    widget.config[configKey] = hostConfigValueForBinding(binding);
+  }
+
+  // Pie / part-to-whole charts use nameField in Tripmatch runtime.
+  if (
+    widget.type === 'pie-chart' &&
+    typeof widget.config.categoryField === 'string' &&
+    !widget.config.nameField
+  ) {
+    widget.config.nameField = widget.config.categoryField;
+  }
+}
+
+function hostConfigValueForBinding(binding: FieldBinding): string {
+  if (binding.aggregation && binding.aggregation !== 'none') {
+    return hostAliasForAggregatedBinding(binding) ?? binding.fieldRef;
+  }
+  return binding.fieldRef;
+}
+
+function hostAliasForAggregatedBinding(binding: FieldBinding): string | undefined {
+  if (binding.aggregation === 'count') {
+    return 'count';
+  }
+  return undefined;
+}
+
+function readLogicalQueryFromWidgetConfig(
+  config: Record<string, unknown>,
+): LogicalQueryLike | null {
+  const logicalQuery = config.logicalQuery;
+  if (!logicalQuery || typeof logicalQuery !== 'object' || Array.isArray(logicalQuery)) {
+    return null;
+  }
+
+  const record = logicalQuery as Record<string, unknown>;
+  if (typeof record.datasetId !== 'string') {
+    return null;
+  }
+
+  const fields: LogicalQueryFieldLike[] = [];
+  if (Array.isArray(record.fields)) {
+    for (const field of record.fields) {
+      if (!field || typeof field !== 'object' || Array.isArray(field)) {
+        continue;
+      }
+      const fieldRecord = field as Record<string, unknown>;
+      if (typeof fieldRecord.fieldId !== 'string') {
+        continue;
+      }
+      const nextField: LogicalQueryFieldLike = { fieldId: fieldRecord.fieldId };
+      if (typeof fieldRecord.aggregation === 'string') {
+        nextField.aggregation = fieldRecord.aggregation;
+      }
+      if (typeof fieldRecord.alias === 'string') {
+        nextField.alias = fieldRecord.alias;
+      }
+      fields.push(nextField);
+    }
+  }
+
+  return { datasetId: record.datasetId, fields };
+}
+
+function resolveLegacyConfigFieldRef(
+  rawRef: string,
+  logicalQuery: LogicalQueryLike,
+): ResolvedFieldBinding | null {
+  const queryField = logicalQuery.fields.find(
+    (field) => field.alias === rawRef || field.fieldId === rawRef,
+  );
+
+  if (queryField) {
+    return {
+      fieldRef: queryField.fieldId,
+      ...(queryField.aggregation ? { aggregation: queryField.aggregation } : {}),
+    };
+  }
+
+  return { fieldRef: rawRef };
+}
+
+function dataBindingHasPopulatedRole(
+  dataBinding: WidgetDefinition['dataBinding'],
+  role: string,
+): boolean {
+  return !!dataBinding?.fields.some(
+    (field) =>
+      field.role === role && typeof field.fieldRef === 'string' && field.fieldRef.length > 0,
+  );
+}
+
+function readLogicalQueryFromProps(props: Record<string, unknown>): LogicalQueryLike | null {
+  const logicalQuery = props.logicalQuery;
+  if (!logicalQuery || typeof logicalQuery !== 'object' || Array.isArray(logicalQuery)) {
+    return null;
+  }
+
+  return readLogicalQueryFromWidgetConfig({ logicalQuery });
+}
+
+function ensureCartesianAxisPuckProps(
+  props: Record<string, unknown>,
+  config: Record<string, unknown>,
+): void {
+  const logicalQuery = readLogicalQueryFromWidgetConfig(config) ?? readLogicalQueryFromProps(props);
+
+  if (!props.xAxisField) {
+    const rawX = config.xField ?? props.xField;
+    if (typeof rawX === 'string' && rawX.length > 0) {
+      if (logicalQuery) {
+        const resolved = resolveLegacyConfigFieldRef(rawX, logicalQuery);
+        props.xAxisField = resolved?.fieldRef ?? rawX;
+      } else {
+        props.xAxisField = rawX;
+      }
+    }
+  }
+
+  if (!props.yAxisField) {
+    const rawY = config.yField ?? props.yField;
+    if (typeof rawY === 'string' && rawY.length > 0) {
+      if (logicalQuery) {
+        const resolved = resolveLegacyConfigFieldRef(rawY, logicalQuery);
+        if (resolved) {
+          props.yAxisField = resolved.fieldRef;
+          if (resolved.aggregation && (!props.aggregation || props.aggregation === 'none')) {
+            props.aggregation = resolved.aggregation;
+          }
+        }
+      } else {
+        props.yAxisField = rawY;
+      }
+    }
+  }
+}
+
+function supplementDataBindingFieldsFromLegacyProps(
+  props: Record<string, unknown>,
+  fields: FieldBinding[],
+): void {
+  const logicalQuery = readLogicalQueryFromProps(props);
+  const populatedRoles = new Set(
+    fields
+      .filter((field) => typeof field.fieldRef === 'string' && field.fieldRef.length > 0)
+      .map((field) => field.role),
+  );
+
+  const legacyMappings: Array<[string, string, string]> = [
+    ['xAxisField', 'xField', 'x-axis'],
+    ['yAxisField', 'yField', 'y-axis'],
+  ];
+
+  for (const [puckKey, configKey, role] of legacyMappings) {
+    if (populatedRoles.has(role)) {
+      continue;
+    }
+
+    const fromPuck = props[puckKey];
+    if (typeof fromPuck === 'string' && fromPuck.length > 0) {
+      fields.push({
+        role,
+        fieldRef: fromPuck,
+        ...(role === 'y-axis' && props.aggregation && props.aggregation !== 'none'
+          ? { aggregation: props.aggregation as string }
+          : {}),
+      });
+      continue;
+    }
+
+    const rawRef = props[configKey];
+    if (typeof rawRef !== 'string' || rawRef.length === 0) {
+      continue;
+    }
+
+    if (logicalQuery) {
+      const resolved = resolveLegacyConfigFieldRef(rawRef, logicalQuery);
+      if (resolved) {
+        fields.push({
+          role,
+          fieldRef: resolved.fieldRef,
+          ...(role === 'y-axis' && resolved.aggregation
+            ? { aggregation: resolved.aggregation }
+            : {}),
+        });
+      }
+      continue;
+    }
+
+    fields.push({ role, fieldRef: rawRef });
+  }
+
+  if (!logicalQuery) {
+    return;
+  }
+
+  if (!fieldBindingListHasPopulatedRole(fields, 'x-axis')) {
+    const dimension = logicalQuery.fields.find((field) => !field.aggregation);
+    if (dimension) {
+      fields.push({ role: 'x-axis', fieldRef: dimension.fieldId });
+    }
+  }
+
+  if (!fieldBindingListHasPopulatedRole(fields, 'y-axis')) {
+    const metric = logicalQuery.fields.find(
+      (field) => field.aggregation && field.aggregation !== 'none',
+    );
+    if (metric) {
+      fields.push({
+        role: 'y-axis',
+        fieldRef: metric.fieldId,
+        aggregation: metric.aggregation,
+      });
+    }
+  }
+}
+
+function fieldBindingListHasPopulatedRole(fields: FieldBinding[], role: string): boolean {
+  return fields.some(
+    (field) =>
+      field.role === role && typeof field.fieldRef === 'string' && field.fieldRef.length > 0,
+  );
 }
 
 function buildContentMeta(
@@ -658,6 +972,7 @@ function buildContentMeta(
 
 function widgetConfigToPuckProps(widget: WidgetDefinition): Record<string, unknown> {
   const props: Record<string, unknown> = {};
+  const logicalQuery = readLogicalQueryFromWidgetConfig(widget.config);
 
   // Reconstruct data binding fields
   if (widget.dataBinding) {
@@ -689,35 +1004,69 @@ function widgetConfigToPuckProps(widget: WidgetDefinition): Record<string, unkno
       if (propKey) {
         props[propKey] = field.fieldRef;
       }
-      if (field.aggregation) {
+      if (
+        field.aggregation &&
+        field.aggregation !== 'none' &&
+        (field.role === 'y-axis' || field.role === 'value')
+      ) {
         props.aggregation = field.aggregation;
       }
     }
   }
 
+  if (!props.datasetRef) {
+    if (typeof widget.config.datasetRef === 'string') {
+      props.datasetRef = widget.config.datasetRef;
+    } else if (logicalQuery?.datasetId) {
+      props.datasetRef = logicalQuery.datasetId;
+    }
+  }
+
+  const logicalQueryForFallback = logicalQuery;
+
   // Fallback: map field-ref keys stored in widget.config to Puck props
   // (for legacy/hand-authored dashboards that don't use dataBinding)
-  const configFieldFallbacks: Array<[string, string]> = [
-    // Standard keys (config key → Puck prop)
-    ['valueField', 'valueField'],
-    ['comparisonField', 'comparisonField'],
-    ['categoryField', 'categoryField'],
-    ['sourceField', 'sourceField'],
-    ['targetField', 'targetField'],
-    ['sizeField', 'sizeField'],
-    ['colorGroupField', 'colorGroupField'],
-    ['nameField', 'nameField'],
-    ['parentField', 'parentField'],
-    ['datasetRef', 'datasetRef'],
-    // Alternative legacy keys
-    ['xField', 'xAxisField'],
-    ['yField', 'yAxisField'],
+  const configFieldFallbacks: Array<[string, string, string]> = [
+    // Standard keys (config key → Puck prop → dataBinding role)
+    ['valueField', 'valueField', 'value'],
+    ['comparisonField', 'comparisonField', 'comparison'],
+    ['categoryField', 'categoryField', 'category'],
+    ['sourceField', 'sourceField', 'source'],
+    ['targetField', 'targetField', 'target'],
+    ['sizeField', 'sizeField', 'size'],
+    ['colorGroupField', 'colorGroupField', 'color-group'],
+    ['nameField', 'nameField', 'name'],
+    ['parentField', 'parentField', 'parent'],
+    ['datasetRef', 'datasetRef', ''],
+    ['xField', 'xAxisField', 'x-axis'],
+    ['yField', 'yAxisField', 'y-axis'],
   ];
 
-  for (const [configKey, puckProp] of configFieldFallbacks) {
-    if (!props[puckProp] && widget.config[configKey]) {
-      props[puckProp] = widget.config[configKey];
+  for (const [configKey, puckProp, role] of configFieldFallbacks) {
+    if (props[puckProp]) {
+      continue;
     }
+    if (role && widget.dataBinding && dataBindingHasPopulatedRole(widget.dataBinding, role)) {
+      continue;
+    }
+
+    const rawRef = widget.config[configKey];
+    if (typeof rawRef !== 'string' || rawRef.length === 0) {
+      continue;
+    }
+
+    if (logicalQueryForFallback && (configKey === 'xField' || configKey === 'yField')) {
+      const resolved = resolveLegacyConfigFieldRef(rawRef, logicalQueryForFallback);
+      if (resolved) {
+        props[puckProp] = resolved.fieldRef;
+        if (resolved.aggregation && configKey === 'yField') {
+          props.aggregation = resolved.aggregation;
+        }
+      }
+      continue;
+    }
+
+    props[puckProp] = rawRef;
   }
 
   // Handle array-valued fields (yFields, barFields, lineFields)
@@ -743,8 +1092,13 @@ function widgetConfigToPuckProps(widget: WidgetDefinition): Record<string, unkno
     props.lineField = widget.config.lineFields[0];
   }
 
-  // Spread config props
+  // Spread config props (skip host axis aliases — mapped to Puck field props via ensureCartesianAxisPuckProps)
+  const HOST_AXIS_ALIAS_KEYS = new Set(['xField', 'yField']);
+
   for (const [key, value] of Object.entries(widget.config)) {
+    if (HOST_AXIS_ALIAS_KEYS.has(key)) {
+      continue;
+    }
     if (
       widget.type === 'alerts' &&
       (key === 'alertMode' || key === 'alertRule' || key === 'alertRuleDraft')
@@ -836,7 +1190,177 @@ function widgetConfigToPuckProps(widget: WidgetDefinition): Record<string, unkno
     }
   }
 
+  ensureCartesianAxisPuckProps(props, widget.config);
+  normalizePuckOptionProps(props);
+
   return props;
+}
+
+interface LogicalQueryFieldShape {
+  fieldId: string;
+  aggregation?: string;
+}
+
+function readLogicalQueryFieldsFromProps(props: Record<string, unknown>): LogicalQueryFieldShape[] {
+  const logicalQuery = readLogicalQueryFromProps(props);
+  return logicalQuery?.fields ?? [];
+}
+
+/**
+ * Repair chart axis Puck props from logicalQuery when axis fields were lost
+ * (e.g. Puck defaultProps merge or chart-type switch dropped yAxisField).
+ */
+export function repairChartAxisPropsInPuckData(data: Data): Data {
+  const beforeSnapshot = collectChartAxisBindingSnapshot(data);
+  const zones = data.zones ? { ...(data.zones as PuckZones) } : undefined;
+  const content = Array.isArray(data.content)
+    ? repairChartAxisPropsInPuckItems(data.content as ComponentData[], zones)
+    : data.content;
+
+  const next = {
+    ...data,
+    content,
+    ...(zones ? { zones } : {}),
+  };
+
+  if (collectChartAxisBindingSnapshot(next) === beforeSnapshot) {
+    return data;
+  }
+
+  return next;
+}
+
+function repairChartAxisPropsInPuckItems(
+  items: ComponentData[],
+  zones?: PuckZones,
+): ComponentData[] {
+  return items.map((item) => {
+    const props: Record<string, unknown> = { ...(item.props ?? {}) };
+    const itemId = typeof props.id === 'string' ? props.id : undefined;
+
+    if (isChartPuckType(item.type)) {
+      repairChartAxisPropsRecord(props);
+    }
+
+    for (const slotField of PUCK_SLOT_FIELD_NAMES) {
+      const zoneKey = itemId ? `${itemId}:${slotField}` : undefined;
+      if (zoneKey && zones?.[zoneKey]) {
+        zones[zoneKey] = repairChartAxisPropsInPuckItems(zones[zoneKey], zones);
+      } else if (Array.isArray(props[slotField])) {
+        props[slotField] = repairChartAxisPropsInPuckItems(
+          props[slotField] as ComponentData[],
+          zones,
+        );
+      }
+    }
+
+    return { ...item, props } as ComponentData;
+  });
+}
+
+function isChartPuckType(puckType: string): boolean {
+  return (
+    puckType.endsWith('Chart') ||
+    puckType === 'KPICard' ||
+    puckType === 'Table' ||
+    puckType === 'AlertsWidgetBlock'
+  );
+}
+
+interface ChartAxisBindingSnapshot {
+  id: string;
+  type: string;
+  xAxisField?: unknown;
+  yAxisField?: unknown;
+  categoryField?: unknown;
+  valueField?: unknown;
+  aggregation?: unknown;
+}
+
+function collectChartAxisBindingSnapshots(
+  items: ComponentData[] | undefined,
+  out: ChartAxisBindingSnapshot[],
+  zones?: PuckZones,
+): void {
+  if (!Array.isArray(items)) {
+    return;
+  }
+
+  for (const item of items) {
+    const props = (item.props ?? {}) as Record<string, unknown>;
+    const itemId = typeof props.id === 'string' ? props.id : undefined;
+
+    if (isChartPuckType(item.type)) {
+      out.push({
+        id: String(props.id ?? ''),
+        type: item.type,
+        xAxisField: props.xAxisField,
+        yAxisField: props.yAxisField,
+        categoryField: props.categoryField,
+        valueField: props.valueField,
+        aggregation: props.aggregation,
+      });
+    }
+
+    for (const slotField of PUCK_SLOT_FIELD_NAMES) {
+      const children = readPuckSlotContent(props, itemId, zones, slotField);
+      if (children.length > 0) {
+        collectChartAxisBindingSnapshots(children, out, zones);
+      }
+    }
+  }
+}
+
+/** Stable string for comparing chart axis bindings before/after repair. */
+export function collectChartAxisBindingSnapshot(data: Data): string {
+  const snapshots: ChartAxisBindingSnapshot[] = [];
+  const zones = data.zones as PuckZones | undefined;
+  collectChartAxisBindingSnapshots(data.content as ComponentData[] | undefined, snapshots, zones);
+  return JSON.stringify(snapshots);
+}
+
+export function repairChartAxisPropsRecord(props: Record<string, unknown>): void {
+  normalizePuckOptionProps(props);
+  ensureCartesianAxisPuckProps(props, props);
+
+  const fields = readLogicalQueryFieldsFromProps(props);
+  if (fields.length === 0) {
+    return;
+  }
+
+  if (!props.yAxisField) {
+    const metric = fields.find((field) => field.aggregation && field.aggregation !== 'none');
+    if (metric) {
+      props.yAxisField = metric.fieldId;
+      if (!props.aggregation || props.aggregation === 'none') {
+        props.aggregation = metric.aggregation;
+      }
+    }
+  }
+
+  if (!props.xAxisField) {
+    const dimension = fields.find((field) => !field.aggregation);
+    if (dimension) {
+      props.xAxisField = dimension.fieldId;
+    }
+  }
+
+  if (!props.categoryField) {
+    const category = fields.find((field) => !field.aggregation);
+    if (category) {
+      props.categoryField = category.fieldId;
+    }
+  }
+
+  if (!props.valueField) {
+    const value = fields.find((field) => field.aggregation && field.aggregation !== 'none');
+    if (value) {
+      props.valueField = value.fieldId;
+      if (!props.aggregation || props.aggregation === 'none') {
+        props.aggregation = value.aggregation;
+      }
+    }
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -849,4 +1373,23 @@ function layoutMetaToPuckProps(node: LayoutComponent): Record<string, unknown> {
   if (node.meta.headerSize) props.size = node.meta.headerSize;
   if (node.meta.height) props.height = node.meta.height;
   return props;
+}
+
+/** Puck resolveData — repairs axis bindings before fields panel / preview read props. */
+export async function chartAxisResolveData(data: {
+  props: Record<string, unknown>;
+}): Promise<{ props: Record<string, unknown> }> {
+  const props = { ...(data.props ?? {}) };
+  repairChartAxisPropsRecord(props);
+
+  const unchanged =
+    props.xAxisField === data.props?.xAxisField &&
+    props.yAxisField === data.props?.yAxisField &&
+    props.aggregation === data.props?.aggregation;
+
+  if (unchanged) {
+    return { props: data.props };
+  }
+
+  return { props };
 }

--- a/packages/designer/src/adapters/switch-puck-chart-type.ts
+++ b/packages/designer/src/adapters/switch-puck-chart-type.ts
@@ -1,0 +1,182 @@
+/**
+ * Switch an existing Puck chart block to another chart type while preserving
+ * compatible field bindings and visual props.
+ */
+import type { ComponentData } from '@puckeditor/core';
+import * as chartBlocks from '../blocks/charts';
+import { repairChartAxisPropsRecord } from './puck-canonical';
+import {
+  CHART_BLOCK_NAMES,
+  PUCK_NAME_TO_WIDGET_TYPE,
+  WIDGET_TYPE_TO_PUCK_NAME,
+} from '../blocks/charts';
+
+/** Puck chart blocks that support in-place type switching (excludes table/KPI/alerts). */
+export const SWITCHABLE_CHART_PUCK_NAMES = new Set(
+  CHART_BLOCK_NAMES.filter((name) => !['AlertsWidgetBlock', 'Table', 'KPICard'].includes(name)),
+);
+
+const PRESERVED_CHART_PROP_KEYS = new Set([
+  'id',
+  'title',
+  'datasetRef',
+  'xAxisField',
+  'yAxisField',
+  'seriesField',
+  'valueField',
+  'categoryField',
+  'nameField',
+  'parentField',
+  'sourceField',
+  'targetField',
+  'comparisonField',
+  'sizeField',
+  'colorGroupField',
+  'barField',
+  'lineField',
+  'messageField',
+  'severityField',
+  'timestampField',
+  'titleField',
+  'aggregation',
+  // Host runtime + designer preview still rely on legacy config keys in Puck props.
+  'xField',
+  'yField',
+  'logicalQuery',
+  'colorScheme',
+  'showLegend',
+  'legendPosition',
+  'showValues',
+  'numberFormat',
+  'xAxisTitle',
+  'yAxisTitle',
+  'xAxisLabelRotate',
+  'yAxisMin',
+  'yAxisMax',
+  'logAxis',
+  'zoomable',
+  'orientation',
+  'stacked',
+  'horizontal',
+  'smooth',
+  'showMarkers',
+  'markerSize',
+  'step',
+  'connectNulls',
+  'areaOpacity',
+  'showArea',
+  'variant',
+  'donut',
+  'filterIds',
+]);
+
+export function isSwitchableChartPuckType(puckType: string): boolean {
+  return SWITCHABLE_CHART_PUCK_NAMES.has(puckType as (typeof CHART_BLOCK_NAMES)[number]);
+}
+
+export function puckTypeToWidgetType(puckType: string): string | undefined {
+  return PUCK_NAME_TO_WIDGET_TYPE[puckType];
+}
+
+export function widgetTypeToPuckType(widgetType: string): string | undefined {
+  return WIDGET_TYPE_TO_PUCK_NAME[widgetType];
+}
+
+function getBlockDefaultProps(puckName: string): Record<string, unknown> {
+  const block = (chartBlocks as Record<string, { defaultProps?: Record<string, unknown> }>)[
+    puckName
+  ];
+  return { ...(block?.defaultProps ?? {}) };
+}
+
+function mergeChartPropsForTypeSwitch(
+  currentProps: Record<string, unknown>,
+  targetDefaults: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...targetDefaults };
+
+  for (const [key, value] of Object.entries(currentProps)) {
+    if (!PRESERVED_CHART_PROP_KEYS.has(key)) continue;
+    if (value === undefined || value === '') continue;
+    merged[key] = value;
+  }
+
+  if (currentProps.id !== undefined) {
+    merged.id = currentProps.id;
+  }
+  if (currentProps.title !== undefined) {
+    merged.title = currentProps.title;
+  }
+
+  return merged;
+}
+
+function applyTargetChartFieldDefaults(
+  props: Record<string, unknown>,
+  targetPuckName: string,
+): void {
+  if (targetPuckName === 'PieChart') {
+    if (!props.categoryField && !props.nameField) {
+      props.categoryField = props.xField ?? props.xAxisField ?? props.nameField;
+    }
+    if (!props.valueField) {
+      props.valueField = props.yField ?? props.yAxisField;
+    }
+  }
+
+  if (
+    targetPuckName === 'BarChart' ||
+    targetPuckName === 'LineChart' ||
+    targetPuckName === 'AreaChart'
+  ) {
+    if (!props.xField) {
+      props.xField = props.categoryField ?? props.nameField ?? props.xAxisField;
+    }
+    if (!props.yField) {
+      props.yField = props.valueField ?? props.yAxisField;
+    }
+  }
+}
+
+/**
+ * Build replacement Puck component data for a chart type switch.
+ * Returns null when the target type matches the current type or is unsupported.
+ */
+export function buildPuckChartTypeReplacement(
+  current: ComponentData,
+  targetWidgetType: string,
+): ComponentData | null {
+  const targetPuckName = widgetTypeToPuckType(targetWidgetType);
+  if (!targetPuckName || !isSwitchableChartPuckType(targetPuckName)) {
+    return null;
+  }
+
+  const currentWidgetType = puckTypeToWidgetType(current.type);
+  if (!currentWidgetType || currentWidgetType === targetWidgetType) {
+    return null;
+  }
+
+  if (!isSwitchableChartPuckType(current.type)) {
+    return null;
+  }
+
+  const targetDefaults = getBlockDefaultProps(targetPuckName);
+  const currentProps = (current.props ?? {}) as Record<string, unknown>;
+  const merged = mergeChartPropsForTypeSwitch(currentProps, targetDefaults);
+  applyTargetChartFieldDefaults(merged, targetPuckName);
+  repairChartAxisPropsRecord(merged);
+
+  const widgetId =
+    typeof current.props?.id === 'string' && current.props.id.length > 0 ? current.props.id : null;
+  if (!widgetId) {
+    return null;
+  }
+
+  return {
+    type: targetPuckName,
+    props: {
+      ...merged,
+      id: widgetId,
+    },
+  };
+}

--- a/packages/designer/src/blocks/charts/index.ts
+++ b/packages/designer/src/blocks/charts/index.ts
@@ -19,7 +19,7 @@ const titleField = {
 
 const xAxisFieldRef = createFieldRefField('X-Axis Field', ['time', 'dimension']);
 
-const yAxisFieldRef = createFieldRefField('Y-Axis Field', ['measure']);
+const yAxisFieldRef = createFieldRefField('Y-Axis Field', ['measure', 'key']);
 
 const seriesFieldRef = createFieldRefField('Series Field', ['dimension']);
 
@@ -296,8 +296,6 @@ export const LineChart: ComponentConfig = {
   defaultProps: {
     title: 'Line Chart',
     datasetRef: '',
-    xAxisField: '',
-    yAxisField: '',
     seriesField: '',
     aggregation: 'none',
     smooth: 'false',
@@ -364,8 +362,6 @@ export const BarChart: ComponentConfig = {
   defaultProps: {
     title: 'Bar Chart',
     datasetRef: '',
-    xAxisField: '',
-    yAxisField: '',
     seriesField: '',
     aggregation: 'none',
     orientation: 'vertical',
@@ -414,9 +410,6 @@ export const PieChart: ComponentConfig = {
   defaultProps: {
     title: 'Pie Chart',
     datasetRef: '',
-    categoryField: '',
-    valueField: '',
-    aggregation: 'none',
     variant: 'pie',
     innerRadius: 0,
     outerRadius: 70,
@@ -453,8 +446,6 @@ export const ScatterChart: ComponentConfig = {
   defaultProps: {
     title: 'Scatter Chart',
     datasetRef: '',
-    xAxisField: '',
-    yAxisField: '',
     sizeField: '',
     colorGroupField: '',
     symbolSize: 10,
@@ -523,8 +514,6 @@ export const AreaChart: ComponentConfig = {
   defaultProps: {
     title: 'Area Chart',
     datasetRef: '',
-    xAxisField: '',
-    yAxisField: '',
     seriesField: '',
     aggregation: 'none',
     stacked: 'false',
@@ -560,7 +549,6 @@ export const ComboChart: ComponentConfig = {
   defaultProps: {
     title: 'Combo Chart',
     datasetRef: '',
-    xAxisField: '',
     barField: '',
     lineField: '',
     aggregation: 'none',

--- a/packages/designer/src/components/ChartAxisResolveOnSelect.tsx
+++ b/packages/designer/src/components/ChartAxisResolveOnSelect.tsx
@@ -1,0 +1,42 @@
+/**
+ * When a chart is selected, run Puck resolveData once for that widget id.
+ *
+ * Uses Puck's built-in replace path (no setData) so axis bindings from logicalQuery
+ * are merged into the store for the fields panel. Must NOT dispatch setData on every
+ * data change — that caused an infinite render loop and browser lockup.
+ */
+import { useEffect, useRef } from 'react';
+import { createUsePuck } from '@puckeditor/core';
+
+const usePuckSelector = createUsePuck();
+
+function isChartPuckType(type: string): boolean {
+  return (
+    type.endsWith('Chart') || type === 'KPICard' || type === 'Table' || type === 'AlertsWidgetBlock'
+  );
+}
+
+export function ChartAxisResolveOnSelect() {
+  const selectedItem = usePuckSelector((store) => store.selectedItem);
+  const resolveDataById = usePuckSelector((store) => store.resolveDataById);
+  const resolvedForIdRef = useRef<string | null>(null);
+
+  const selectedId = typeof selectedItem?.props?.id === 'string' ? selectedItem.props.id : null;
+  const selectedType = selectedItem?.type ?? null;
+
+  useEffect(() => {
+    if (!selectedId || !selectedType || !isChartPuckType(selectedType)) {
+      resolvedForIdRef.current = null;
+      return;
+    }
+
+    if (resolvedForIdRef.current === selectedId) {
+      return;
+    }
+
+    resolvedForIdRef.current = selectedId;
+    void resolveDataById(selectedId, 'force');
+  }, [resolveDataById, selectedId, selectedType]);
+
+  return null;
+}

--- a/packages/designer/src/components/ChartTypeSwitchPanel.tsx
+++ b/packages/designer/src/components/ChartTypeSwitchPanel.tsx
@@ -1,0 +1,104 @@
+/**
+ * Contextual chart type switcher shown in Puck's right sidebar when a chart
+ * widget is selected. Dispatches a Puck replace action so puckToCanonical
+ * emits the new canonical widget type on publish.
+ */
+import React, { useCallback } from 'react';
+import { createUsePuck } from '@puckeditor/core';
+import { ChartTypePicker } from './ChartTypePicker';
+import {
+  buildPuckChartTypeReplacement,
+  isSwitchableChartPuckType,
+  puckTypeToWidgetType,
+} from '../adapters/switch-puck-chart-type';
+
+// Puck's default `usePuck()` ignores selectors — use createUsePuck() instead.
+const usePuckSelector = createUsePuck();
+
+export function ChartTypeSwitchPanel() {
+  const selectedItem = usePuckSelector((store) => store.selectedItem);
+  const dispatch = usePuckSelector((store) => store.dispatch);
+  const getSelectorForId = usePuckSelector((store) => store.getSelectorForId);
+  const appState = usePuckSelector((store) => store.appState);
+
+  const handleChange = useCallback(
+    (targetWidgetType: string) => {
+      if (!selectedItem) return;
+
+      const replacement = buildPuckChartTypeReplacement(selectedItem, targetWidgetType);
+      if (!replacement) return;
+
+      const widgetId = selectedItem.props?.id;
+      if (typeof widgetId !== 'string' || widgetId.length === 0) return;
+
+      let destinationZone: string | undefined;
+      let destinationIndex = -1;
+
+      const selector = getSelectorForId(widgetId);
+      if (selector) {
+        destinationZone = selector.zone;
+        destinationIndex = selector.index;
+      }
+
+      if (destinationIndex < 0 && appState?.data) {
+        const rootIndex = appState.data.content.findIndex((item) => item.props?.id === widgetId);
+        if (rootIndex >= 0) {
+          destinationIndex = rootIndex;
+        } else if (appState.data.zones) {
+          for (const [zoneName, zoneContent] of Object.entries(appState.data.zones)) {
+            const zoneIndex = zoneContent.findIndex((item) => item.props?.id === widgetId);
+            if (zoneIndex >= 0) {
+              destinationZone = zoneName;
+              destinationIndex = zoneIndex;
+              break;
+            }
+          }
+        }
+      }
+
+      if (destinationIndex < 0) return;
+
+      dispatch({
+        type: 'replace',
+        destinationIndex,
+        destinationZone: destinationZone ?? '',
+        data: replacement,
+      });
+    },
+    [appState, dispatch, getSelectorForId, selectedItem],
+  );
+
+  if (!selectedItem || !isSwitchableChartPuckType(selectedItem.type)) {
+    return null;
+  }
+
+  const currentWidgetType = puckTypeToWidgetType(selectedItem.type);
+  if (!currentWidgetType) {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid="chart-type-switch-panel"
+      style={{
+        marginBottom: 16,
+        paddingBottom: 16,
+        borderBottom: '1px solid var(--puck-color-grey-09, #e2e8f0)',
+      }}
+    >
+      <div
+        style={{
+          fontSize: 12,
+          fontWeight: 600,
+          letterSpacing: '0.02em',
+          textTransform: 'uppercase',
+          color: 'var(--puck-color-grey-04, #64748b)',
+          marginBottom: 8,
+        }}
+      >
+        Chart type
+      </div>
+      <ChartTypePicker compact value={currentWidgetType} onChange={handleChange} />
+    </div>
+  );
+}

--- a/packages/designer/src/components/SupersubsetDesigner.tsx
+++ b/packages/designer/src/components/SupersubsetDesigner.tsx
@@ -10,7 +10,11 @@ import type { Data } from '@puckeditor/core';
 import type { DashboardDefinition, PageDefinition } from '@supersubset/schema';
 import type { NormalizedDataset } from '@supersubset/data-model';
 import { createPuckConfig } from '../config/puck-config';
-import { puckToCanonical, canonicalToPuck } from '../adapters/puck-canonical';
+import {
+  puckToCanonical,
+  canonicalToPuck,
+  repairChartAxisPropsInPuckData,
+} from '../adapters/puck-canonical';
 import { getComponentIcon } from '../icons/component-icons';
 import { DatasetProvider } from '../context/DatasetContext';
 import { PreviewDataProvider, type FetchPreviewData } from '../context/PreviewDataContext';
@@ -20,6 +24,8 @@ import {
   decorateDesignerShell,
   injectDesignerSidebarStyles,
 } from './designer-shell-utils';
+import { ChartTypeSwitchPanel } from './ChartTypeSwitchPanel';
+import { ChartAxisResolveOnSelect } from './ChartAxisResolveOnSelect';
 import { FilterBuilderPanel } from './FilterBuilderPanel';
 import { SlideOverPanel } from './SlideOverPanel';
 
@@ -86,6 +92,12 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
     DashboardDefinition | undefined
   >(defaultValue);
   const sourceDashboard = isControlled ? value : (uncontrolledDashboard ?? defaultValue);
+
+  useEffect(() => {
+    if (!isControlled && defaultValue) {
+      setUncontrolledDashboard(defaultValue);
+    }
+  }, [defaultValue, isControlled]);
   const pages = sourceDashboard?.pages ?? [];
   const [activePageId, setActivePageId] = useState<string | undefined>(
     sourceDashboard?.defaults?.activePage ?? sourceDashboard?.pages[0]?.id,
@@ -103,6 +115,8 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
   const [pendingDeletePageId, setPendingDeletePageId] = useState<string | undefined>();
   const [controlledSyncRevision, setControlledSyncRevision] = useState(0);
   const canMutateDashboard = !isControlled || !!onChange;
+  /** Avoid Puck onChange → parent re-render → data prop churn loops in publish-only hosts. */
+  const syncPuckCanvasToDashboard = isControlled || !!onChange;
   const pendingDeletePage = pages.find((page) => page.id === pendingDeletePageId);
   const hasUncommittedDraftChanges =
     canMutateDashboard &&
@@ -398,6 +412,15 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
   // Sidebar icon overrides + header actions wrapper
   const overrides = useMemo(
     () => ({
+      fields: ({ children }: { children: React.ReactNode }) => {
+        return React.createElement(
+          React.Fragment,
+          null,
+          React.createElement(ChartAxisResolveOnSelect),
+          React.createElement(ChartTypeSwitchPanel),
+          children,
+        );
+      },
       drawerItem: ({ name, children }: { name: string; children: React.ReactNode }) => {
         const icon = getComponentIcon(name);
         return React.createElement(
@@ -492,7 +515,7 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
     if (!source) {
       return { root: { props: {} }, content: [] };
     }
-    return canonicalToPuck(source, { pageIndex: activePageIndex });
+    return repairChartAxisPropsInPuckData(canonicalToPuck(source, { pageIndex: activePageIndex }));
   }, [activePageIndex, sourceDashboard]);
 
   // Track latest dashboard ID from source
@@ -506,7 +529,8 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
 
   const handleChange = useCallback(
     (puckData: Data) => {
-      const dashboard = puckToCanonical(puckData, {
+      const repaired = repairChartAxisPropsInPuckData(puckData);
+      const dashboard = puckToCanonical(repaired, {
         dashboardId: dashboardIdRef.current,
         dashboardTitle: effectiveDashboardTitle,
         baseDashboard: sourceDashboard,
@@ -529,7 +553,8 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
   const handlePublish = useCallback(
     (puckData: Data) => {
       if (onPublish) {
-        const dashboard = puckToCanonical(puckData, {
+        const repaired = repairChartAxisPropsInPuckData(puckData);
+        const dashboard = puckToCanonical(repaired, {
           dashboardId: dashboardIdRef.current,
           dashboardTitle: effectiveDashboardTitle,
           baseDashboard: sourceDashboard,
@@ -579,6 +604,7 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
     {
       ref: designerRootRef,
       'data-supersubset-designer-root': 'true',
+      ...(disableIframe ? { 'data-supersubset-inline-preview': 'true' } : {}),
       style: {
         display: 'flex',
         flexDirection: 'column',
@@ -601,7 +627,7 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
                 key: editorKey,
                 config,
                 data: initialData,
-                onChange: canMutateDashboard ? handleChange : undefined,
+                onChange: syncPuckCanvasToDashboard ? handleChange : undefined,
                 onPublish: onPublish ? handlePublish : undefined,
                 headerTitle: headerTitle ?? (sourceDashboard?.title || 'Supersubset Designer'),
                 height,
@@ -615,7 +641,7 @@ export function SupersubsetDesigner(props: SupersubsetDesignerProps) {
               key: editorKey,
               config,
               data: initialData,
-              onChange: canMutateDashboard ? handleChange : undefined,
+              onChange: syncPuckCanvasToDashboard ? handleChange : undefined,
               onPublish: onPublish ? handlePublish : undefined,
               headerTitle: headerTitle ?? (sourceDashboard?.title || 'Supersubset Designer'),
               height,

--- a/packages/designer/src/components/designer-shell-utils.ts
+++ b/packages/designer/src/components/designer-shell-utils.ts
@@ -10,6 +10,10 @@ const SIDEBAR_CSS = `\
 [data-supersubset-designer-root] [class*="PuckHeader-inner"]{grid-template-columns:auto auto 1fr}\
 [data-supersubset-designer-root] [class*="PuckHeader-tools"]{min-width:0}\
 }\
+[data-supersubset-designer-root][data-supersubset-inline-preview="true"] [class*="PuckCanvas-root"],\
+[data-supersubset-designer-root][data-supersubset-inline-preview="true"] #puck-canvas-root{position:relative!important;top:auto!important;bottom:auto!important;transform:none!important}\
+[data-supersubset-designer-root][data-supersubset-inline-preview="true"] [class*="PuckLayout-inner"]{min-height:0!important}\
+[data-supersubset-designer-root][data-supersubset-inline-preview="true"] [class*="PuckCanvas"]{min-height:0!important}\
 @media (min-width:638px) and (max-width:1024px){[data-supersubset-designer-root] [class*="PuckLayout-inner"]{--puck-user-left-side-bar-width:212px;--puck-user-right-side-bar-width:168px;--puck-frame-width:minmax(320px,1fr)}[data-testid="designer-header-controls"]{gap:8px!important;row-gap:6px!important}[data-testid="designer-page-controls"]{flex:1 0 100%!important}[data-supersubset-header-metadata="true"]{flex:0 1 auto!important;flex-wrap:nowrap!important;align-items:center!important}[data-supersubset-header-metadata="true"] label{gap:0!important}[data-supersubset-header-metadata="true"] label>span{display:none!important}[data-testid="designer-page-title-input"]{width:150px!important}[data-testid="designer-dashboard-title-input"]{width:180px!important}[data-supersubset-built-in-actions="true"]{flex:0 0 auto!important}[data-testid="designer-host-actions"]{flex:1 1 220px!important;justify-content:flex-start!important;min-width:0!important;overflow:hidden!important}}\
 `;
 

--- a/packages/designer/src/config/puck-config.ts
+++ b/packages/designer/src/config/puck-config.ts
@@ -2,7 +2,7 @@
  * Central Puck Config for the Supersubset Designer.
  * Defines all components and categories for the editor sidebar.
  */
-import type { Config } from '@puckeditor/core';
+import type { Config, ComponentConfig } from '@puckeditor/core';
 import type { FilterDefinition } from '@supersubset/schema';
 import React from 'react';
 
@@ -10,6 +10,28 @@ import * as chartBlocks from '../blocks/charts';
 import * as contentBlocks from '../blocks/content';
 import * as controlBlocks from '../blocks/controls';
 import * as layoutBlocks from '../blocks/layout';
+import { chartAxisResolveData } from '../adapters/puck-canonical';
+
+const BINDING_REPAIR_CHARTS = new Set([
+  'LineChart',
+  'BarChart',
+  'ScatterChart',
+  'AreaChart',
+  'ComboChart',
+  'PieChart',
+  'KPICard',
+]);
+
+function withChartAxisResolveData(block: ComponentConfig): ComponentConfig {
+  return { ...block, resolveData: chartAxisResolveData };
+}
+
+function registerChartBlock(name: string, block: ComponentConfig): ComponentConfig {
+  if (BINDING_REPAIR_CHARTS.has(name)) {
+    return withChartAxisResolveData(block);
+  }
+  return block;
+}
 
 /**
  * Build the complete Puck Config with all Supersubset blocks.
@@ -38,12 +60,12 @@ export function createPuckConfig(options: CreatePuckConfigOptions = {}): Config 
     },
     components: {
       // Charts
-      LineChart: chartBlocks.LineChart,
-      BarChart: chartBlocks.BarChart,
-      PieChart: chartBlocks.PieChart,
-      ScatterChart: chartBlocks.ScatterChart,
-      AreaChart: chartBlocks.AreaChart,
-      ComboChart: chartBlocks.ComboChart,
+      LineChart: registerChartBlock('LineChart', chartBlocks.LineChart),
+      BarChart: registerChartBlock('BarChart', chartBlocks.BarChart),
+      PieChart: registerChartBlock('PieChart', chartBlocks.PieChart),
+      ScatterChart: registerChartBlock('ScatterChart', chartBlocks.ScatterChart),
+      AreaChart: registerChartBlock('AreaChart', chartBlocks.AreaChart),
+      ComboChart: registerChartBlock('ComboChart', chartBlocks.ComboChart),
       HeatmapChart: chartBlocks.HeatmapChart,
       RadarChart: chartBlocks.RadarChart,
       FunnelChart: chartBlocks.FunnelChart,
@@ -54,7 +76,7 @@ export function createPuckConfig(options: CreatePuckConfigOptions = {}): Config 
       GaugeChart: chartBlocks.GaugeChart,
       AlertsWidgetBlock: chartBlocks.AlertsWidgetBlock,
       Table: chartBlocks.Table,
-      KPICard: chartBlocks.KPICard,
+      KPICard: registerChartBlock('KPICard', chartBlocks.KPICard),
       // Content
       HeaderBlock: contentBlocks.HeaderBlock,
       MarkdownBlock: contentBlocks.MarkdownBlock,

--- a/packages/designer/src/fields/field-ref-field.tsx
+++ b/packages/designer/src/fields/field-ref-field.tsx
@@ -57,6 +57,21 @@ function FieldRefSelect({
     return result;
   }, [datasets, acceptRoles]);
 
+  const optionsWithCurrentValue = React.useMemo(() => {
+    if (!value || options.some((opt) => opt.value === value)) {
+      return options;
+    }
+    return [
+      {
+        value,
+        label: `${value} (bound)`,
+        dataset: 'Current binding',
+        role: 'dimension' as FieldRole,
+      },
+      ...options,
+    ];
+  }, [options, value]);
+
   // If no datasets are available, fall back to a text input
   if (datasets.length === 0) {
     return React.createElement(
@@ -111,7 +126,7 @@ function FieldRefSelect({
         },
       },
       React.createElement('option', { value: '' }, `Select ${label.toLowerCase()}…`),
-      ...options.map((opt) =>
+      ...optionsWithCurrentValue.map((opt) =>
         React.createElement(
           'option',
           { key: `${opt.dataset}-${opt.value}`, value: opt.value },

--- a/packages/designer/test/designer-controlled-sync.test.tsx
+++ b/packages/designer/test/designer-controlled-sync.test.tsx
@@ -33,6 +33,12 @@ vi.mock('@puckeditor/core', async () => {
     },
     blocksPlugin: () => ({ name: 'blocks', label: 'Blocks' }),
     outlinePlugin: () => ({ name: 'outline', label: 'Outline' }),
+    createUsePuck: () => () => ({
+      selectedItem: null,
+      dispatch: vi.fn(),
+      getSelectorForId: vi.fn(),
+      appState: { data: { content: [] } },
+    }),
   };
 });
 

--- a/packages/designer/test/designer.test.tsx
+++ b/packages/designer/test/designer.test.tsx
@@ -59,6 +59,12 @@ vi.mock('@puckeditor/core', () => ({
   },
   blocksPlugin: () => ({ name: 'blocks', label: 'Blocks' }),
   outlinePlugin: () => ({ name: 'outline', label: 'Outline' }),
+  createUsePuck: () => () => ({
+    selectedItem: null,
+    dispatch: vi.fn(),
+    getSelectorForId: vi.fn(),
+    appState: { data: { content: [] } },
+  }),
 }));
 
 vi.mock('@puckeditor/core/puck.css', () => ({}));
@@ -188,6 +194,19 @@ describe('SupersubsetDesigner', () => {
     expect(root?.style.height).toBe('100%');
     expect(root?.style.overflow).toBe('hidden');
     expect(root?.style.display).toBe('flex');
+  });
+
+  it('marks inline preview mode when iframes are disabled', () => {
+    const { container } = render(
+      React.createElement(SupersubsetDesigner, {
+        disableIframe: true,
+      }),
+    );
+
+    const root = container.querySelector(
+      '[data-supersubset-designer-root="true"]',
+    ) as HTMLDivElement | null;
+    expect(root?.getAttribute('data-supersubset-inline-preview')).toBe('true');
   });
 
   it('passes headerTitle from props', () => {

--- a/packages/designer/test/host-embedded-chart-roundtrip.test.ts
+++ b/packages/designer/test/host-embedded-chart-roundtrip.test.ts
@@ -1,0 +1,544 @@
+/**
+ * Round-trip tests for host-embedded dashboards (Tripmatch analytics seed shape).
+ */
+import { describe, it, expect } from 'vitest';
+import type { DashboardDefinition } from '@supersubset/schema';
+import {
+  canonicalToPuck,
+  puckToCanonical,
+  repairChartAxisPropsInPuckData,
+  collectChartAxisBindingSnapshot,
+} from '../src/adapters/puck-canonical';
+import { buildPuckChartTypeReplacement } from '../src/adapters/switch-puck-chart-type';
+
+const PLAN_CHART_DAY_WIDGET = {
+  id: 'plan_chart_day',
+  type: 'area-chart',
+  title: 'Plans created per day',
+  dataBinding: {
+    datasetRef: 'fact_plan_events',
+    fields: [
+      { role: 'x-axis', fieldRef: 'event_date' },
+      { role: 'y-axis', fieldRef: 'event_id', aggregation: 'count' },
+    ],
+  },
+  config: {
+    logicalQuery: {
+      datasetId: 'fact_plan_events',
+      fields: [
+        { fieldId: 'event_date' },
+        { fieldId: 'event_id', aggregation: 'count', alias: 'count' },
+      ],
+      filters: [{ fieldId: 'event_type', operator: 'eq', value: 'CREATED' }],
+      sort: [{ fieldId: 'event_date', direction: 'asc' }],
+      limit: 90,
+    },
+    xField: 'event_date',
+    yField: 'count',
+  },
+};
+
+function makeDashboard(widget: Record<string, unknown>): DashboardDefinition {
+  return makeDashboardWithLayout(widget, 'flat');
+}
+
+/** Tripmatch seed uses row → widget slots (not flat grid → widget). */
+function makeRowLayoutDashboard(widget: Record<string, unknown>): DashboardDefinition {
+  return makeDashboardWithLayout(widget, 'row');
+}
+
+/** Matches buildPage('plan', ...) row 2 — two chart widgets side by side. */
+function makeTripmatchPlanChartsRowDashboard(
+  primaryWidget: Record<string, unknown>,
+): DashboardDefinition {
+  const secondaryWidget = {
+    id: 'plan_chart_type',
+    type: 'pie-chart',
+    title: 'Plans by type',
+    config: {
+      logicalQuery: PLAN_CHART_DAY_WIDGET.config.logicalQuery,
+      nameField: 'plan_type',
+      valueField: 'count',
+    },
+  };
+
+  return {
+    schemaVersion: '0.2.0',
+    id: 'tripmatch-analytics',
+    title: 'Tripmatch analytics',
+    pages: [
+      {
+        id: 'plan-activity',
+        title: 'Plan activity',
+        rootNodeId: 'plan_root',
+        layout: {
+          plan_root: { id: 'plan_root', type: 'root', children: ['plan_grid'], meta: {} },
+          plan_grid: {
+            id: 'plan_grid',
+            type: 'grid',
+            children: ['plan_row_2'],
+            parentId: 'plan_root',
+            meta: { columns: 12, gap: '16px' },
+          },
+          plan_row_2: {
+            id: 'plan_row_2',
+            type: 'row',
+            children: ['plan_slot_2_0', 'plan_slot_2_1'],
+            meta: {},
+          },
+          plan_slot_2_0: {
+            id: 'plan_slot_2_0',
+            type: 'widget',
+            children: [],
+            meta: { widgetRef: 'plan_chart_day', width: 6, height: 32 },
+          },
+          plan_slot_2_1: {
+            id: 'plan_slot_2_1',
+            type: 'widget',
+            children: [],
+            meta: { widgetRef: 'plan_chart_type', width: 6, height: 32 },
+          },
+        },
+        widgets: [primaryWidget as never, secondaryWidget as never],
+      },
+    ],
+  };
+}
+
+function makeDashboardWithLayout(
+  widget: Record<string, unknown>,
+  layout: 'flat' | 'row',
+): DashboardDefinition {
+  const rowLayout =
+    layout === 'row'
+      ? {
+          root: { id: 'root', type: 'root', children: ['grid-main'], meta: {} },
+          'grid-main': {
+            id: 'grid-main',
+            type: 'grid',
+            children: ['row-0'],
+            parentId: 'root',
+            meta: { columns: 12 },
+          },
+          'row-0': {
+            id: 'row-0',
+            type: 'row',
+            children: ['slot-1', 'slot-2'],
+            parentId: 'grid-main',
+            meta: {},
+          },
+          'slot-1': {
+            id: 'slot-1',
+            type: 'widget',
+            parentId: 'row-0',
+            children: [],
+            meta: { widgetRef: 'plan_chart_day', width: 6 },
+          },
+          'slot-2': {
+            id: 'slot-2',
+            type: 'widget',
+            parentId: 'row-0',
+            children: [],
+            meta: { widgetRef: 'plan_chart_type', width: 6 },
+          },
+        }
+      : {
+          root: { id: 'root', type: 'root', children: ['grid-main'], meta: {} },
+          'grid-main': {
+            id: 'grid-main',
+            type: 'grid',
+            children: ['slot-1'],
+            parentId: 'root',
+            meta: { columns: 12 },
+          },
+          'slot-1': {
+            id: 'slot-1',
+            type: 'widget',
+            parentId: 'grid-main',
+            children: [],
+            meta: { widgetRef: 'plan_chart_day', width: 6 },
+          },
+        };
+
+  return {
+    schemaVersion: '0.2.0',
+    id: 'tripmatch-analytics',
+    title: 'Tripmatch analytics',
+    pages: [
+      {
+        id: 'plan-activity',
+        title: 'Plan activity',
+        rootNodeId: 'root',
+        layout: rowLayout,
+        widgets: [widget as never],
+      },
+    ],
+  };
+}
+
+function findChartProps(content: unknown[]): Record<string, unknown> | undefined {
+  for (const item of content) {
+    if (!item || typeof item !== 'object') continue;
+    const record = item as Record<string, unknown>;
+    if (record.type === 'AreaChart' || record.type === 'BarChart') {
+      return record.props as Record<string, unknown>;
+    }
+    const props = record.props as Record<string, unknown> | undefined;
+    const nested = props?.content;
+    if (Array.isArray(nested)) {
+      const found = findChartProps(nested);
+      if (found) return found;
+    }
+    const rowContent = props?.content;
+    if (Array.isArray(rowContent)) {
+      for (const rowItem of rowContent) {
+        if (!rowItem || typeof rowItem !== 'object') continue;
+        const rowProps = (rowItem as Record<string, unknown>).props as
+          | Record<string, unknown>
+          | undefined;
+        const columnContent = rowProps?.content;
+        if (Array.isArray(columnContent)) {
+          const found = findChartProps(columnContent);
+          if (found) return found;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+describe('host-embedded chart round-trip', () => {
+  it('loads normalized browser JSON for plan_chart_day in tripmatch row layout', () => {
+    const browserWidget = {
+      id: 'plan_chart_day',
+      type: 'area-chart',
+      title: 'Plans created per day',
+      config: {
+        logicalQuery: PLAN_CHART_DAY_WIDGET.config.logicalQuery,
+        xField: 'event_date',
+        yField: 'count',
+      },
+      dataBinding: {
+        datasetRef: 'fact_plan_events',
+        fields: [
+          { role: 'x-axis', fieldRef: 'event_date' },
+          { role: 'y-axis', fieldRef: 'event_id', aggregation: 'count' },
+        ],
+      },
+    };
+    const puck = canonicalToPuck(makeTripmatchPlanChartsRowDashboard(browserWidget));
+    const props = findChartProps((puck.content ?? []) as unknown[]);
+    expect(props?.xAxisField).toBe('event_date');
+    expect(props?.yAxisField).toBe('event_id');
+    expect(props?.aggregation).toBe('count');
+  });
+
+  it('loads seed-only config in row layout (Tripmatch buildPage shape)', () => {
+    const seedWidget = {
+      id: 'plan_chart_day',
+      type: 'area-chart',
+      title: 'Plans created per day',
+      config: {
+        logicalQuery: PLAN_CHART_DAY_WIDGET.config.logicalQuery,
+        xField: 'event_date',
+        yField: 'count',
+      },
+    };
+    const puck = canonicalToPuck(makeRowLayoutDashboard(seedWidget));
+    const props = findChartProps((puck.content ?? []) as unknown[]);
+    expect(props?.xAxisField).toBe('event_date');
+    expect(props?.yAxisField).toBe('event_id');
+    expect(props?.aggregation).toBe('count');
+  });
+
+  it('chart type switch keeps logicalQuery and host aliases when yAxisField is empty', () => {
+    const puck = canonicalToPuck(makeDashboard(PLAN_CHART_DAY_WIDGET));
+    const areaProps = findChartProps((puck.content ?? []) as unknown[]);
+    expect(areaProps).toBeDefined();
+
+    const areaItem = {
+      type: 'AreaChart',
+      props: {
+        ...areaProps,
+        yAxisField: undefined,
+        xAxisField: 'event_date',
+        xField: 'event_date',
+        yField: 'count',
+        logicalQuery: PLAN_CHART_DAY_WIDGET.config.logicalQuery,
+        datasetRef: 'fact_plan_events',
+        aggregation: 'count',
+      },
+    };
+
+    const bar = buildPuckChartTypeReplacement(areaItem as never, 'bar-chart');
+    expect(bar?.props.xAxisField).toBe('event_date');
+    expect(bar?.props.xField).toBe('event_date');
+    expect(bar?.props.yField).toBe('count');
+    expect(bar?.props.logicalQuery).toEqual(PLAN_CHART_DAY_WIDGET.config.logicalQuery);
+
+    const published = puckToCanonical(
+      { root: { props: {} }, content: [bar!] },
+      {
+        dashboardId: 'tripmatch-analytics',
+        baseDashboard: makeDashboard(PLAN_CHART_DAY_WIDGET),
+      },
+    );
+
+    const widget = published.pages[0]?.widgets.find((w) => w.id === 'plan_chart_day');
+    expect(widget?.type).toBe('bar-chart');
+    expect(widget?.config.xField).toBe('event_date');
+    expect(widget?.config.yField).toBe('count');
+    expect(widget?.config.logicalQuery).toEqual(PLAN_CHART_DAY_WIDGET.config.logicalQuery);
+  });
+
+  it('loads seed-only config (no dataBinding) into puck axis props', () => {
+    const seedWidget = {
+      id: 'plan_chart_day',
+      type: 'area-chart',
+      title: 'Plans created per day',
+      config: {
+        logicalQuery: PLAN_CHART_DAY_WIDGET.config.logicalQuery,
+        xField: 'event_date',
+        yField: 'count',
+      },
+    };
+    const puck = canonicalToPuck(makeDashboard(seedWidget));
+    const props = findChartProps((puck.content ?? []) as unknown[]);
+    expect(props?.xAxisField).toBe('event_date');
+    expect(props?.yAxisField).toBe('event_id');
+    expect(props?.aggregation).toBe('count');
+  });
+
+  it('repairs incomplete dataBinding missing y-axis on load', () => {
+    const partialWidget = {
+      ...PLAN_CHART_DAY_WIDGET,
+      dataBinding: {
+        datasetRef: 'fact_plan_events',
+        fields: [{ role: 'x-axis', fieldRef: 'event_date' }],
+      },
+    };
+    const puck = canonicalToPuck(makeDashboard(partialWidget));
+    const props = findChartProps((puck.content ?? []) as unknown[]);
+    expect(props?.xAxisField).toBe('event_date');
+    expect(props?.yAxisField).toBe('event_id');
+    expect(props?.aggregation).toBe('count');
+  });
+
+  it('publish preserves host fields when puck yAxisField was empty but config yField alias exists', () => {
+    const puck = canonicalToPuck(
+      makeDashboard({
+        ...PLAN_CHART_DAY_WIDGET,
+        dataBinding: {
+          datasetRef: 'fact_plan_events',
+          fields: [{ role: 'x-axis', fieldRef: 'event_date' }],
+        },
+      }),
+    );
+    const chart = puck.content?.[0];
+    expect(chart).toBeDefined();
+    const props = { ...(chart!.props as Record<string, unknown>) };
+    delete props.yAxisField;
+    props.logicalQuery = PLAN_CHART_DAY_WIDGET.config.logicalQuery;
+
+    const published = puckToCanonical(
+      { root: { props: {} }, content: [{ ...chart!, props }] },
+      {
+        dashboardId: 'tripmatch-analytics',
+        baseDashboard: makeDashboard(PLAN_CHART_DAY_WIDGET),
+      },
+    );
+
+    const widget = published.pages[0]?.widgets.find((w) => w.id === 'plan_chart_day');
+    expect(widget?.config.xField).toBe('event_date');
+    expect(widget?.config.yField).toBe('count');
+    expect(widget?.dataBinding?.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ role: 'y-axis', fieldRef: 'event_id', aggregation: 'count' }),
+      ]),
+    );
+  });
+
+  it('loads legacy xField/yField aliases into puck props with resolved y-axis field', () => {
+    const puck = canonicalToPuck(makeDashboard(PLAN_CHART_DAY_WIDGET));
+    const chart = puck.content?.[0];
+    expect(chart?.props.xAxisField).toBe('event_date');
+    expect(chart?.props.yAxisField).toBe('event_id');
+    expect(chart?.props.aggregation).toBe('count');
+  });
+
+  it('publish preserves host xField/yField and dataBinding after puck round-trip', () => {
+    const puck = canonicalToPuck(makeDashboard(PLAN_CHART_DAY_WIDGET));
+    const published = puckToCanonical(puck, {
+      dashboardId: 'tripmatch-analytics',
+      dashboardTitle: 'Tripmatch analytics',
+      baseDashboard: makeDashboard(PLAN_CHART_DAY_WIDGET),
+    });
+
+    const widget = published.pages[0]?.widgets.find((w) => w.id === 'plan_chart_day');
+    expect(widget?.type).toBe('area-chart');
+    expect(widget?.config.xField).toBe('event_date');
+    expect(widget?.config.yField).toBe('count');
+    expect(widget?.dataBinding?.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ role: 'x-axis', fieldRef: 'event_date' }),
+        expect.objectContaining({
+          role: 'y-axis',
+          fieldRef: 'event_id',
+          aggregation: 'count',
+        }),
+      ]),
+    );
+  });
+
+  it('chart type switch preserves x/y bindings and host config fields on publish', () => {
+    const puck = canonicalToPuck(makeDashboard(PLAN_CHART_DAY_WIDGET));
+    const area = puck.content?.[0];
+    expect(area).toBeDefined();
+
+    const bar = buildPuckChartTypeReplacement(area!, 'bar-chart');
+    expect(bar?.type).toBe('BarChart');
+    expect(bar?.props.xAxisField).toBe('event_date');
+    expect(bar?.props.yAxisField).toBe('event_id');
+    expect(bar?.props.aggregation).toBe('count');
+
+    const published = puckToCanonical(
+      { root: { props: {} }, content: [bar!] },
+      {
+        dashboardId: 'tripmatch-analytics',
+        baseDashboard: makeDashboard(PLAN_CHART_DAY_WIDGET),
+      },
+    );
+
+    const widget = published.pages[0]?.widgets.find((w) => w.id === 'plan_chart_day');
+    expect(widget?.type).toBe('bar-chart');
+    expect(widget?.config.xField).toBe('event_date');
+    expect(widget?.config.yField).toBe('count');
+  });
+
+  it('repairs puck chart props from logicalQuery when yAxisField was cleared', () => {
+    const puck = canonicalToPuck(makeDashboard(PLAN_CHART_DAY_WIDGET));
+    const area = findChartProps((puck.content ?? []) as unknown[]);
+    expect(area).toBeDefined();
+
+    const broken = repairChartAxisPropsInPuckData({
+      root: { props: {} },
+      content: [
+        {
+          type: 'AreaChart',
+          props: {
+            ...area,
+            yAxisField: undefined,
+            logicalQuery: PLAN_CHART_DAY_WIDGET.config.logicalQuery,
+            datasetRef: 'fact_plan_events',
+            aggregation: 'count',
+          },
+        },
+      ],
+    });
+
+    const fixed = findChartProps((broken.content ?? []) as unknown[]);
+    expect(fixed?.yAxisField).toBe('event_id');
+    expect(fixed?.xAxisField).toBe('event_date');
+  });
+
+  it('repairs yAxisField when chart lives in Puck runtime zones', () => {
+    const logicalQuery = PLAN_CHART_DAY_WIDGET.config.logicalQuery;
+    const puckZonesData = {
+      root: { props: {} },
+      content: [{ type: 'RowBlock', props: { id: 'plan_row_2' } }],
+      zones: {
+        'plan_row_2:content': [
+          { type: 'ColumnBlock', props: { id: 'plan_slot_2_0', span: 6 } },
+          { type: 'ColumnBlock', props: { id: 'plan_slot_2_1', span: 6 } },
+        ],
+        'plan_slot_2_0:content': [
+          {
+            type: 'AreaChart',
+            props: {
+              id: 'plan_chart_day',
+              title: 'Plans created per day',
+              datasetRef: 'fact_plan_events',
+              xAxisField: 'event_date',
+              xField: 'event_date',
+              yField: 'count',
+              logicalQuery,
+            },
+          },
+        ],
+      },
+    };
+
+    const before = collectChartAxisBindingSnapshot(puckZonesData);
+    expect(JSON.parse(before)[0]?.yAxisField).toBeUndefined();
+
+    const repaired = repairChartAxisPropsInPuckData(puckZonesData);
+    const chartProps = (repaired.zones?.['plan_slot_2_0:content']?.[0]?.props ?? {}) as Record<
+      string,
+      unknown
+    >;
+    expect(chartProps.yAxisField).toBe('event_id');
+    expect(chartProps.aggregation).toBe('count');
+
+    const published = puckToCanonical(repaired, {
+      dashboardId: 'tripmatch-analytics',
+      baseDashboard: makeTripmatchPlanChartsRowDashboard(PLAN_CHART_DAY_WIDGET),
+    });
+    const widget = published.pages[0]?.widgets.find((w) => w.id === 'plan_chart_day');
+    expect(widget?.config.xField).toBe('event_date');
+    expect(widget?.config.yField).toBe('count');
+  });
+
+  it('repairChartAxisPropsInPuckData is idempotent for zone-stored charts', () => {
+    const logicalQuery = PLAN_CHART_DAY_WIDGET.config.logicalQuery;
+    const puckZonesData = {
+      root: { props: {} },
+      content: [{ type: 'RowBlock', props: { id: 'plan_row_2' } }],
+      zones: {
+        'plan_slot_2_0:content': [
+          {
+            type: 'AreaChart',
+            props: {
+              id: 'plan_chart_day',
+              datasetRef: 'fact_plan_events',
+              xField: 'event_date',
+              yField: 'count',
+              logicalQuery,
+            },
+          },
+        ],
+      },
+    };
+
+    const once = repairChartAxisPropsInPuckData(puckZonesData);
+    const twice = repairChartAxisPropsInPuckData(once);
+    expect(collectChartAxisBindingSnapshot(once)).toBe(collectChartAxisBindingSnapshot(twice));
+  });
+
+  it('collectChartAxisBindingSnapshot detects axis repair delta', () => {
+    const puck = canonicalToPuck(makeDashboard(PLAN_CHART_DAY_WIDGET));
+    const areaProps = findChartProps((puck.content ?? []) as unknown[]);
+    expect(areaProps).toBeDefined();
+
+    const brokenData = {
+      root: puck.root,
+      content: [
+        {
+          type: 'AreaChart',
+          props: {
+            ...areaProps,
+            yAxisField: '',
+            logicalQuery: PLAN_CHART_DAY_WIDGET.config.logicalQuery,
+            xField: 'event_date',
+            yField: 'count',
+            datasetRef: 'fact_plan_events',
+          },
+        },
+      ],
+    };
+    const brokenSnapshot = collectChartAxisBindingSnapshot(brokenData);
+    const fixed = repairChartAxisPropsInPuckData(brokenData);
+    const after = collectChartAxisBindingSnapshot(fixed);
+    expect(brokenSnapshot).not.toBe(after);
+    expect(JSON.parse(after)[0]?.yAxisField).toBe('event_id');
+  });
+});

--- a/packages/designer/test/switch-puck-chart-type.test.ts
+++ b/packages/designer/test/switch-puck-chart-type.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for in-place chart type switching in the Puck designer.
+ */
+import { describe, it, expect } from 'vitest';
+import type { ComponentData, Data } from '@puckeditor/core';
+import { puckToCanonical } from '../src/adapters/puck-canonical';
+import {
+  buildPuckChartTypeReplacement,
+  isSwitchableChartPuckType,
+  puckTypeToWidgetType,
+} from '../src/adapters/switch-puck-chart-type';
+
+describe('switch-puck-chart-type', () => {
+  it('identifies switchable chart puck types', () => {
+    expect(isSwitchableChartPuckType('AreaChart')).toBe(true);
+    expect(isSwitchableChartPuckType('BarChart')).toBe(true);
+    expect(isSwitchableChartPuckType('KPICard')).toBe(false);
+    expect(isSwitchableChartPuckType('Table')).toBe(false);
+  });
+
+  it('maps puck types to widget types', () => {
+    expect(puckTypeToWidgetType('AreaChart')).toBe('area-chart');
+    expect(puckTypeToWidgetType('BarChart')).toBe('bar-chart');
+  });
+
+  it('switches area-chart to bar-chart preserving bindings', () => {
+    const current: ComponentData = {
+      type: 'AreaChart',
+      props: {
+        id: 'plan_chart_day',
+        title: 'Plans created per day',
+        datasetRef: 'fact_plan_events',
+        xAxisField: 'event_date',
+        yAxisField: 'event_id',
+        aggregation: 'count',
+      },
+    };
+
+    const replacement = buildPuckChartTypeReplacement(current, 'bar-chart');
+    expect(replacement).not.toBeNull();
+    expect(replacement?.type).toBe('BarChart');
+    expect(replacement?.props).toMatchObject({
+      id: 'plan_chart_day',
+      title: 'Plans created per day',
+      datasetRef: 'fact_plan_events',
+      xAxisField: 'event_date',
+      yAxisField: 'event_id',
+      aggregation: 'count',
+    });
+  });
+
+  it('returns null when target type matches current type', () => {
+    const current: ComponentData = {
+      type: 'BarChart',
+      props: { id: 'w1', title: 'Test' },
+    };
+    expect(buildPuckChartTypeReplacement(current, 'bar-chart')).toBeNull();
+  });
+
+  it('puckToCanonical emits updated widget type after replacement', () => {
+    const areaChart: ComponentData = {
+      type: 'AreaChart',
+      props: {
+        id: 'plan_chart_day',
+        title: 'Plans created per day',
+        datasetRef: 'fact_plan_events',
+        xAxisField: 'event_date',
+        yAxisField: 'event_id',
+        aggregation: 'count',
+      },
+    };
+
+    const barChart = buildPuckChartTypeReplacement(areaChart, 'bar-chart');
+    expect(barChart).not.toBeNull();
+
+    const puckData: Data = {
+      root: { props: { title: 'Test Dashboard' } },
+      content: [barChart!],
+    };
+
+    const dashboard = puckToCanonical(puckData, {
+      dashboardId: 'test-dashboard',
+      dashboardTitle: 'Test Dashboard',
+    });
+
+    const widget = dashboard.pages[0]?.widgets.find((w) => w.id === 'plan_chart_day');
+    expect(widget?.type).toBe('bar-chart');
+    expect(widget?.dataBinding?.datasetRef).toBe('fact_plan_events');
+    expect(widget?.dataBinding?.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ role: 'x-axis', fieldRef: 'event_date' }),
+        expect.objectContaining({
+          role: 'y-axis',
+          fieldRef: 'event_id',
+          aggregation: 'count',
+        }),
+      ]),
+    );
+    expect(widget?.config.xField).toBe('event_date');
+    expect(widget?.config.yField).toBe('count');
+  });
+});

--- a/packages/runtime/src/layout/render-query-helpers.ts
+++ b/packages/runtime/src/layout/render-query-helpers.ts
@@ -53,23 +53,22 @@ export function buildWidgetQuery(
     };
   }
 
+  const configQuery = readConfigLogicalQuery(widgetDef);
+  if (configQuery) {
+    return mergeActiveFiltersIntoQuery(configQuery, filters, activeFilters);
+  }
+
   const dataBinding = widgetDef.dataBinding;
   if (!dataBinding?.datasetRef || !dataBinding.fields || dataBinding.fields.length === 0) {
     return null;
   }
 
-  const fields = dataBinding.fields.map((field) => {
-    const queryField: LogicalQuery['fields'][number] = {
-      fieldId: field.fieldRef,
-    };
+  const mergedConfig = resolveDataBindingConfig(widgetDef);
+  const fields = buildQueryFieldsFromDataBinding(dataBinding.fields, mergedConfig);
 
-    const aggregation = normalizeAggregation(field.aggregation);
-    if (aggregation) {
-      queryField.aggregation = aggregation;
-    }
-
-    return queryField;
-  });
+  if (fields.length === 0) {
+    return null;
+  }
 
   const compiledFilters = compileActiveFiltersForQuery(
     dataBinding.datasetRef,
@@ -82,6 +81,202 @@ export function buildWidgetQuery(
     fields,
     ...(compiledFilters.length > 0 ? { filters: compiledFilters } : {}),
   };
+}
+
+/** Host-embedded dashboards (e.g. Tripmatch) often store the executable query on config. */
+function readConfigLogicalQuery(widgetDef: WidgetDefinition): LogicalQuery | null {
+  const raw = widgetDef.config?.logicalQuery;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null;
+  }
+
+  const record = raw as Record<string, unknown>;
+  if (typeof record.datasetId !== 'string' || record.datasetId.length === 0) {
+    return null;
+  }
+
+  if (!Array.isArray(record.fields) || record.fields.length === 0) {
+    return null;
+  }
+
+  const fields: LogicalQuery['fields'] = [];
+  for (const entry of record.fields) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      continue;
+    }
+    const field = entry as Record<string, unknown>;
+    if (typeof field.fieldId !== 'string' || field.fieldId.length === 0) {
+      continue;
+    }
+
+    const queryField: LogicalQuery['fields'][number] = {
+      fieldId: field.fieldId,
+    };
+    const aggregation = normalizeAggregation(
+      typeof field.aggregation === 'string' ? field.aggregation : undefined,
+    );
+    if (aggregation) {
+      queryField.aggregation = aggregation;
+    }
+    if (typeof field.alias === 'string' && field.alias.length > 0) {
+      queryField.alias = field.alias;
+    }
+    fields.push(queryField);
+  }
+
+  if (fields.length === 0) {
+    return null;
+  }
+
+  const query: LogicalQuery = {
+    datasetId: record.datasetId,
+    fields,
+  };
+
+  if (Array.isArray(record.filters)) {
+    const parsedFilters = parseQueryFilters(record.filters);
+    if (parsedFilters.length > 0) {
+      query.filters = parsedFilters;
+    }
+  }
+
+  if (Array.isArray(record.sort)) {
+    const parsedSort = parseQuerySort(record.sort);
+    if (parsedSort.length > 0) {
+      query.sort = parsedSort;
+    }
+  }
+
+  if (typeof record.limit === 'number' && Number.isFinite(record.limit)) {
+    query.limit = record.limit;
+  }
+
+  if (typeof record.offset === 'number' && Number.isFinite(record.offset)) {
+    query.offset = record.offset;
+  }
+
+  if (record.distinct === true) {
+    query.distinct = true;
+  }
+
+  return query;
+}
+
+function mergeActiveFiltersIntoQuery(
+  base: LogicalQuery,
+  filters: FilterDefinition[] | undefined,
+  activeFilters: FilterValue[] | undefined,
+): LogicalQuery {
+  const compiledFilters = compileActiveFiltersForQuery(base.datasetId, filters, activeFilters);
+
+  if (compiledFilters.length === 0) {
+    return base;
+  }
+
+  return {
+    ...base,
+    filters: [...(base.filters ?? []), ...compiledFilters],
+  };
+}
+
+function buildQueryFieldsFromDataBinding(
+  bindings: NonNullable<WidgetDefinition['dataBinding']>['fields'],
+  config: Record<string, unknown>,
+): LogicalQuery['fields'] {
+  const seenRoles = new Set<string>();
+  const fields: LogicalQuery['fields'] = [];
+
+  for (const field of bindings) {
+    if (!field?.fieldRef || seenRoles.has(field.role)) {
+      continue;
+    }
+
+    seenRoles.add(field.role);
+
+    const queryField: LogicalQuery['fields'][number] = {
+      fieldId: field.fieldRef,
+    };
+
+    const aggregation = normalizeAggregation(field.aggregation);
+    if (aggregation) {
+      queryField.aggregation = aggregation;
+    }
+
+    const alias = aliasForDataBindingField(field.role, config);
+    if (alias && alias !== field.fieldRef) {
+      queryField.alias = alias;
+    }
+
+    fields.push(queryField);
+  }
+
+  return fields;
+}
+
+function aliasForDataBindingField(
+  role: string,
+  config: Record<string, unknown>,
+): string | undefined {
+  switch (role) {
+    case 'y-axis':
+      return readConfigString(config, 'yField');
+    case 'value':
+      return readConfigString(config, 'valueField') ?? readConfigString(config, 'metricField');
+    case 'category':
+      return readConfigString(config, 'nameField');
+    case 'bar-y':
+      return readConfigString(config, 'barField');
+    case 'line-y':
+      return readConfigString(config, 'lineField');
+    default:
+      return undefined;
+  }
+}
+
+function readConfigString(config: Record<string, unknown>, key: string): string | undefined {
+  const value = config[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function parseQueryFilters(raw: unknown[]): NonNullable<LogicalQuery['filters']> {
+  const filters: NonNullable<LogicalQuery['filters']> = [];
+
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      continue;
+    }
+    const filter = entry as Record<string, unknown>;
+    if (typeof filter.fieldId !== 'string' || typeof filter.operator !== 'string') {
+      continue;
+    }
+    filters.push({
+      fieldId: filter.fieldId,
+      operator: filter.operator as NonNullable<LogicalQuery['filters']>[number]['operator'],
+      ...(filter.value !== undefined ? { value: filter.value } : {}),
+    });
+  }
+
+  return filters;
+}
+
+function parseQuerySort(raw: unknown[]): NonNullable<LogicalQuery['sort']> {
+  const sort: NonNullable<LogicalQuery['sort']> = [];
+
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      continue;
+    }
+    const item = entry as Record<string, unknown>;
+    if (typeof item.fieldId !== 'string') {
+      continue;
+    }
+    if (item.direction !== 'asc' && item.direction !== 'desc') {
+      continue;
+    }
+    sort.push({ fieldId: item.fieldId, direction: item.direction });
+  }
+
+  return sort;
 }
 
 export function parseStructuredAlertRule(
@@ -360,30 +555,3 @@ function parseCrossFilterId(filterId: string): { sourceWidgetId: string; fieldRe
     fieldRef: remainder.slice(separatorIndex + 1),
   };
 }
-
-const ROLE_TO_CONFIG_KEY: Record<string, string> = {
-  'x-axis': 'xField',
-  'y-axis': 'yField',
-  series: 'seriesField',
-  value: 'valueField',
-  category: 'categoryField',
-  size: 'sizeField',
-  'color-group': 'colorGroupField',
-  'bar-y': 'barField',
-  'line-y': 'lineField',
-  name: 'nameField',
-  parent: 'parentField',
-  source: 'sourceField',
-  target: 'targetField',
-  comparison: 'comparisonField',
-  'alert-title': 'titleField',
-  'alert-message': 'messageField',
-  'alert-severity': 'severityField',
-  'alert-timestamp': 'timestampField',
-};
-
-const ROLE_TO_ARRAY_CONFIG_KEY: Record<string, string> = {
-  'y-axis': 'yFields',
-  'bar-y': 'barFields',
-  'line-y': 'lineFields',
-};

--- a/packages/runtime/src/layout/widget-config.ts
+++ b/packages/runtime/src/layout/widget-config.ts
@@ -27,6 +27,13 @@ const ROLE_TO_ARRAY_CONFIG_KEY: Record<string, string> = {
   'line-y': 'lineFields',
 };
 
+/** When a scalar sibling is already set (host apps often use yField), prefer it over dataBinding fieldRefs (mart ids). */
+const ARRAY_SCALAR_SIBLING: Record<string, string> = {
+  yFields: 'yField',
+  barFields: 'barField',
+  lineFields: 'lineField',
+};
+
 export function resolveDataBindingConfig(widgetDef: WidgetDefinition): Record<string, unknown> {
   const config = { ...widgetDef.config };
   if (!widgetDef.dataBinding?.fields) return config;
@@ -46,9 +53,11 @@ export function resolveDataBindingConfig(widgetDef: WidgetDefinition): Record<st
   }
 
   for (const [key, values] of Object.entries(arrayCollectors)) {
-    if (config[key] === undefined) {
-      config[key] = values;
-    }
+    if (config[key] !== undefined) continue;
+    const siblingKey = ARRAY_SCALAR_SIBLING[key];
+    const siblingValue =
+      siblingKey && typeof config[siblingKey] === 'string' ? config[siblingKey] : undefined;
+    config[key] = siblingValue ? [siblingValue] : values;
   }
 
   if (widgetDef.dataBinding.datasetRef && !config.datasetRef) {

--- a/packages/runtime/test/filter-bar.test.tsx
+++ b/packages/runtime/test/filter-bar.test.tsx
@@ -427,6 +427,9 @@ describe('FilterBar', () => {
   });
 
   it('[filters-and-interactions.FILTER_BAR.5] renders authored weekly date range options', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 4, 28));
+
     const options = generateWeeklyDateRangeOptions(
       weeklyDateFilter.dateConfig,
       new Date(2026, 4, 28),
@@ -446,6 +449,8 @@ describe('FilterBar', () => {
 
     expect(labels[0]).toBe('All time');
     expect(labels).toContain('May 25 - May 31');
+
+    vi.useRealTimers();
   });
 
   it('[filters-and-interactions.FILTER_BAR.5] emits weekly range values that compile to logical query ranges', () => {

--- a/packages/runtime/test/render-query-helpers.test.ts
+++ b/packages/runtime/test/render-query-helpers.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import type { WidgetDefinition } from '@supersubset/schema';
+import { buildWidgetQuery } from '../src/layout/render-query-helpers';
+
+describe('buildWidgetQuery', () => {
+  it('prefers config.logicalQuery over polluted dataBinding field refs', () => {
+    const widget: WidgetDefinition = {
+      id: 'plan_chart_day',
+      type: 'area-chart',
+      title: 'Plans created per day',
+      config: {
+        xField: 'event_date',
+        yField: 'count',
+        logicalQuery: {
+          datasetId: 'fact_plan_events',
+          fields: [
+            { fieldId: 'event_date' },
+            { fieldId: 'event_id', aggregation: 'count', alias: 'count' },
+          ],
+          filters: [{ fieldId: 'event_type', operator: 'eq', value: 'CREATED' }],
+          sort: [{ fieldId: 'event_date', direction: 'asc' }],
+          limit: 90,
+        },
+      },
+      dataBinding: {
+        datasetRef: 'fact_plan_events',
+        fields: [
+          { role: 'x-axis', fieldRef: 'event_date' },
+          { role: 'y-axis', fieldRef: 'event_id', aggregation: 'count' },
+          { role: 'value', fieldRef: 'count', aggregation: 'count' },
+          { role: 'category', fieldRef: 'event_date' },
+        ],
+      },
+    };
+
+    expect(buildWidgetQuery(widget, undefined, undefined)).toEqual({
+      datasetId: 'fact_plan_events',
+      fields: [
+        { fieldId: 'event_date' },
+        { fieldId: 'event_id', aggregation: 'count', alias: 'count' },
+      ],
+      filters: [{ fieldId: 'event_type', operator: 'eq', value: 'CREATED' }],
+      sort: [{ fieldId: 'event_date', direction: 'asc' }],
+      limit: 90,
+    });
+  });
+
+  it('adds aliases when building from dataBinding and config field names', () => {
+    const widget: WidgetDefinition = {
+      id: 'w1',
+      type: 'bar-chart',
+      config: {
+        xField: 'event_date',
+        yField: 'count',
+      },
+      dataBinding: {
+        datasetRef: 'fact_plan_events',
+        fields: [
+          { role: 'x-axis', fieldRef: 'event_date' },
+          { role: 'y-axis', fieldRef: 'event_id', aggregation: 'count' },
+        ],
+      },
+    };
+
+    expect(buildWidgetQuery(widget, undefined, undefined)).toEqual({
+      datasetId: 'fact_plan_events',
+      fields: [
+        { fieldId: 'event_date' },
+        { fieldId: 'event_id', aggregation: 'count', alias: 'count' },
+      ],
+    });
+  });
+});

--- a/packages/runtime/test/widget-config.test.ts
+++ b/packages/runtime/test/widget-config.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import type { WidgetDefinition } from '@supersubset/schema';
+import { resolveDataBindingConfig } from '../src/layout/widget-config';
+
+describe('resolveDataBindingConfig', () => {
+  it('prefers scalar yField over dataBinding y-axis fieldRef when building yFields', () => {
+    const widget: WidgetDefinition = {
+      id: 'plan_chart_day',
+      type: 'area-chart',
+      title: 'Plans created per day',
+      config: {
+        xField: 'event_date',
+        yField: 'count',
+      },
+      dataBinding: {
+        datasetRef: 'fact_plan_events',
+        fields: [
+          { role: 'x-axis', fieldRef: 'event_date' },
+          { role: 'y-axis', fieldRef: 'event_id', aggregation: 'count' },
+        ],
+      },
+    };
+
+    expect(resolveDataBindingConfig(widget)).toMatchObject({
+      xField: 'event_date',
+      yField: 'count',
+      yFields: ['count'],
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,25 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      '@supersubset/adapter-sql':
+        specifier: file:.yalc/@supersubset/adapter-sql
+        version: file:.yalc/@supersubset/adapter-sql
+      '@supersubset/data-model':
+        specifier: file:.yalc/@supersubset/data-model
+        version: file:.yalc/@supersubset/data-model
+      '@supersubset/designer':
+        specifier: file:.yalc/@supersubset/designer
+        version: file:.yalc/@supersubset/designer(@floating-ui/dom@1.7.6)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
+      '@supersubset/query-client':
+        specifier: file:.yalc/@supersubset/query-client
+        version: file:.yalc/@supersubset/query-client
+      '@supersubset/runtime':
+        specifier: file:.yalc/@supersubset/runtime
+        version: file:.yalc/@supersubset/runtime(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@supersubset/schema':
+        specifier: file:.yalc/@supersubset/schema
+        version: file:.yalc/@supersubset/schema
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.6.0
@@ -3041,6 +3060,51 @@ packages:
     resolution: {integrity: sha512-n6OEjEtHupa2PdTwWzRepr7cO8NkDd4rgF6BKLitRbujOspLxzMBEqdphs+QLcuiCIgf33SqmEA64QWnbSMhPw==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@supersubset/adapter-sql@file:.yalc/@supersubset/adapter-sql':
+    resolution: {directory: .yalc/@supersubset/adapter-sql, type: directory}
+
+  '@supersubset/charts-echarts@0.2.0':
+    resolution: {integrity: sha512-nK1lty+GwJvifIZypKSAHJrIKXPpYpb7FcMkeocW5ja1j2xIMBUZinQ0N9+xbW0vi/6DvA1mItE6seyH5l4eXQ==}
+    peerDependencies:
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+
+  '@supersubset/data-model@0.2.0':
+    resolution: {integrity: sha512-EYssvjDLS3G3VtmpKHMvehSrdLyjXy/87v9iAKWfbURGGLDv151oB+oXBhQWOVVZp5DIkXZVu8Ggu2B0cZELiw==}
+
+  '@supersubset/data-model@file:.yalc/@supersubset/data-model':
+    resolution: {directory: .yalc/@supersubset/data-model, type: directory}
+
+  '@supersubset/designer@file:.yalc/@supersubset/designer':
+    resolution: {directory: .yalc/@supersubset/designer, type: directory}
+    peerDependencies:
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+
+  '@supersubset/query-client@file:.yalc/@supersubset/query-client':
+    resolution: {directory: .yalc/@supersubset/query-client, type: directory}
+
+  '@supersubset/runtime@0.2.0':
+    resolution: {integrity: sha512-GdWZoI2Fi10V4Q0Cx4FFUNZGWZGe4x9nf3wJBrArrwiBbbrv98rlBJetJoJ5v/Aew+dz4Fon2lam05z1j7tdvw==}
+    peerDependencies:
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+
+  '@supersubset/runtime@file:.yalc/@supersubset/runtime':
+    resolution: {directory: .yalc/@supersubset/runtime, type: directory}
+    peerDependencies:
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+
+  '@supersubset/schema@0.2.0':
+    resolution: {integrity: sha512-l7g5YtRVcKRfWHsiT+lA8Cu48gbpnesSzYTZ4RYgAwhEU1QKpLVRm5RUraj7wQM28aZAiQGzcu4JxOhW9v4PSw==}
+
+  '@supersubset/schema@file:.yalc/@supersubset/schema':
+    resolution: {directory: .yalc/@supersubset/schema, type: directory}
+
+  '@supersubset/theme@0.2.0':
+    resolution: {integrity: sha512-hCS92NxI2RuIT8DEJYMmBGjzYVFwz7bD+/uH4HWlBrJtHvVeIUU2hcYetkUuWSOosxKpJ800KNell0rkK24ang==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -9305,6 +9369,80 @@ snapshots:
   '@storybook/theming@8.6.18(storybook@8.6.18(prettier@3.8.2))':
     dependencies:
       storybook: 8.6.18(prettier@3.8.2)
+
+  '@supersubset/adapter-sql@file:.yalc/@supersubset/adapter-sql':
+    dependencies:
+      '@supersubset/data-model': 0.2.0
+
+  '@supersubset/charts-echarts@0.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@supersubset/runtime': 0.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@supersubset/schema': 0.2.0
+      '@supersubset/theme': 0.2.0
+      echarts: 5.6.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@supersubset/data-model@0.2.0':
+    dependencies:
+      '@supersubset/schema': 0.2.0
+
+  '@supersubset/data-model@file:.yalc/@supersubset/data-model':
+    dependencies:
+      '@supersubset/schema': 0.2.0
+
+  '@supersubset/designer@file:.yalc/@supersubset/designer(@floating-ui/dom@1.7.6)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))':
+    dependencies:
+      '@puckeditor/core': 0.21.2(@floating-ui/dom@1.7.6)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
+      '@supersubset/charts-echarts': 0.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@supersubset/data-model': 0.2.0
+      '@supersubset/runtime': 0.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@supersubset/schema': 0.2.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@floating-ui/dom'
+      - '@types/react'
+      - '@types/react-dom'
+      - bufferutil
+      - immer
+      - use-sync-external-store
+      - utf-8-validate
+
+  '@supersubset/query-client@file:.yalc/@supersubset/query-client':
+    dependencies:
+      '@supersubset/data-model': 0.2.0
+      '@supersubset/schema': 0.2.0
+
+  '@supersubset/runtime@0.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@supersubset/data-model': 0.2.0
+      '@supersubset/schema': 0.2.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@supersubset/runtime@file:.yalc/@supersubset/runtime(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@supersubset/data-model': 0.2.0
+      '@supersubset/schema': 0.2.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@supersubset/schema@0.2.0':
+    dependencies:
+      yaml: 2.9.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+
+  '@supersubset/schema@file:.yalc/@supersubset/schema':
+    dependencies:
+      yaml: 2.9.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+
+  '@supersubset/theme@0.2.0':
+    dependencies:
+      '@supersubset/schema': 0.2.0
 
   '@swc/helpers@0.5.15':
     dependencies:


### PR DESCRIPTION
## Summary
- Prefer `config.logicalQuery` in runtime `buildWidgetQuery` so host dashboards with polluted `dataBinding` still query correctly
- Resolve output field aliases for chart series (`yField` vs mart field ids) in runtime, charts-echarts, and designer publish path
- Add combo chart cumulative line support via `cumulativeFromField`
- Designer: chart type switch panel, axis binding repair on select, inline preview scroll fix
- Tests for query building, widget config, combo cumulative, host-embedded round-trip, and chart type switch

## Changeset
Includes `.changeset/analytics-host-integration.md` (patch) for npm publish on promotion to `main`.

## Test plan
- [x] `pnpm build && pnpm lint && pnpm typecheck && pnpm test`
- [x] Browser-verified in Tripmatch issue-604 worktree via yalc (Metrics + User growth combo)


Made with [Cursor](https://cursor.com)