### PR TITLE
fix: pie legend layout and dashboard publish verticalAlign (#680)

### DIFF
--- a/.changeset/fix-pie-legend-vertical-align.md
+++ b/.changeset/fix-pie-legend-vertical-align.md
@@ -1,0 +1,11 @@
+---
+'@supersubset/designer': patch
+'@supersubset/charts-echarts': patch
+---
+
+Fix analytics dashboard editor publish validation and pie chart legend:
+
+- Map Puck ColumnBlock `verticalAlign` CSS values to canonical schema (`top`/`center`/`bottom`; omit `stretch`).
+- Respect `showLegend: false` on pie charts (remove hard-coded legend fallback).
+- Reserve canvas space when a pie legend is shown so the series stays visible (center/radius layout).
+- Reduce overlapping outside labels on skewed pie data when legend is off (`hideOverlap`, `minShowLabelAngle`).

--- a/.changeset/fix-pie-legend-vertical-align.md
+++ b/.changeset/fix-pie-legend-vertical-align.md
@@ -9,3 +9,4 @@ Fix analytics dashboard editor publish validation and pie chart legend:
 - Respect `showLegend: false` on pie charts (remove hard-coded legend fallback).
 - Reserve canvas space when a pie legend is shown so the series stays visible (center/radius layout).
 - Reduce overlapping outside labels on skewed pie data when legend is off (`hideOverlap`, `minShowLabelAngle`).
+- Deduplicate table columns when runtime metadata repeats a configured field id (fixes React key warnings in host E2E).

--- a/e2e/workflows/designer-chart-matrix.spec.ts
+++ b/e2e/workflows/designer-chart-matrix.spec.ts
@@ -292,7 +292,7 @@ test.describe('Designer chart matrix certification', () => {
       expect(getSeriesList(option)[0]).toEqual(
         expect.objectContaining({
           type: 'pie',
-          center: ['50%', '58%'],
+          center: ['50%', '62%'],
           radius: ['0%', '58%'],
         }),
       );

--- a/e2e/workflows/designer-chart-matrix.spec.ts
+++ b/e2e/workflows/designer-chart-matrix.spec.ts
@@ -236,6 +236,7 @@ test.describe('Designer chart matrix certification', () => {
     await openDesigner(page);
     await openDesignerPage(page, 'page-gallery');
     await selectDesignerWidget(page, 'chart-pie');
+    await setRadioField(page, 'chart-pie', 'showLegend', 'No');
     await setSelectField(page, 'chart-pie', 'variant', 'donut');
     await setSelectField(page, 'chart-pie', 'labelPosition', 'inside');
     await setNumberField(page, 'chart-pie', 'innerRadius', 45);
@@ -260,6 +261,7 @@ test.describe('Designer chart matrix certification', () => {
     await openDesigner(page);
     await openDesignerPage(page, 'page-gallery');
     await selectDesignerWidget(page, 'chart-pie');
+    await setRadioField(page, 'chart-pie', 'showLegend', 'No');
     await setSelectField(page, 'chart-pie', 'variant', 'donut');
     await setSelectField(page, 'chart-pie', 'labelPosition', 'inside');
     await setNumberField(page, 'chart-pie', 'innerRadius', 45);
@@ -277,6 +279,24 @@ test.describe('Designer chart matrix certification', () => {
           }),
         }),
       );
+    });
+  });
+
+  test('pie chart with legend reserves center and radius', async ({ page }) => {
+    await openDesigner(page);
+    await openDesignerPage(page, 'page-gallery');
+    await selectDesignerWidget(page, 'chart-pie');
+    await setRadioField(page, 'chart-pie', 'showLegend', 'Yes');
+
+    await expectBaseChartOption(await getDesignerPreviewSurface(page, 'chart-pie'), (option) => {
+      expect(getSeriesList(option)[0]).toEqual(
+        expect.objectContaining({
+          type: 'pie',
+          center: ['50%', '58%'],
+          radius: ['0%', '58%'],
+        }),
+      );
+      expect(option.legend).toBeDefined();
     });
   });
 

--- a/e2e/workflows/designer-chart-matrix.spec.ts
+++ b/e2e/workflows/designer-chart-matrix.spec.ts
@@ -293,7 +293,7 @@ test.describe('Designer chart matrix certification', () => {
         expect.objectContaining({
           type: 'pie',
           center: ['50%', '62%'],
-          radius: ['0%', '58%'],
+          radius: ['40%', '58%'],
         }),
       );
       expect(option.legend).toBeDefined();

--- a/packages/charts-echarts/src/charts/PieChartWidget.tsx
+++ b/packages/charts-echarts/src/charts/PieChartWidget.tsx
@@ -16,9 +16,41 @@ import {
   buildTooltipOption,
   formatNumber,
   buildTitleOption,
+  type SharedConfig,
 } from '../base/shared-options';
 
 echarts.use([EChartsPie]);
+
+/** Keep the pie series inside the canvas when a legend reserves edge space. */
+export function resolvePieLayout(
+  shared: SharedConfig,
+  legend: Record<string, unknown> | undefined,
+  hasTitle: boolean,
+  innerRadius: number,
+  outerRadius: number,
+  labelPosition: 'outside' | 'inside' | 'center' | 'none',
+): { center: [string, string]; radius: [string, string] } {
+  const cappedOuter = legend ? Math.min(outerRadius, 58) : outerRadius;
+  const radius: [string, string] = [`${innerRadius}%`, `${cappedOuter}%`];
+
+  if (!legend) {
+    const y = labelPosition === 'outside' ? '55%' : '52%';
+    return { center: ['50%', y], radius };
+  }
+
+  const position = shared.legendPosition ?? 'top';
+  switch (position) {
+    case 'bottom':
+      return { center: ['50%', hasTitle ? '44%' : '46%'], radius };
+    case 'left':
+      return { center: ['58%', hasTitle ? '54%' : '52%'], radius };
+    case 'right':
+      return { center: ['42%', hasTitle ? '54%' : '52%'], radius };
+    case 'top':
+    default:
+      return { center: ['50%', hasTitle ? '62%' : '58%'], radius };
+  }
+}
 
 export function PieChartWidget({ config, data, columns, title, height, theme }: WidgetProps) {
   const option = useMemo(() => {
@@ -62,6 +94,16 @@ export function PieChartWidget({ config, data, columns, title, height, theme }: 
             formatter: shared.showValues === false ? '{b}' : labelFormatter,
           };
 
+    const legend = buildLegendOption(shared, sliceNames, hasTitle);
+    const { center, radius } = resolvePieLayout(
+      shared,
+      legend,
+      hasTitle,
+      innerRadius,
+      outerRadius,
+      labelPosition,
+    );
+
     return {
       ...(buildTitleOption(title) ? { title: buildTitleOption(title) } : {}),
       color: buildColorOption(shared),
@@ -72,19 +114,23 @@ export function PieChartWidget({ config, data, columns, title, height, theme }: 
               `${params.name}: ${formatNumber(params.value, shared.numberFormat!)} (${params.percent}%)`
           : '{b}: {c} ({d}%)',
       },
-      legend: buildLegendOption(shared, sliceNames, hasTitle) ?? {
-        orient: 'vertical' as const,
-        left: 'left',
-      },
+      ...(legend ? { legend } : {}),
       series: [
         {
           type: 'pie' as const,
           data: seriesData,
-          radius: [`${innerRadius}%`, `${outerRadius}%`],
+          radius,
+          center,
           emphasis: {
             itemStyle: { shadowBlur: 10, shadowOffsetX: 0, shadowColor: 'rgba(0, 0, 0, 0.5)' },
           },
           label: labelConfig,
+          ...(labelPosition === 'outside' && !legend
+            ? {
+                minShowLabelAngle: 8,
+                labelLayout: { hideOverlap: true },
+              }
+            : {}),
           ...(roseType ? { roseType } : {}),
           ...(padAngle > 0 ? { padAngle } : {}),
         },

--- a/packages/charts-echarts/src/charts/TableWidget.tsx
+++ b/packages/charts-echarts/src/charts/TableWidget.tsx
@@ -13,7 +13,15 @@ export function TableWidget({ config, data, columns, title, height }: WidgetProp
   const displayColumns = useMemo(() => {
     const configColumns = config.columns as string[] | undefined;
     if (configColumns && configColumns.length > 0 && columns) {
-      return columns.filter((c) => configColumns.includes(c.fieldId));
+      const byFieldId = new Map<string, (typeof columns)[number]>();
+      for (const col of columns) {
+        if (!byFieldId.has(col.fieldId)) {
+          byFieldId.set(col.fieldId, col);
+        }
+      }
+      return configColumns
+        .map((fieldId) => byFieldId.get(fieldId))
+        .filter((col): col is NonNullable<typeof col> => col != null);
     }
     return columns ?? [];
   }, [config, columns]);
@@ -36,7 +44,10 @@ export function TableWidget({ config, data, columns, title, height }: WidgetProp
       let isNumeric = false;
       for (const row of data) {
         const v = row[col.fieldId];
-        if (typeof v === 'number' && Number.isFinite(v)) { sum += v; isNumeric = true; }
+        if (typeof v === 'number' && Number.isFinite(v)) {
+          sum += v;
+          isNumeric = true;
+        }
       }
       if (isNumeric) sums[col.fieldId] = sum;
     }
@@ -45,7 +56,10 @@ export function TableWidget({ config, data, columns, title, height }: WidgetProp
 
   if (!data || data.length === 0) {
     return (
-      <div className="ss-table-empty" style={{ textAlign: 'center', padding: '24px', color: '#999' }}>
+      <div
+        className="ss-table-empty"
+        style={{ textAlign: 'center', padding: '24px', color: '#999' }}
+      >
         <div style={{ fontWeight: 600 }}>{title ?? 'Table'}</div>
         <div>No data available</div>
       </div>
@@ -71,7 +85,20 @@ export function TableWidget({ config, data, columns, title, height }: WidgetProp
         <thead>
           <tr>
             {showRowNumbers && (
-              <th style={{ padding: '8px 12px', textAlign: headerAlign, borderBottom: '2px solid #e0e0e0', fontWeight: 600, position: 'sticky', top: 0, background: 'var(--ss-color-surface, #fff)', width: 40 }}>#</th>
+              <th
+                style={{
+                  padding: '8px 12px',
+                  textAlign: headerAlign,
+                  borderBottom: '2px solid #e0e0e0',
+                  fontWeight: 600,
+                  position: 'sticky',
+                  top: 0,
+                  background: 'var(--ss-color-surface, #fff)',
+                  width: 40,
+                }}
+              >
+                #
+              </th>
             )}
             {displayColumns.map((col) => (
               <th
@@ -95,10 +122,21 @@ export function TableWidget({ config, data, columns, title, height }: WidgetProp
           {displayData.map((row, rowIdx) => (
             <tr
               key={rowIdx}
-              style={{ background: striped && rowIdx % 2 !== 0 ? 'rgba(0,0,0,0.02)' : 'transparent' }}
+              style={{
+                background: striped && rowIdx % 2 !== 0 ? 'rgba(0,0,0,0.02)' : 'transparent',
+              }}
             >
               {showRowNumbers && (
-                <td style={{ padding: '6px 12px', borderBottom: '1px solid #f0f0f0', textAlign: cellAlign, color: '#999' }}>{rowIdx + 1}</td>
+                <td
+                  style={{
+                    padding: '6px 12px',
+                    borderBottom: '1px solid #f0f0f0',
+                    textAlign: cellAlign,
+                    color: '#999',
+                  }}
+                >
+                  {rowIdx + 1}
+                </td>
               )}
               {displayColumns.map((col) => (
                 <td

--- a/packages/charts-echarts/test/per-chart-properties.test.tsx
+++ b/packages/charts-echarts/test/per-chart-properties.test.tsx
@@ -405,11 +405,177 @@ describe('PieChartWidget — per-chart properties', () => {
     capturedOption = null;
   });
 
+  it('showLegend=false omits legend option', () => {
+    render(
+      <PieChartWidget
+        {...makeProps({
+          config: {
+            nameField: 'name',
+            valueField: 'value',
+            showLegend: false,
+          },
+          data: samplePieData,
+        })}
+      />,
+    );
+    expect(getOption().legend).toBeUndefined();
+  });
+
+  // Regression: #680 — legend must not collapse the pie (center/radius reserved)
+  it('showLegend=true keeps an explicit center below a top legend', () => {
+    render(
+      <PieChartWidget
+        {...makeProps({
+          config: {
+            nameField: 'name',
+            valueField: 'value',
+            showLegend: true,
+            legendPosition: 'top',
+          },
+          data: samplePieData,
+        })}
+      />,
+    );
+    expect(getOption().legend).toBeDefined();
+    expect(getSeries().center).toEqual(['50%', '58%']);
+    expect(getSeries().radius).toEqual(['0%', '58%']);
+  });
+
+  it.each([
+    ['bottom', ['50%', '46%']],
+    ['left', ['58%', '52%']],
+    ['right', ['42%', '52%']],
+  ] as const)('showLegend=true with legendPosition=%s shifts center', (position, center) => {
+    render(
+      <PieChartWidget
+        {...makeProps({
+          config: {
+            nameField: 'name',
+            valueField: 'value',
+            showLegend: true,
+            legendPosition: position,
+          },
+          data: samplePieData,
+        })}
+      />,
+    );
+    expect(getSeries().center).toEqual(center);
+  });
+
+  it('showLegend=true with title lowers center further for top legend', () => {
+    render(
+      <PieChartWidget
+        {...makeProps({
+          title: 'Plans by type',
+          config: {
+            nameField: 'name',
+            valueField: 'value',
+            showLegend: true,
+            legendPosition: 'top',
+          },
+          data: samplePieData,
+        })}
+      />,
+    );
+    expect(getSeries().center).toEqual(['50%', '62%']);
+  });
+
+  it('labelPosition=outside without legend enables overlap hiding', () => {
+    render(
+      <PieChartWidget
+        {...makeProps({
+          config: {
+            nameField: 'name',
+            valueField: 'value',
+            showLegend: false,
+            labelPosition: 'outside',
+          },
+          data: samplePieData,
+        })}
+      />,
+    );
+    expect(getSeries().labelLayout).toEqual({ hideOverlap: true });
+    expect(getSeries().minShowLabelAngle).toBe(8);
+  });
+
+  it('labelPosition=outside with legend skips overlap hiding', () => {
+    render(
+      <PieChartWidget
+        {...makeProps({
+          config: {
+            nameField: 'name',
+            valueField: 'value',
+            showLegend: true,
+            labelPosition: 'outside',
+          },
+          data: samplePieData,
+        })}
+      />,
+    );
+    expect(getSeries().labelLayout).toBeUndefined();
+    expect(getSeries().minShowLabelAngle).toBeUndefined();
+  });
+
+  it('labelPosition=center shows labels at center', () => {
+    render(
+      <PieChartWidget
+        {...makeProps({
+          config: {
+            nameField: 'name',
+            valueField: 'value',
+            showLegend: false,
+            labelPosition: 'center',
+          },
+          data: samplePieData,
+        })}
+      />,
+    );
+    const label = getSeries().label as Record<string, unknown>;
+    expect(label.show).toBe(true);
+    expect(label.position).toBe('center');
+  });
+
+  it('colorScheme sets palette on option', () => {
+    render(
+      <PieChartWidget
+        {...makeProps({
+          config: {
+            nameField: 'name',
+            valueField: 'value',
+            showLegend: false,
+            colorScheme: 'warm',
+          },
+          data: samplePieData,
+        })}
+      />,
+    );
+    expect(getOption().color).toBeDefined();
+  });
+
+  it('showValues=true formats outside labels with values', () => {
+    render(
+      <PieChartWidget
+        {...makeProps({
+          config: {
+            nameField: 'name',
+            valueField: 'value',
+            showLegend: false,
+            labelPosition: 'outside',
+            showValues: true,
+          },
+          data: samplePieData,
+        })}
+      />,
+    );
+    const label = getSeries().label as Record<string, unknown>;
+    expect(label.formatter).toBeDefined();
+  });
+
   it('donut=true with no explicit innerRadius uses 40%', () => {
     render(
       <PieChartWidget
         {...makeProps({
-          config: { nameField: 'name', valueField: 'value', donut: true },
+          config: { nameField: 'name', valueField: 'value', donut: true, showLegend: false },
           data: samplePieData,
         })}
       />,
@@ -421,7 +587,7 @@ describe('PieChartWidget — per-chart properties', () => {
     render(
       <PieChartWidget
         {...makeProps({
-          config: { nameField: 'name', valueField: 'value' },
+          config: { nameField: 'name', valueField: 'value', showLegend: false },
           data: samplePieData,
         })}
       />,
@@ -433,7 +599,13 @@ describe('PieChartWidget — per-chart properties', () => {
     render(
       <PieChartWidget
         {...makeProps({
-          config: { nameField: 'name', valueField: 'value', donut: true, innerRadius: 60 },
+          config: {
+            nameField: 'name',
+            valueField: 'value',
+            donut: true,
+            innerRadius: 60,
+            showLegend: false,
+          },
           data: samplePieData,
         })}
       />,
@@ -445,7 +617,12 @@ describe('PieChartWidget — per-chart properties', () => {
     render(
       <PieChartWidget
         {...makeProps({
-          config: { nameField: 'name', valueField: 'value', outerRadius: 85 },
+          config: {
+            nameField: 'name',
+            valueField: 'value',
+            outerRadius: 85,
+            showLegend: false,
+          },
           data: samplePieData,
         })}
       />,
@@ -522,7 +699,13 @@ describe('PieChartWidget — per-chart properties', () => {
     render(
       <PieChartWidget
         {...makeProps({
-          config: { nameField: 'name', valueField: 'value', donut: true, innerRadius: 0 },
+          config: {
+            nameField: 'name',
+            valueField: 'value',
+            donut: true,
+            innerRadius: 0,
+            showLegend: false,
+          },
           data: samplePieData,
         })}
       />,
@@ -535,7 +718,12 @@ describe('PieChartWidget — per-chart properties', () => {
     render(
       <PieChartWidget
         {...makeProps({
-          config: { nameField: 'name', valueField: 'value', variant: 'donut' },
+          config: {
+            nameField: 'name',
+            valueField: 'value',
+            variant: 'donut',
+            showLegend: false,
+          },
           data: samplePieData,
         })}
       />,
@@ -547,7 +735,13 @@ describe('PieChartWidget — per-chart properties', () => {
     render(
       <PieChartWidget
         {...makeProps({
-          config: { nameField: 'name', valueField: 'value', variant: 'donut', innerRadius: 0 },
+          config: {
+            nameField: 'name',
+            valueField: 'value',
+            variant: 'donut',
+            innerRadius: 0,
+            showLegend: false,
+          },
           data: samplePieData,
         })}
       />,

--- a/packages/charts-echarts/test/per-chart-properties.test.tsx
+++ b/packages/charts-echarts/test/per-chart-properties.test.tsx
@@ -1757,6 +1757,28 @@ describe('TableWidget — per-chart properties', () => {
     expect(headerCells.length).toBe(4); // # + 3 columns
   });
 
+  it('config.columns preserves order and dedupes repeated runtime columns', () => {
+    const { container } = render(
+      <TableWidget
+        {...makeProps({
+          config: { columns: ['name', 'score', 'grade'] },
+          data: tableData,
+          columns: [
+            { fieldId: 'name', label: 'Name', dataType: 'string' as const },
+            { fieldId: 'name', label: 'Name dup', dataType: 'string' as const },
+            { fieldId: 'score', label: 'Score', dataType: 'number' as const },
+            { fieldId: 'grade', label: 'Grade', dataType: 'string' as const },
+          ],
+        })}
+      />,
+    );
+    const headerCells = container.querySelectorAll('th');
+    expect(headerCells.length).toBe(3);
+    expect(headerCells[0].textContent).toBe('Name');
+    expect(headerCells[1].textContent).toBe('Score');
+    expect(headerCells[2].textContent).toBe('Grade');
+  });
+
   it('showRowNumbers=false (default) omits row number column', () => {
     const { container } = render(
       <TableWidget

--- a/packages/designer/src/adapters/puck-canonical.ts
+++ b/packages/designer/src/adapters/puck-canonical.ts
@@ -181,6 +181,32 @@ const layoutTypeToPuckName: Record<string, string> = {
   column: 'ColumnBlock',
 };
 
+/** Puck ColumnBlock uses CSS alignSelf values; canonical schema uses top/center/bottom. */
+const PUCK_TO_CANONICAL_VERTICAL_ALIGN: Record<string, 'top' | 'center' | 'bottom' | undefined> = {
+  start: 'top',
+  top: 'top',
+  center: 'center',
+  end: 'bottom',
+  bottom: 'bottom',
+  stretch: undefined,
+};
+
+const CANONICAL_TO_PUCK_VERTICAL_ALIGN: Record<string, string> = {
+  top: 'start',
+  center: 'center',
+  bottom: 'end',
+};
+
+function puckVerticalAlignToCanonical(value: unknown): 'top' | 'center' | 'bottom' | undefined {
+  if (typeof value !== 'string') return undefined;
+  return PUCK_TO_CANONICAL_VERTICAL_ALIGN[value];
+}
+
+function canonicalVerticalAlignToPuck(value: unknown): string {
+  if (typeof value !== 'string') return 'stretch';
+  return CANONICAL_TO_PUCK_VERTICAL_ALIGN[value] ?? 'stretch';
+}
+
 /**
  * Recursively walk Puck content items and build layout nodes + widgets.
  * Handles RowBlock/ColumnBlock nesting by creating row/column layout nodes.
@@ -412,7 +438,8 @@ function buildLayoutBlockMeta(
   }
   if (puckType === 'ColumnBlock') {
     if (props.span !== undefined) meta.width = props.span;
-    if (props.verticalAlign) meta.verticalAlign = props.verticalAlign;
+    const verticalAlign = puckVerticalAlignToCanonical(props.verticalAlign);
+    if (verticalAlign) meta.verticalAlign = verticalAlign;
   }
   return meta;
 }
@@ -427,7 +454,9 @@ function layoutNodeToPuckProps(node: LayoutComponent): Record<string, unknown> {
   }
   if (node.type === 'column') {
     if (node.meta.width !== undefined) props.span = node.meta.width;
-    if (node.meta.verticalAlign) props.verticalAlign = node.meta.verticalAlign;
+    if (node.meta.verticalAlign) {
+      props.verticalAlign = canonicalVerticalAlignToPuck(node.meta.verticalAlign);
+    }
   }
   return props;
 }

--- a/packages/designer/test/host-embedded-chart-roundtrip.test.ts
+++ b/packages/designer/test/host-embedded-chart-roundtrip.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import type { DashboardDefinition } from '@supersubset/schema';
+import { dashboardDefinitionSchema } from '@supersubset/schema';
 import {
   canonicalToPuck,
   puckToCanonical,
@@ -540,5 +541,23 @@ describe('host-embedded chart round-trip', () => {
     const after = collectChartAxisBindingSnapshot(fixed);
     expect(brokenSnapshot).not.toBe(after);
     expect(JSON.parse(after)[0]?.yAxisField).toBe('event_id');
+  });
+
+  it('publish round-trip omits invalid stretch verticalAlign from column meta', () => {
+    const puck = canonicalToPuck(makeTripmatchPlanChartsRowDashboard(PLAN_CHART_DAY_WIDGET));
+    const published = puckToCanonical(puck, {
+      dashboardId: 'tripmatch-analytics',
+      dashboardTitle: 'Tripmatch analytics',
+      baseDashboard: makeTripmatchPlanChartsRowDashboard(PLAN_CHART_DAY_WIDGET),
+    });
+
+    expect(() => dashboardDefinitionSchema.parse(published)).not.toThrow();
+
+    for (const node of Object.values(published.pages[0].layout)) {
+      const verticalAlign = node.meta?.verticalAlign;
+      if (verticalAlign !== undefined) {
+        expect(['top', 'center', 'bottom']).toContain(verticalAlign);
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fixes analytics dashboard issues surfaced in wandir-tech/tripmatch#680:

- **Pie legend on:** reserve `center`/`radius` when a legend is shown so the pie series stays visible (top/bottom/left/right).
- **Pie legend off:** honor `showLegend: false` (remove hard-coded legend fallback).
- **Pie labels:** reduce overlapping outside labels when legend is off (`hideOverlap`, `minShowLabelAngle`).
- **Publish validation:** map Puck `ColumnBlock` `verticalAlign` CSS values (`stretch`/`start`/`end`) to canonical schema (`top`/`center`/`bottom`; omit `stretch`).

Includes a **patch changeset** for `@supersubset/designer` and `@supersubset/charts-echarts`.

## Test plan

- [x] `pnpm --filter @supersubset/charts-echarts test` (238 tests)
- [x] `pnpm --filter @supersubset/designer test` (768 tests)
- [ ] After merge to `main`: verify Release workflow opens version-packages PR and publishes `@supersubset/*` **0.2.2**

## Deploy compatibility

Ordered — Tripmatch PR wandir-tech/tripmatch#TBD should bump `@supersubset/designer` and `@supersubset/charts-echarts` to **^0.2.2** after this release lands on npm.


Made with [Cursor](https://cursor.com)